### PR TITLE
Make the index item cap configurable, and say when it truncates

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { defaultDataDir } from './lib/paths.js';
 import { DEFAULT_FULLTEXT_MAX_CHARS } from './features/search/fulltext-source.js';
+import { DEFAULT_INDEX_MAX_ITEMS } from './features/search/limits.js';
 
 export interface ZoteusConfig {
   apiKey?: string;
@@ -18,6 +19,8 @@ export interface ZoteusConfig {
   indexFulltext: boolean;
   /** Cap on indexed full-text characters per item (0 = no cap). */
   indexFulltextMaxChars: number;
+  /** Cap on items per index build. Raise it for libraries larger than the default. */
+  indexMaxItems: number;
   scholarProviders: string[];
   dataDir: string;
   contactEmail?: string;
@@ -87,6 +90,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ZoteusConfig {
     ZOTEUS_TRANSFORMERS_PATH: z.string().optional(),
     ZOTEUS_INDEX_FULLTEXT: bool(false),
     ZOTEUS_INDEX_FULLTEXT_MAX_CHARS: z.coerce.number().int().nonnegative().default(DEFAULT_FULLTEXT_MAX_CHARS),
+    ZOTEUS_INDEX_MAX_ITEMS: z.coerce.number().int().positive().default(DEFAULT_INDEX_MAX_ITEMS),
     ZOTEUS_SCHOLAR_PROVIDERS: z.string().default('openalex'),
     ZOTEUS_DATA_DIR: z.string().optional(),
     ZOTEUS_CONTACT_EMAIL: z.string().email().optional(),
@@ -167,6 +171,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ZoteusConfig {
     transformersPath: parsed.ZOTEUS_TRANSFORMERS_PATH?.trim() || undefined,
     indexFulltext: parsed.ZOTEUS_INDEX_FULLTEXT,
     indexFulltextMaxChars: parsed.ZOTEUS_INDEX_FULLTEXT_MAX_CHARS,
+    indexMaxItems: parsed.ZOTEUS_INDEX_MAX_ITEMS,
     scholarProviders: parsed.ZOTEUS_SCHOLAR_PROVIDERS.split(',')
       .map((s) => s.trim())
       .filter(Boolean),

--- a/src/features/search/build.ts
+++ b/src/features/search/build.ts
@@ -3,15 +3,23 @@ import type { LibraryRef } from '../../api/web-client.js';
 import type { IndexBuildStatus } from './index-manager.js';
 import { createFulltextSource, type FulltextSource } from './fulltext-source.js';
 import { saveIndex } from './persistence.js';
+import { DEFAULT_INDEX_MAX_ITEMS } from './limits.js';
 
-/** Hard cap on items per build — keeps very large libraries bounded. */
-export const MAX_ITEMS = 5000;
+/**
+ * Default cap on items per build — keeps very large libraries bounded. Re-exported from
+ * `limits.ts`; raise it at runtime with `ZOTEUS_INDEX_MAX_ITEMS`.
+ *
+ * @deprecated Read `ctx.config.indexMaxItems` instead: this is the default, not the cap
+ * in force. Kept so existing importers still resolve.
+ */
+export const MAX_ITEMS = DEFAULT_INDEX_MAX_ITEMS;
 /** Both Zotero APIs (cloud Web API and desktop local API) page items 100-at-a-time. */
 export const PAGE_SIZE = 100;
 
 /** One-line progress summary used in tool messages and status output. */
 export function progressLine(s: IndexBuildStatus): string {
-  const total = s.itemsTotal > 0 ? String(s.itemsTotal) : '?';
+  const capped = s.itemsAvailable > s.itemsTotal;
+  const total = s.itemsTotal > 0 ? `${s.itemsTotal}${capped ? ` of ${s.itemsAvailable}` : ''}` : '?';
   const fulltext = s.fulltextEnabled ? `, full text of ${s.fulltextItems} items (${s.fulltextPassages} passages)` : '';
   return `${s.itemsFetched}/${total} items, ${s.passages} passages, ${s.vectors} vectors${fulltext} (embedder=${s.embedder})`;
 }
@@ -37,9 +45,22 @@ export function fulltextNotice(s: IndexBuildStatus): string {
   return ` Full-text indexing produced nothing: ${s.fulltextReason}`;
 }
 
+/**
+ * Sentence appended when the build limit stopped the crawl short of the library. Same
+ * reasoning as `embedderNotice` and `fulltextNotice`: without it a capped build reports
+ * `5000/5000` and reads as complete coverage, so a search that finds nothing in the
+ * unindexed remainder is indistinguishable from a search over a library that holds
+ * nothing on the subject.
+ */
+export function truncationNotice(s: IndexBuildStatus): string {
+  if (s.itemsAvailable <= s.itemsTotal) return '';
+  const missing = s.itemsAvailable - s.itemsTotal;
+  return ` Only the first ${s.itemsTotal} of ${s.itemsAvailable} items were indexed — ${missing} are NOT searchable. Raise ZOTEUS_INDEX_MAX_ITEMS and rebuild to cover them.`;
+}
+
 /** Human summary of a build/status snapshot. */
 export function statusSummary(s: IndexBuildStatus): string {
-  const notice = embedderNotice(s) + fulltextNotice(s);
+  const notice = embedderNotice(s) + fulltextNotice(s) + truncationNotice(s);
   switch (s.state) {
     case 'building':
       return `Index build in progress — ${progressLine(s)}. Poll zotero_index action:"status" again shortly.${notice}`;
@@ -82,10 +103,12 @@ export interface BuildFulltextOptions {
 export function startIndexBuild(
   ctx: ToolContext,
   lib?: LibraryRef,
-  maxItems = MAX_ITEMS,
+  maxItems?: number,
   opts: BuildFulltextOptions = {},
 ): IndexBuildStatus {
-  const cap = Math.min(maxItems, MAX_ITEMS);
+  // The configured limit is the ceiling; an explicit `maxItems` may only lower it.
+  const configured = ctx.config.indexMaxItems;
+  const cap = maxItems === undefined ? configured : Math.min(maxItems, configured);
   const fetchPage = async (start: number) => {
     // Page through the router, not the Web API directly: a running desktop app serves the
     // personal library key-free (users/0), so indexing needs no cloud key. The router still

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -63,6 +63,13 @@ export interface IndexBuildStatus extends SearchIndexStatus {
   itemsFetched: number;
   /** Total items expected (0 = not yet known). Capped by the build limit. */
   itemsTotal: number;
+  /**
+   * Items the library actually holds, before the build limit is applied (0 = not yet
+   * known). Kept apart from `itemsTotal` so a truncated build stays legible: with only
+   * the capped figure, a build that stopped at the limit reports `5000/5000` and is
+   * indistinguishable from one that indexed the whole library.
+   */
+  itemsAvailable: number;
   /** Passages indexed so far (alias of documents). */
   passages: number;
   /** Set when state === 'error'. */
@@ -200,6 +207,7 @@ export class SearchIndex {
   private buildState: BuildState = 'idle';
   private itemsFetched = 0;
   private itemsTotal = 0;
+  private itemsAvailable = 0;
   private lastBuildError: string | undefined = undefined;
   private cancelToken: { cancelled: boolean } | null = null;
   /**
@@ -279,6 +287,7 @@ export class SearchIndex {
       state: this.buildState,
       itemsFetched: this.itemsFetched,
       itemsTotal: this.itemsTotal,
+      itemsAvailable: this.itemsAvailable,
     };
     if (this.buildState === 'error' && this.lastBuildError) s.lastError = this.lastBuildError;
     return s;
@@ -391,6 +400,7 @@ export class SearchIndex {
     this.fulltextUnavailable = undefined;
     this.itemsFetched = 0;
     this.itemsTotal = 0;
+    this.itemsAvailable = 0;
     const token = { cancelled: false };
     this.cancelToken = token;
     this.reset();
@@ -466,6 +476,7 @@ export class SearchIndex {
         const pageItems = page.items ?? [];
         if (pageItems.length === 0) break;
         if (!this.itemsTotal && page.totalResults) {
+          this.itemsAvailable = page.totalResults;
           this.itemsTotal = maxItems !== undefined ? Math.min(page.totalResults, maxItems) : page.totalResults;
         }
         // Only the items that still fit under the cap are worth fetching full text for.

--- a/src/features/search/limits.ts
+++ b/src/features/search/limits.ts
@@ -1,0 +1,12 @@
+/**
+ * Index build limits, kept in their own module so `config.ts` can read the default
+ * without importing `build.ts` — which pulls in the registry and would close an
+ * import cycle back onto config.
+ */
+
+/**
+ * Default cap on items per build. Not a hard ceiling: `ZOTEUS_INDEX_MAX_ITEMS` raises it
+ * for libraries that outgrow it. The default stays where it was so an existing install
+ * keeps its build time and index size unchanged.
+ */
+export const DEFAULT_INDEX_MAX_ITEMS = 5000;

--- a/src/tools/index-tool.ts
+++ b/src/tools/index-tool.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ToolDefinition } from '../registry/registry.js';
 import { ok } from '../registry/registry.js';
-import { MAX_ITEMS, progressLine, startIndexBuild, statusSummary } from '../features/search/build.js';
+import { progressLine, startIndexBuild, statusSummary } from '../features/search/build.js';
 import { DEFAULT_FULLTEXT_MAX_CHARS } from '../features/search/fulltext-source.js';
 import type { LibraryRef } from '../api/web-client.js';
 
@@ -18,9 +18,11 @@ const indexTool: ToolDefinition = {
       .number()
       .int()
       .min(1)
-      .max(MAX_ITEMS)
       .optional()
-      .describe(`Max items to index (default ${MAX_ITEMS}, which is also the hard cap).`),
+      .describe(
+        'Max items to index. Lowers the configured cap for this build only; it cannot raise it. ' +
+          'The cap defaults to 5000 and is set by ZOTEUS_INDEX_MAX_ITEMS.',
+      ),
     fulltext: z
       .boolean()
       .optional()
@@ -66,7 +68,7 @@ const indexTool: ToolDefinition = {
     const lib: LibraryRef | undefined = args.library_id
       ? { type: (args.library_type ?? 'group') as 'user' | 'group', id: args.library_id }
       : undefined;
-    const maxItems = Math.min(args.limit ?? MAX_ITEMS, MAX_ITEMS);
+    const maxItems = Math.min(args.limit ?? ctx.config.indexMaxItems, ctx.config.indexMaxItems);
     const fulltext = args.fulltext ?? ctx.config.indexFulltext;
     const s = startIndexBuild(ctx, lib, maxItems, {
       fulltext,

--- a/tests/features/index-truncation.test.ts
+++ b/tests/features/index-truncation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { SearchIndex } from '../../src/features/search/index-manager.js';
+import { progressLine, statusSummary, truncationNotice } from '../../src/features/search/build.js';
+import { DEFAULT_INDEX_MAX_ITEMS } from '../../src/features/search/limits.js';
+import { loadConfig } from '../../src/config.js';
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} } as any;
+
+function keywordIndex(): SearchIndex {
+  return new SearchIndex({ embedder: null, configured: 'off', logger: silentLogger });
+}
+
+/** A library of `total` items, served 100 at a time, like both Zotero APIs. */
+function pager(total: number) {
+  return async (start: number) => ({
+    items: Array.from({ length: Math.min(100, Math.max(0, total - start)) }, (_, i) => ({
+      key: `K${start + i}`,
+      data: { itemType: 'journalArticle', title: `Item ${start + i}` },
+    })),
+    totalResults: total,
+  });
+}
+
+describe('a build stopped by the item cap says so', () => {
+  it('keeps the library total apart from the capped total', async () => {
+    const index = keywordIndex();
+    await index.buildIncremental(pager(320), { maxItems: 200 });
+    const s = index.buildStatus();
+
+    expect(s.itemsFetched).toBe(200);
+    expect(s.itemsTotal).toBe(200);
+    // Without this the two are equal and the truncation leaves no trace anywhere.
+    expect(s.itemsAvailable).toBe(320);
+  });
+
+  it('reports the shortfall in the progress line and the summary', async () => {
+    const index = keywordIndex();
+    await index.buildIncremental(pager(320), { maxItems: 200 });
+    const s = index.buildStatus();
+
+    expect(progressLine(s)).toContain('200 of 320');
+    expect(truncationNotice(s)).toContain('120 are NOT searchable');
+    expect(statusSummary(s)).toContain('ZOTEUS_INDEX_MAX_ITEMS');
+  });
+
+  it('stays silent when the whole library fits', async () => {
+    const index = keywordIndex();
+    await index.buildIncremental(pager(150), { maxItems: 200 });
+    const s = index.buildStatus();
+
+    expect(s.itemsAvailable).toBe(150);
+    expect(truncationNotice(s)).toBe('');
+    expect(progressLine(s)).not.toContain(' of ');
+  });
+});
+
+describe('the item cap is a runtime parameter', () => {
+  it('defaults to the historical value, so an existing install is unchanged', () => {
+    expect(loadConfig({}).indexMaxItems).toBe(DEFAULT_INDEX_MAX_ITEMS);
+    expect(DEFAULT_INDEX_MAX_ITEMS).toBe(5000);
+  });
+
+  it('is raised by ZOTEUS_INDEX_MAX_ITEMS', () => {
+    expect(loadConfig({ ZOTEUS_INDEX_MAX_ITEMS: '20000' }).indexMaxItems).toBe(20000);
+  });
+
+  it('rejects a non-positive value rather than building an empty index', () => {
+    expect(() => loadConfig({ ZOTEUS_INDEX_MAX_ITEMS: '0' })).toThrow();
+  });
+});


### PR DESCRIPTION
`MAX_ITEMS` is a hard 5000 with no runtime override, and a build that reaches it leaves no trace. `index-manager.ts` clamps `itemsTotal` to the cap:

```ts
this.itemsTotal = maxItems !== undefined ? Math.min(page.totalResults, maxItems) : page.totalResults;
```

so the library's real size is discarded. On my library (7540 top-level items) the status reads `itemsTotal: 5000`, `itemsFetched: 5000`, `state: "done"` — indistinguishable from a build that indexed everything, while 2540 items (34%) were never touched. `zotero_semantic_search` then answers "nothing found" over that remainder with the same confidence it uses for a genuine miss.

The tool *description* does mention the cap, but the status object an agent polls does not, and that is the channel it reads.

## Changes

- **`ZOTEUS_INDEX_MAX_ITEMS`** sets the cap. It defaults to the historical 5000, so an existing install is unchanged in build time and index size. The `limit` argument may still lower it for a single build; it cannot raise it above the configured value.
- **`itemsAvailable`** on `IndexBuildStatus` records what the library actually holds, next to the capped `itemsTotal`. `progressLine` renders `200 of 320` when they differ.
- **`truncationNotice()`** in `build.ts`, appended by `statusSummary` beside `embedderNotice` and `fulltextNotice`.

That third one is really your own idea applied once more — the comment on `embedderNotice` says a keyword-only index is indistinguishable from a healthy one, and `fulltextNotice` says the same for metadata-only. A truncated index is the third member of that family, and it was the one still missing.

The default constant lives in a new `features/search/limits.ts` rather than in `build.ts`, so `config.ts` can read it without importing the registry and closing an import cycle. `MAX_ITEMS` remains exported, marked deprecated, pointing at `ctx.config.indexMaxItems`.

## Tests

`tests/features/index-truncation.test.ts`, six cases: the cap biting (totals kept apart, notice and progress line), the cap not biting (silence), and the runtime knob (default preserved, raised by env, non-positive rejected).

Full suite: 474 passed, 7 skipped. `tsc --noEmit` and `eslint` clean.

## Note

Raising this cap is what let me reach #10 — at the stock 5000 my library never gets far enough to hit the serialisation ceiling described there. The two are independent changes; this one is safe on its own, and on a large library it is what makes the other visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)