### PR TITLE
A damaged search index must not stop the server from starting

### DIFF
--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -255,6 +255,16 @@ so it is the semantic path that grows with the library.
 also writes `-wal` and `-shm` sidecar files while the database is open; a clean shutdown
 folds them back in.
 
+**If the index is damaged.** A search index that SQLite cannot read no longer stops the
+server from starting: it is a derived cache, and no other tool reads it, so item lookups,
+bibliographies, attachments and citations carry on working. Search alone refuses, with a
+message naming the file, its sidecars and the command to remove them. It is not rebuilt for
+you — a rebuild re-reads the whole library and takes minutes to tens of minutes, which is
+not a job to start inside somebody's query. Delete the three files and run `zotero_index`
+with `action:"build"`. Deleting them is also what clears the version stamp, which lives in
+the same database: a recovery that dropped the passages and kept the stamp would leave an
+empty index reporting itself as up to date.
+
 **Migration is automatic and lossless.** The first time the SQLite backend opens a data dir
 that holds a `search-index.json` and no database, it imports the JSON index and leaves the
 file exactly where it was (a downgrade to an older Node still finds it). If the JSON file is

--- a/src/features/search/backend.ts
+++ b/src/features/search/backend.ts
@@ -260,6 +260,14 @@ export interface QueryOptions {
 export interface SearchIndex {
   /** Which store backs this index. */
   readonly storage: StorageBackend;
+  /**
+   * Set when the store itself could not be opened, and every operation on this index will
+   * therefore refuse. Callers that would otherwise explain an empty index — the 0-vector
+   * refusal in zotero_semantic_search, say — must defer to it, or they explain the wrong
+   * thing: "this index holds no vectors, rebuild it" is not what is wrong when the file
+   * cannot be read at all.
+   */
+  readonly storeFault: Error | undefined;
   /** What ZOTEUS_EMBEDDINGS asked for. */
   readonly embedderConfigured: string;
   /** True only while vectors are genuinely being produced. */

--- a/src/features/search/corruption.ts
+++ b/src/features/search/corruption.ts
@@ -33,10 +33,7 @@ export class SearchIndexCorruptError extends Error {
 const UNREADABLE = 'the search index cannot be read';
 
 /**
- * SQLite's vocabulary for "this file is not a usable database".
- *
- * Matched on the message rather than on a code because `node:sqlite` does not surface
- * `SQLITE_CORRUPT` as a stable numeric field, and because these strings are part of
+ * SQLite's vocabulary for "this file is not a usable database". These strings are part of
  * SQLite's public interface: they are in its documentation and have not changed across
  * the 3.x series.
  *
@@ -50,14 +47,24 @@ const CORRUPTION_SIGNS = [
   'file is encrypted or is not a database',
   'malformed database schema',
   'database corruption',
-  'sqlite_corrupt',
-  'sqlite_notadb',
 ];
+
+/**
+ * SQLite primary result codes for corruption: SQLITE_CORRUPT (11) and SQLITE_NOTADB (26).
+ * `node:sqlite` sets `code` to the constant 'ERR_SQLITE_ERROR' on every error and carries
+ * the real classification in numeric `errcode` and textual `errstr` — and the message can
+ * be an unrelated wrapper: a corrupt FTS5 shadow table surfaces as "vtable constructor
+ * failed: passages_fts" with errcode 11, which no message scan can recognize. Extended
+ * codes put the primary code in the low byte, hence the mask.
+ */
+const CORRUPT_ERRCODES = new Set([11, 26]);
 
 /** True when `e` says the file itself is unusable, not that one operation failed. */
 export function isCorruptionError(e: unknown): boolean {
   if (e instanceof SearchIndexCorruptError) return true;
-  const text = (e instanceof Error ? `${e.message} ${(e as { code?: string }).code ?? ''}` : String(e)).toLowerCase();
+  const { errcode, errstr } = (e ?? {}) as { errcode?: number; errstr?: string };
+  if (typeof errcode === 'number' && CORRUPT_ERRCODES.has(errcode & 0xff)) return true;
+  const text = `${e instanceof Error ? e.message : String(e)} ${errstr ?? ''}`.toLowerCase();
   return CORRUPTION_SIGNS.some((sign) => text.includes(sign));
 }
 
@@ -119,14 +126,6 @@ export class CorruptSearchIndex extends SearchIndexBase {
    */
   override get isEmpty(): boolean {
     return false;
-  }
-
-  /**
-   * Short, because `storageNotice` already carries the file, the sidecars and the command,
-   * and the two are printed in the same sentence.
-   */
-  override get embedderReason(): string {
-    return UNREADABLE;
   }
 
   override buildStatus(): IndexBuildStatus {

--- a/src/features/search/corruption.ts
+++ b/src/features/search/corruption.ts
@@ -3,6 +3,7 @@ import type {
   IndexBuildStatus,
   SearchHit,
   SearchIndex,
+  SearchIndexOptions,
   SearchIndexStatus,
   StorageBackend,
   VersionBackend,
@@ -75,9 +76,11 @@ export function corruptionMessage(dbPath: string, detail: string): string {
     'Every other tool still works: only search is affected, because the index is a derived ' +
     'cache and nothing else reads it. It is not rebuilt automatically, because rebuilding ' +
     're-reads the whole Zotero library and takes minutes to tens of minutes. To recover, ' +
-    'delete the file and its write-ahead sidecars, then rebuild:\n' +
+    'delete the file and its write-ahead sidecars, then restart:\n' +
     `  rm ${JSON.stringify(dbPath)} ${JSON.stringify(`${dbPath}-wal`)} ${JSON.stringify(`${dbPath}-shm`)}\n` +
-    '  then call zotero_index with action:"build" (add fulltext:true if you index attachment text).'
+    'If a legacy search-index.json is still beside it, the next start imports that and the ' +
+    'library is searchable again immediately. Otherwise call zotero_index with ' +
+    'action:"build" (add fulltext:true if you index attachment text).'
   );
 }
 
@@ -93,7 +96,6 @@ export function corruptionMessage(dbPath: string, detail: string): string {
  */
 export class CorruptSearchIndex implements SearchIndex {
   readonly storage: StorageBackend = 'sqlite';
-  readonly embedderConfigured: string;
   readonly embedderActive = false;
   readonly embedderId = undefined;
   readonly vectorEmbedderId = undefined;
@@ -105,18 +107,21 @@ export class CorruptSearchIndex implements SearchIndex {
 
   constructor(
     readonly failure: SearchIndexCorruptError,
-    embedderConfigured = 'off',
-  ) {
-    this.embedderConfigured = embedderConfigured;
+    private readonly opts: SearchIndexOptions,
+  ) {}
+
+  /** Read the same way every other index reads it, so a status still says what was asked for. */
+  get embedderConfigured(): string {
+    return this.opts.configured ?? this.opts.embedder?.name ?? 'off';
   }
 
   /**
-   * Nothing is wrong with the embedder, so this stays empty: filling it would make
-   * `statusSummary` print the whole recovery message a second time under a heading about
-   * semantic ranking, which is not what failed.
+   * Short on purpose. `statusSummary` prints this beside `storageNotice`, which already
+   * carries the file, the sidecars and the command; repeating all of that here printed the
+   * same paragraph three times in one response.
    */
-  get embedderReason(): undefined {
-    return undefined;
+  get embedderReason(): string {
+    return 'the search index could not be opened';
   }
 
   /**
@@ -159,9 +164,7 @@ export class CorruptSearchIndex implements SearchIndex {
       itemsTotal: 0,
       itemsAvailable: 0,
       passages: 0,
-      // Short, because `statusSummary` prints this and `storageNotice` in the same
-      // sentence: the recovery instructions belong in one of them, not in both.
-      lastError: 'the search index could not be opened',
+      lastError: this.embedderReason,
     };
   }
 

--- a/src/features/search/corruption.ts
+++ b/src/features/search/corruption.ts
@@ -1,0 +1,205 @@
+import type {
+  BuildOptions,
+  IndexBuildStatus,
+  SearchHit,
+  SearchIndex,
+  SearchIndexStatus,
+  StorageBackend,
+  VersionBackend,
+} from './backend.js';
+
+/**
+ * The SQLite search index cannot be read.
+ *
+ * Raised in place of SQLite's own sentence, which reaches the caller as a bare "database
+ * disk image is malformed" naming neither the file nor anything to do about it.
+ */
+export class SearchIndexCorruptError extends Error {
+  constructor(
+    readonly dbPath: string,
+    readonly detail: string,
+  ) {
+    super(corruptionMessage(dbPath, detail));
+    this.name = 'SearchIndexCorruptError';
+  }
+}
+
+/**
+ * SQLite's vocabulary for "this file is not a usable database".
+ *
+ * Matched on the message rather than on a code because `node:sqlite` does not surface
+ * `SQLITE_CORRUPT` as a stable numeric field, and because these strings are part of
+ * SQLite's public interface: they are in its documentation and have not changed across
+ * the 3.x series.
+ *
+ * Deliberately narrow. A locked database, a read-only filesystem and a missing table are
+ * all failures and none of them is corruption; widening this list would turn a transient
+ * fault into a message telling someone to delete their index.
+ */
+const CORRUPTION_SIGNS = [
+  'database disk image is malformed',
+  'file is not a database',
+  'file is encrypted or is not a database',
+  'malformed database schema',
+  'database corruption',
+  'sqlite_corrupt',
+  'sqlite_notadb',
+];
+
+/** True when `e` says the file itself is unusable, not that one operation failed. */
+export function isCorruptionError(e: unknown): boolean {
+  if (e instanceof SearchIndexCorruptError) return true;
+  const text = (e instanceof Error ? `${e.message} ${(e as { code?: string }).code ?? ''}` : String(e)).toLowerCase();
+  return CORRUPTION_SIGNS.some((sign) => text.includes(sign));
+}
+
+/**
+ * Name the file, the sidecars and the command, because the caller can act on none of it
+ * otherwise — least of all an agent, which is what is usually holding this connection.
+ *
+ * The index is derived data: deleting it costs only the time to rebuild. That is also the
+ * reason not to rebuild it here without being asked. A rebuild re-crawls the whole library
+ * and takes minutes to tens of minutes with full text on, and this error surfaces in the
+ * middle of somebody's query — not a moment at which to start a job of that length on
+ * their behalf. See the pull request for the alternatives.
+ *
+ * Deleting the file also clears the version stamp, which lives in the `meta` table inside
+ * the same database. A recovery that dropped the passage tables and left `meta` standing
+ * would leave an empty index claiming to be current, and `action:"update"` would then diff
+ * against a stamp for passages that no longer exist — an empty library that reports itself
+ * as up to date, which is worse than the error it replaced.
+ */
+export function corruptionMessage(dbPath: string, detail: string): string {
+  return (
+    `The search index at ${dbPath} cannot be read — SQLite reports: ${detail}. ` +
+    'Every other tool still works: only search is affected, because the index is a derived ' +
+    'cache and nothing else reads it. It is not rebuilt automatically, because rebuilding ' +
+    're-reads the whole Zotero library and takes minutes to tens of minutes. To recover, ' +
+    'delete the file and its write-ahead sidecars, then rebuild:\n' +
+    `  rm ${JSON.stringify(dbPath)} ${JSON.stringify(`${dbPath}-wal`)} ${JSON.stringify(`${dbPath}-shm`)}\n` +
+    '  then call zotero_index with action:"build" (add fulltext:true if you index attachment text).'
+  );
+}
+
+/**
+ * The index the server holds when its database could not be opened.
+ *
+ * Not an empty index, and that is the whole design. An empty one answers every query with
+ * no hits, which reads to a caller exactly like a library holding nothing — a silent wrong
+ * answer in place of a loud right one. So every operation that would read or write the
+ * index refuses with the message above, and the rest of the server is untouched: item
+ * reads, bibliographies and attachment full text go to Zotero and never through here, so
+ * one bad cache file no longer takes the whole MCP server down with it.
+ */
+export class CorruptSearchIndex implements SearchIndex {
+  readonly storage: StorageBackend = 'sqlite';
+  readonly embedderConfigured: string;
+  readonly embedderActive = false;
+  readonly embedderId = undefined;
+  readonly vectorEmbedderId = undefined;
+  readonly supportsDelete = false;
+  readonly embedderName = 'none (search index unreadable)';
+  readonly hasEmbedder = false;
+  readonly hasVectors = false;
+  readonly isBuilding = false;
+
+  constructor(
+    readonly failure: SearchIndexCorruptError,
+    embedderConfigured = 'off',
+  ) {
+    this.embedderConfigured = embedderConfigured;
+  }
+
+  /**
+   * Nothing is wrong with the embedder, so this stays empty: filling it would make
+   * `statusSummary` print the whole recovery message a second time under a heading about
+   * semantic ranking, which is not what failed.
+   */
+  get embedderReason(): undefined {
+    return undefined;
+  }
+
+  /**
+   * Reported non-empty so that nothing mistakes this for a library awaiting its first
+   * build and helpfully starts one — `zotero_semantic_search`'s `auto_build` would.
+   */
+  get isEmpty(): boolean {
+    return false;
+  }
+
+  noteFulltextUnavailable(): void {
+    /* Nothing to report about full text: the index cannot be read at all. */
+  }
+
+  status(): SearchIndexStatus {
+    return {
+      documents: 0,
+      vectors: 0,
+      items: 0,
+      storage: 'sqlite',
+      storageNotice: this.failure.message,
+      embedder: this.embedderName,
+      embedderConfigured: this.embedderConfigured,
+      embedderActive: false,
+      fulltextEnabled: false,
+      fulltextItems: 0,
+      fulltextPassages: 0,
+      builtFromVersion: 0,
+      libraryVersion: 0,
+    };
+  }
+
+  buildStatus(): IndexBuildStatus {
+    return {
+      ...this.status(),
+      state: 'error',
+      operation: 'build',
+      itemsFetched: 0,
+      itemsRemoved: 0,
+      itemsTotal: 0,
+      itemsAvailable: 0,
+      passages: 0,
+      // Short, because `statusSummary` prints this and `storageNotice` in the same
+      // sentence: the recovery instructions belong in one of them, not in both.
+      lastError: 'the search index could not be opened',
+    };
+  }
+
+  requestStop(): boolean {
+    return false;
+  }
+
+  async embed(): Promise<number[][]> {
+    return [];
+  }
+
+  async build(_libraryItems: any[], _opts?: BuildOptions): Promise<SearchIndexStatus> {
+    throw this.failure;
+  }
+
+  async buildIncremental(): Promise<IndexBuildStatus> {
+    throw this.failure;
+  }
+
+  /** Never attempt a delta against an index that could not be read. */
+  updateBlocker(_backend: VersionBackend): string {
+    return 'the search index cannot be read';
+  }
+
+  async updateIncremental(): Promise<IndexBuildStatus> {
+    throw this.failure;
+  }
+
+  async query(_q: string, _opts?: unknown): Promise<SearchHit[]> {
+    throw this.failure;
+  }
+
+  /** Nothing is held, so nothing can be written; saving must not report false success. */
+  async save(): Promise<void> {
+    throw this.failure;
+  }
+
+  async close(): Promise<void> {
+    /* No handle was ever opened. */
+  }
+}

--- a/src/features/search/corruption.ts
+++ b/src/features/search/corruption.ts
@@ -1,12 +1,12 @@
+import { SearchIndexBase } from './index-manager.js';
 import type {
-  BuildOptions,
+  IndexCounts,
   IndexBuildStatus,
+  RankedId,
   SearchHit,
-  SearchIndex,
   SearchIndexOptions,
   SearchIndexStatus,
   StorageBackend,
-  VersionBackend,
 } from './backend.js';
 
 /**
@@ -16,14 +16,21 @@ import type {
  * disk image is malformed" naming neither the file nor anything to do about it.
  */
 export class SearchIndexCorruptError extends Error {
+  readonly detail: string;
+
   constructor(
     readonly dbPath: string,
-    readonly detail: string,
+    cause: unknown,
   ) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
     super(corruptionMessage(dbPath, detail));
+    this.detail = detail;
     this.name = 'SearchIndexCorruptError';
   }
 }
+
+/** One sentence for the status fields that have room only to say the index is unusable. */
+const UNREADABLE = 'the search index cannot be read';
 
 /**
  * SQLite's vocabulary for "this file is not a usable database".
@@ -55,33 +62,21 @@ export function isCorruptionError(e: unknown): boolean {
 }
 
 /**
- * Name the file, the sidecars and the command, because the caller can act on none of it
- * otherwise — least of all an agent, which is what is usually holding this connection.
+ * The message the refusal carries, which is the whole of what a caller has to go on.
  *
- * The index is derived data: deleting it costs only the time to rebuild. That is also the
- * reason not to rebuild it here without being asked. A rebuild re-crawls the whole library
- * and takes minutes to tens of minutes with full text on, and this error surfaces in the
- * middle of somebody's query — not a moment at which to start a job of that length on
- * their behalf. See the pull request for the alternatives.
- *
- * Deleting the file also clears the version stamp, which lives in the `meta` table inside
- * the same database. A recovery that dropped the passage tables and left `meta` standing
- * would leave an empty index claiming to be current, and `action:"update"` would then diff
- * against a stamp for passages that no longer exist — an empty library that reports itself
- * as up to date, which is worse than the error it replaced.
+ * It says why there is no automatic rebuild; what it does not say, and the reason deleting
+ * the file is the recovery rather than emptying it, is the version stamp. That lives in the
+ * `meta` table inside this same database. A repair that dropped the passage tables and left
+ * `meta` standing would leave an empty index carrying a current stamp, and `action:"update"`
+ * would then diff against passages that no longer exist — an empty library reporting itself
+ * as up to date, which is worse than the error it replaced. Removing the file removes the
+ * stamp with it, by construction.
  */
-export function corruptionMessage(dbPath: string, detail: string): string {
-  return (
-    `The search index at ${dbPath} cannot be read — SQLite reports: ${detail}. ` +
-    'Every other tool still works: only search is affected, because the index is a derived ' +
-    'cache and nothing else reads it. It is not rebuilt automatically, because rebuilding ' +
-    're-reads the whole Zotero library and takes minutes to tens of minutes. To recover, ' +
-    'delete the file and its write-ahead sidecars, then restart:\n' +
-    `  rm ${JSON.stringify(dbPath)} ${JSON.stringify(`${dbPath}-wal`)} ${JSON.stringify(`${dbPath}-shm`)}\n` +
-    'If a legacy search-index.json is still beside it, the next start imports that and the ' +
-    'library is searchable again immediately. Otherwise call zotero_index with ' +
-    'action:"build" (add fulltext:true if you index attachment text).'
-  );
+function corruptionMessage(dbPath: string, detail: string): string {
+  const files = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`].map((p) => JSON.stringify(p)).join(' ');
+  return `The search index at ${dbPath} cannot be read — SQLite reports: ${detail}. Every other tool still works: only search is affected, because the index is a derived cache and nothing else reads it. It is not rebuilt automatically, because rebuilding re-reads the whole Zotero library and takes minutes to tens of minutes, which is not a job to start inside somebody's query. To recover, delete the file and its write-ahead sidecars, then restart:
+  rm ${files}
+If a legacy search-index.json is still beside it, the next start imports that and the library is searchable again immediately. Otherwise call zotero_index with action:"build" (add fulltext:true if you index attachment text).`;
 }
 
 /**
@@ -93,107 +88,69 @@ export function corruptionMessage(dbPath: string, detail: string): string {
  * index refuses with the message above, and the rest of the server is untouched: item
  * reads, bibliographies and attachment full text go to Zotero and never through here, so
  * one bad cache file no longer takes the whole MCP server down with it.
+ *
+ * It extends `SearchIndexBase` rather than implementing `SearchIndex` directly, so that
+ * everything a caller reads but this class has no opinion about — the embedder identity and
+ * its degradation reasons, the counts, the build-status shape — keeps coming from the same
+ * place it comes from on a healthy index. A hand-written copy drifts the first time a field
+ * is added to the interface, and drifts silently, because the missing field is optional.
  */
-export class CorruptSearchIndex implements SearchIndex {
+export class CorruptSearchIndex extends SearchIndexBase {
   readonly storage: StorageBackend = 'sqlite';
-  readonly embedderActive = false;
-  readonly embedderId = undefined;
-  readonly vectorEmbedderId = undefined;
+  /** No store to delete from, and never a delta: see `updateBlocker`. */
   readonly supportsDelete = false;
-  readonly embedderName = 'none (search index unreadable)';
-  readonly hasEmbedder = false;
-  readonly hasVectors = false;
-  readonly isBuilding = false;
 
-  constructor(
-    readonly failure: SearchIndexCorruptError,
-    private readonly opts: SearchIndexOptions,
-  ) {}
-
-  /** Read the same way every other index reads it, so a status still says what was asked for. */
-  get embedderConfigured(): string {
-    return this.opts.configured ?? this.opts.embedder?.name ?? 'off';
+  constructor(readonly failure: SearchIndexCorruptError, opts: SearchIndexOptions) {
+    super(opts);
+    // The channel the store already uses to explain what opening it did or refused to do,
+    // so this reaches `status().storageNotice` and `statusSummary` the same way a refused
+    // JSON migration does.
+    this.storeNotice = failure.message;
   }
 
-  /**
-   * Short on purpose. `statusSummary` prints this beside `storageNotice`, which already
-   * carries the file, the sidecars and the command; repeating all of that here printed the
-   * same paragraph three times in one response.
-   */
-  get embedderReason(): string {
-    return 'the search index could not be opened';
+  /** The refusal every caller can defer to instead of explaining an empty index. */
+  override get storeFault(): Error {
+    return this.failure;
   }
 
   /**
    * Reported non-empty so that nothing mistakes this for a library awaiting its first
    * build and helpfully starts one — `zotero_semantic_search`'s `auto_build` would.
    */
-  get isEmpty(): boolean {
+  override get isEmpty(): boolean {
     return false;
   }
 
-  noteFulltextUnavailable(): void {
-    /* Nothing to report about full text: the index cannot be read at all. */
+  /**
+   * Short, because `storageNotice` already carries the file, the sidecars and the command,
+   * and the two are printed in the same sentence.
+   */
+  override get embedderReason(): string {
+    return UNREADABLE;
   }
 
-  status(): SearchIndexStatus {
-    return {
-      documents: 0,
-      vectors: 0,
-      items: 0,
-      storage: 'sqlite',
-      storageNotice: this.failure.message,
-      embedder: this.embedderName,
-      embedderConfigured: this.embedderConfigured,
-      embedderActive: false,
-      fulltextEnabled: false,
-      fulltextItems: 0,
-      fulltextPassages: 0,
-      builtFromVersion: 0,
-      libraryVersion: 0,
-    };
-  }
-
-  buildStatus(): IndexBuildStatus {
-    return {
-      ...this.status(),
-      state: 'error',
-      operation: 'build',
-      itemsFetched: 0,
-      itemsRemoved: 0,
-      itemsTotal: 0,
-      itemsAvailable: 0,
-      passages: 0,
-      lastError: this.embedderReason,
-    };
-  }
-
-  requestStop(): boolean {
-    return false;
-  }
-
-  async embed(): Promise<number[][]> {
-    return [];
-  }
-
-  async build(_libraryItems: any[], _opts?: BuildOptions): Promise<SearchIndexStatus> {
-    throw this.failure;
-  }
-
-  async buildIncremental(): Promise<IndexBuildStatus> {
-    throw this.failure;
+  override buildStatus(): IndexBuildStatus {
+    return { ...super.buildStatus(), state: 'error', lastError: UNREADABLE };
   }
 
   /** Never attempt a delta against an index that could not be read. */
-  updateBlocker(_backend: VersionBackend): string {
-    return 'the search index cannot be read';
+  override updateBlocker(): string {
+    return UNREADABLE;
   }
 
-  async updateIncremental(): Promise<IndexBuildStatus> {
+  override async build(): Promise<SearchIndexStatus> {
     throw this.failure;
   }
 
-  async query(_q: string, _opts?: unknown): Promise<SearchHit[]> {
+  override async buildIncremental(): Promise<IndexBuildStatus> {
+    throw this.failure;
+  }
+
+  override async updateIncremental(): Promise<IndexBuildStatus> {
+    throw this.failure;
+  }
+
+  override async query(): Promise<SearchHit[]> {
     throw this.failure;
   }
 
@@ -203,6 +160,41 @@ export class CorruptSearchIndex implements SearchIndex {
   }
 
   async close(): Promise<void> {
-    /* No handle was ever opened. */
+    /* No handle was ever opened by this object: the store closed its own before throwing. */
+  }
+
+  // The storage primitives the base would call. Nothing reaches them — every public entry
+  // point above refuses first — so they exist to satisfy the contract, not to be run.
+  protected counts(): IndexCounts {
+    return { documents: 0, vectors: 0, items: 0, fulltextItems: 0, fulltextPassages: 0 };
+  }
+  protected clearStore(): void {}
+  protected clearVectors(): void {}
+  protected putItem(): void {
+    throw this.failure;
+  }
+  protected putPassage(): void {
+    throw this.failure;
+  }
+  protected deleteItem(): void {
+    throw this.failure;
+  }
+  protected putVector(): void {
+    throw this.failure;
+  }
+  protected listItemKeys(): string[] {
+    return [];
+  }
+  protected vectorDimension(): number | undefined {
+    return undefined;
+  }
+  protected keywordSearch(): RankedId[] {
+    throw this.failure;
+  }
+  protected vectorSearch(): RankedId[] {
+    throw this.failure;
+  }
+  protected passage(): undefined {
+    return undefined;
   }
 }

--- a/src/features/search/factory.ts
+++ b/src/features/search/factory.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { CorruptSearchIndex, SearchIndexCorruptError, isCorruptionError } from './corruption.js';
 import { MemorySearchIndex } from './index-manager.js';
 import { loadIndex } from './persistence.js';
 import type { SearchIndex, SearchIndexOptions } from './backend.js';
@@ -50,12 +51,25 @@ export async function createSearchIndex(opts: CreateSearchIndexOptions): Promise
   if (backend !== 'memory') {
     if (nodeSqliteAvailable()) {
       const { SqliteSearchIndex } = await import('./sqlite-index.js');
+      const path = jsonPath ? sqliteIndexPath(jsonPath) : ':memory:';
       const index = new SqliteSearchIndex({
         ...indexOpts,
-        path: jsonPath ? sqliteIndexPath(jsonPath) : ':memory:',
+        path,
         ...(jsonPath ? { migrateFrom: jsonPath } : {}),
       });
-      await index.open();
+      try {
+        await index.open();
+      } catch (e) {
+        // An unreadable index must not take the server with it. Everything that does not
+        // read the index — item lookups, bibliographies, attachments, citations — is
+        // unaffected by a bad cache file and keeps working; search alone refuses, and says
+        // why. Anything that is not corruption still throws: a permission error or a full
+        // disk is not a reason to tell someone their index is beyond saving.
+        if (!isCorruptionError(e)) throw e;
+        const failure = new SearchIndexCorruptError(path, e instanceof Error ? e.message : String(e));
+        opts.logger?.error(failure.message);
+        return new CorruptSearchIndex(failure, indexOpts.configured ?? indexOpts.embedder?.name ?? 'off');
+      }
       return index;
     }
     if (backend === 'sqlite') {

--- a/src/features/search/factory.ts
+++ b/src/features/search/factory.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-import { CorruptSearchIndex, SearchIndexCorruptError, isCorruptionError } from './corruption.js';
+import { CorruptSearchIndex, SearchIndexCorruptError } from './corruption.js';
 import { MemorySearchIndex } from './index-manager.js';
 import { loadIndex } from './persistence.js';
 import type { SearchIndex, SearchIndexOptions } from './backend.js';
@@ -51,10 +51,9 @@ export async function createSearchIndex(opts: CreateSearchIndexOptions): Promise
   if (backend !== 'memory') {
     if (nodeSqliteAvailable()) {
       const { SqliteSearchIndex } = await import('./sqlite-index.js');
-      const path = jsonPath ? sqliteIndexPath(jsonPath) : ':memory:';
       const index = new SqliteSearchIndex({
         ...indexOpts,
-        path,
+        path: jsonPath ? sqliteIndexPath(jsonPath) : ':memory:',
         ...(jsonPath ? { migrateFrom: jsonPath } : {}),
       });
       try {
@@ -63,12 +62,12 @@ export async function createSearchIndex(opts: CreateSearchIndexOptions): Promise
         // An unreadable index must not take the server with it. Everything that does not
         // read the index — item lookups, bibliographies, attachments, citations — is
         // unaffected by a bad cache file and keeps working; search alone refuses, and says
-        // why. Anything that is not corruption still throws: a permission error or a full
-        // disk is not a reason to tell someone their index is beyond saving.
-        if (!isCorruptionError(e)) throw e;
-        const failure = new SearchIndexCorruptError(path, e instanceof Error ? e.message : String(e));
-        opts.logger?.error(failure.message);
-        return new CorruptSearchIndex(failure, indexOpts);
+        // why. Anything else still throws: a permission error or a full disk is not a
+        // reason to tell someone their index is beyond saving, and the store is the only
+        // thing that knows which is which.
+        if (!(e instanceof SearchIndexCorruptError)) throw e;
+        opts.logger?.error(e.message);
+        return new CorruptSearchIndex(e, indexOpts);
       }
       return index;
     }

--- a/src/features/search/factory.ts
+++ b/src/features/search/factory.ts
@@ -68,7 +68,7 @@ export async function createSearchIndex(opts: CreateSearchIndexOptions): Promise
         if (!isCorruptionError(e)) throw e;
         const failure = new SearchIndexCorruptError(path, e instanceof Error ? e.message : String(e));
         opts.logger?.error(failure.message);
-        return new CorruptSearchIndex(failure, indexOpts.configured ?? indexOpts.embedder?.name ?? 'off');
+        return new CorruptSearchIndex(failure, indexOpts);
       }
       return index;
     }

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -151,6 +151,11 @@ export abstract class SearchIndexBase implements SearchIndex {
   /** What opening the store had to do or refused to do (JSON migration; see #10). */
   protected storeNotice: string | undefined = undefined;
 
+  /** No fault: an index that could not be opened at all is a different class (see backend.ts). */
+  get storeFault(): Error | undefined {
+    return undefined;
+  }
+
   // Asynchronous build lifecycle (see buildIncremental / requestStop / buildStatus).
   private buildState: BuildState = 'idle';
   private operation: 'build' | 'update' = 'build';

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
 import { tokenize } from './tokenize.js';
+import { SearchIndexCorruptError, isCorruptionError } from './corruption.js';
 import type { ChunkRecord, IndexCounts, IndexSnapshot, RankedId, SearchIndexOptions } from './backend.js';
 
 /**
@@ -423,6 +424,10 @@ export class SqliteSearchIndex extends SearchIndexBase {
       const rows = this.stmts.keyword.all(match, topK) as Array<{ id: string; rank: number }>;
       return rows.map((r) => ({ id: r.id, score: -r.rank }));
     } catch (e) {
+      // A file that has gone bad under us is not a rejected query, and must not be
+      // swallowed into an empty result set: an index that answers "no matches" forever
+      // reads as an empty library rather than as a fault.
+      if (isCorruptionError(e)) throw new SearchIndexCorruptError(this.file, e instanceof Error ? e.message : String(e));
       // A term the FTS5 parser rejects must not take the whole search down with it.
       this.opts.logger?.debug(`FTS5 query rejected (${match}): ${e instanceof Error ? e.message : String(e)}`);
       return [];

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -104,19 +104,29 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // Checked before the handle is created, because creating it creates the file.
     const existed = this.file !== ':memory:' && existsSync(this.file);
     this.db = new DatabaseSync(this.file);
-    // WAL rather than the rollback journal: a build commits every few hundred items, and
-    // WAL makes those commits cheap while still leaving a complete database behind a
-    // crash (an interrupted build rolls back to its last commit, never a torn file).
-    this.db.exec('PRAGMA journal_mode = WAL');
-    // NORMAL fsyncs at checkpoints instead of on every commit. A power cut can then cost
-    // the last commits of a running build, which the next build replaces anyway, but it
-    // can never cost the database itself.
-    this.db.exec('PRAGMA synchronous = NORMAL');
-    this.createSchema();
-    this.prepareStatements();
-    if (!existed && this.migrateFrom) await this.importJson(this.migrateFrom);
-    this.refreshCounts();
-    this.loadMeta();
+    try {
+      // WAL rather than the rollback journal: a build commits every few hundred items, and
+      // WAL makes those commits cheap while still leaving a complete database behind a
+      // crash (an interrupted build rolls back to its last commit, never a torn file).
+      this.db.exec('PRAGMA journal_mode = WAL');
+      // NORMAL fsyncs at checkpoints instead of on every commit. A power cut can then cost
+      // the last commits of a running build, which the next build replaces anyway, but it
+      // can never cost the database itself.
+      this.db.exec('PRAGMA synchronous = NORMAL');
+      this.createSchema();
+      this.prepareStatements();
+      if (!existed && this.migrateFrom) await this.importJson(this.migrateFrom);
+      this.refreshCounts();
+      this.loadMeta();
+    } catch (e) {
+      if (!isCorruptionError(e)) throw e;
+      // The handle exists from the line above, so this object owns it and must release it
+      // before handing the failure on. Not housekeeping: the message names three files for
+      // the user to delete, and on Windows an open handle refuses the delete — a server
+      // holding them would block the recovery it is prescribing.
+      await this.close().catch(() => {});
+      throw new SearchIndexCorruptError(this.file, e);
+    }
   }
 
   private get handle(): Database {
@@ -427,7 +437,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
       // A file that has gone bad under us is not a rejected query, and must not be
       // swallowed into an empty result set: an index that answers "no matches" forever
       // reads as an empty library rather than as a fault.
-      if (isCorruptionError(e)) throw new SearchIndexCorruptError(this.file, e instanceof Error ? e.message : String(e));
+      if (isCorruptionError(e)) throw new SearchIndexCorruptError(this.file, e);
       // A term the FTS5 parser rejects must not take the whole search down with it.
       this.opts.logger?.debug(`FTS5 query rejected (${match}): ${e instanceof Error ? e.message : String(e)}`);
       return [];

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -466,11 +466,19 @@ export class SqliteSearchIndex extends SearchIndexBase {
   }
 
   protected passage(id: string): ChunkRecord | undefined {
-    const row = this.stmts.selectPassage.get(id) as PassageRow | undefined;
-    if (!row) return undefined;
-    const rec: ChunkRecord = { id: row.id, itemKey: row.item_key, title: row.title, text: row.text };
-    if (row.source === 'fulltext') rec.source = 'fulltext';
-    return rec;
+    try {
+      const row = this.stmts.selectPassage.get(id) as PassageRow | undefined;
+      if (!row) return undefined;
+      const rec: ChunkRecord = { id: row.id, itemKey: row.item_key, title: row.title, text: row.text };
+      if (row.source === 'fulltext') rec.source = 'fulltext';
+      return rec;
+    } catch (e) {
+      // Corruption in the passages b-tree is discovered here — every fused hit hydrates
+      // through this read — and must reach the caller as the typed refusal, not as
+      // SQLite's bare sentence naming neither the file nor the way out.
+      if (isCorruptionError(e)) throw new SearchIndexCorruptError(this.file, e);
+      throw e;
+    }
   }
 
   /** Write the index-level state and commit whatever the build has inserted so far. */

--- a/src/tools/semantic-search.ts
+++ b/src/tools/semantic-search.ts
@@ -79,7 +79,10 @@ const semanticSearch: ToolDefinition = {
     // Semantic mode ranks by vectors alone. With none in the index every query returns an
     // empty list, which reads exactly like "your library has nothing on this": the failure
     // mode reported in #7. Refuse instead, and name the cause.
-    if (args.mode === 'semantic' && !ctx.search.hasVectors) {
+    // A store that could not be opened explains itself; this branch would otherwise tell
+    // the caller their index holds no vectors and to rebuild it, which is true and beside
+    // the point. Falling through lets query() refuse with the file and the command.
+    if (args.mode === 'semantic' && !ctx.search.hasVectors && !ctx.search.storeFault) {
       const why =
         // A model switch is the one cause that names its own remedy, so it wins over the
         // generic "no vectors yet" line.

--- a/tests/features/search-corruption.test.ts
+++ b/tests/features/search-corruption.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, openSync, writeSync, closeSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createSearchIndex, nodeSqliteAvailable, sqliteIndexPath } from '../../src/features/search/factory.js';
+import {
+  CorruptSearchIndex,
+  SearchIndexCorruptError,
+  isCorruptionError,
+} from '../../src/features/search/corruption.js';
+import { statusSummary } from '../../src/features/search/build.js';
+
+/**
+ * A damaged search index used to take the whole MCP server with it: `open()` threw
+ * SQLite's own sentence out of `createSearchIndex`, which nothing catches, so `buildServer`
+ * rejected and the process exited before serving a single tool. The index is a derived
+ * cache that no other tool reads, so the blast radius was the entire server for a file
+ * that only search needs.
+ */
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+const hasSqlite = nodeSqliteAvailable();
+const sqliteIt = hasSqlite ? it : it.skip;
+
+function tmpJsonPath(name: string): string {
+  return join(mkdtempSync(join(tmpdir(), `zoteus-${name}-`)), 'search-index.json');
+}
+
+/** A real index, closed, with one interior page overwritten: a bad sector or a torn write. */
+async function corruptedIndex(): Promise<string> {
+  const jsonPath = tmpJsonPath('corrupt');
+  const dbPath = sqliteIndexPath(jsonPath);
+  const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+  await index.build([{ key: 'A', data: { itemType: 'book', title: 'Deep learning', abstractNote: 'neural networks' } }]);
+  await index.save();
+  await index.close();
+  const fd = openSync(dbPath, 'r+');
+  // Page 3, leaving the header intact: SQLite opens the file and fails when it reads it.
+  writeSync(fd, Buffer.alloc(4096, 0x5a), 0, 4096, 8192);
+  closeSync(fd);
+  return jsonPath;
+}
+
+describe('isCorruptionError', () => {
+  it('recognizes SQLite saying the file is not a usable database', () => {
+    for (const m of [
+      'database disk image is malformed',
+      'file is not a database',
+      'file is encrypted or is not a database',
+      'malformed database schema (passages_fts)',
+    ]) {
+      expect(isCorruptionError(new Error(m)), m).toBe(true);
+    }
+    expect(isCorruptionError(new SearchIndexCorruptError('/x.sqlite', 'malformed'))).toBe(true);
+  });
+
+  it('leaves every other failure alone, because they are not a reason to delete an index', () => {
+    // Deliberately narrow: a locked database, a full disk and a missing table are faults,
+    // and telling someone to delete their index over one would be its own defect.
+    for (const m of [
+      'database is locked',
+      'attempt to write a readonly database',
+      'no such table: passages',
+      'disk I/O error',
+      'unable to open database file',
+      'database or disk is full',
+    ]) {
+      expect(isCorruptionError(new Error(m)), m).toBe(false);
+    }
+  });
+});
+
+describe('opening an index that cannot be read', () => {
+  sqliteIt('serves the rest of the server instead of failing to start', async () => {
+    const jsonPath = await corruptedIndex();
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    expect(index).toBeInstanceOf(CorruptSearchIndex);
+    await index.close();
+  });
+
+  sqliteIt('refuses a query with the file, the sidecars and the command to run', async () => {
+    const jsonPath = await corruptedIndex();
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    await expect(index.query('neural')).rejects.toThrow(SearchIndexCorruptError);
+    await expect(index.query('neural')).rejects.toThrow(sqliteIndexPath(jsonPath));
+    await expect(index.query('neural')).rejects.toThrow(/-wal/);
+    await expect(index.query('neural')).rejects.toThrow(/zotero_index/);
+    await index.close();
+  });
+
+  sqliteIt('answers no query with an empty result set, which would read as an empty library', async () => {
+    // The failure this replaces: `keywordSearch` catches everything, so a corrupt index
+    // answered "No matches" forever and looked like a library holding nothing.
+    const jsonPath = await corruptedIndex();
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    await expect(index.query('neural')).rejects.toThrow();
+    await index.close();
+  });
+
+  sqliteIt('does not look like a library awaiting its first build', async () => {
+    // `zotero_semantic_search` auto-builds an empty index. Reporting empty here would
+    // start a full library crawl on top of the fault.
+    const jsonPath = await corruptedIndex();
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    expect(index.isEmpty).toBe(false);
+    expect(index.updateBlocker('local')).toBeTruthy();
+    expect(index.buildStatus().state).toBe('error');
+    await index.close();
+  });
+
+  sqliteIt('states the fault once, not once per status field', async () => {
+    const jsonPath = await corruptedIndex();
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const summary = statusSummary(index.buildStatus());
+    expect(summary.match(/cannot be read/g)).toHaveLength(1);
+    await index.close();
+  });
+
+  sqliteIt('refuses to report a successful save of an index it never opened', async () => {
+    const jsonPath = await corruptedIndex();
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    await expect(index.save()).rejects.toThrow(SearchIndexCorruptError);
+    await index.close();
+  });
+
+  sqliteIt('treats a file that is not a database at all the same way', async () => {
+    const jsonPath = tmpJsonPath('notadb');
+    writeFileSync(sqliteIndexPath(jsonPath), 'this is not a database, it is a text file\n');
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    expect(index).toBeInstanceOf(CorruptSearchIndex);
+    await index.close();
+  });
+
+  sqliteIt('still throws when the failure is not corruption', async () => {
+    // A path that cannot be opened is a fault to fix, not an index to delete: it must not
+    // be dressed up as corruption with recovery instructions that would lose data.
+    const dir = mkdtempSync(join(tmpdir(), 'zoteus-blocked-'));
+    const jsonPath = join(dir, 'search-index.json');
+    // The database path is a directory, so SQLite cannot open it as a file.
+    mkdirSync(sqliteIndexPath(jsonPath));
+    await expect(
+      createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath }),
+    ).rejects.not.toBeInstanceOf(SearchIndexCorruptError);
+  });
+});

--- a/tests/features/search-corruption.test.ts
+++ b/tests/features/search-corruption.test.ts
@@ -55,7 +55,34 @@ async function openCorrupted(): Promise<{ jsonPath: string; index: SearchIndex }
   return { jsonPath, index: await openIndex(jsonPath) };
 }
 
+/** An error shaped exactly as node:sqlite raises it (code is constant, truth in errcode/errstr). */
+function sqliteError(message: string, errcode: number, errstr: string): Error {
+  const e = new Error(message) as Error & { code: string; errcode: number; errstr: string };
+  e.code = 'ERR_SQLITE_ERROR';
+  e.errcode = errcode;
+  e.errstr = errstr;
+  return e;
+}
+
 describe('isCorruptionError', () => {
+  it('recognizes corruption behind a wrapper message, where the message alone says nothing', () => {
+    // The case a message scan cannot see: a corrupt FTS5 shadow table surfaces from
+    // prepare() as a vtable failure, with the real classification in errcode/errstr.
+    // Measured on real single-page corruptions, roughly one in ten takes this shape —
+    // and before this check, each of those still killed the whole server at startup.
+    expect(isCorruptionError(sqliteError('vtable constructor failed: passages_fts', 11, 'database disk image is malformed'))).toBe(true);
+    // Extended result codes carry the primary code in the low byte.
+    expect(isCorruptionError(sqliteError('some wrapper', 267, 'database disk image is malformed'))).toBe(true);
+    expect(isCorruptionError(sqliteError('unhelpful wrapper text', 26, 'file is not a database'))).toBe(true);
+  });
+
+  it('still leaves non-corruption result codes alone', () => {
+    expect(isCorruptionError(sqliteError('database is locked', 5, 'database is locked'))).toBe(false);
+    expect(isCorruptionError(sqliteError('no such table: passages', 1, 'SQL logic error'))).toBe(false);
+    expect(isCorruptionError(sqliteError('disk I/O error', 10, 'disk I/O error'))).toBe(false);
+    expect(isCorruptionError(sqliteError('database or disk is full', 13, 'database or disk is full'))).toBe(false);
+  });
+
   it('recognizes SQLite saying the file is not a usable database', () => {
     for (const m of [
       'database disk image is malformed',
@@ -156,6 +183,54 @@ describe('opening an index that cannot be read', () => {
     expect(healed).not.toBeInstanceOf(CorruptSearchIndex);
     expect((await healed.query('neural', { mode: 'keyword' }))[0]?.itemKey).toBe('A');
     await healed.close();
+  });
+
+  sqliteIt('converts corruption discovered at query time, in the hydration read', async () => {
+    // Every fused hit hydrates through passage(); corruption in the passages b-tree is
+    // found there, mid-flight, on an index that opened cleanly. The caller must get the
+    // typed refusal with the file and the recovery command, not SQLite's bare sentence.
+    const jsonPath = tmpJsonPath('midflight');
+    const index = await openIndex(jsonPath);
+    await index.build([ITEM]);
+    const anyIndex = index as unknown as { stmts: { selectPassage: { get(id: string): unknown } } };
+    anyIndex.stmts.selectPassage = {
+      get() {
+        throw sqliteError('vtable constructor failed: passages_fts', 11, 'database disk image is malformed');
+      },
+    };
+    const rejection = await index.query('neural', { mode: 'keyword' }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(rejection).toBeInstanceOf(SearchIndexCorruptError);
+    expect((rejection as Error).message).toContain(sqliteIndexPath(jsonPath));
+    expect((rejection as Error).message).toMatch(/rm /);
+    await index.close();
+  });
+
+  sqliteIt('does not blame the embedder for the store\'s fault', async () => {
+    // whoami and status read embedderReason to explain the embedder. On a corrupt index
+    // the embedder is healthy; attributing the store fault to it sends the user to the
+    // wrong remedy. The fault travels in storeFault/storageNotice/lastError instead.
+    const { index } = await openCorrupted();
+    expect(index.embedderReason).toBeUndefined();
+    expect(index.buildStatus().storageNotice).toContain('cannot be read');
+    await index.close();
+  });
+
+  sqliteIt('refuses mode:"semantic" with the store fault, not with vector advice', async () => {
+    // The storeFault field exists for exactly one caller: the 0-vector refusal in
+    // zotero_semantic_search fires BEFORE query(), and without the deferral it answers
+    // "this index has 0 vectors... re-run with mode:keyword" — advice that fails, since
+    // keyword refuses too, and the file is never named.
+    const { index } = await openCorrupted();
+    expect(index.storeFault).toBeInstanceOf(SearchIndexCorruptError);
+    expect(index.hasVectors).toBe(false);
+    // The guard condition semantic-search.ts uses, asserted against this index: with the
+    // fault present the branch must fall through to query(), whose refusal names the file.
+    const guardFires = !index.hasVectors && !index.storeFault;
+    expect(guardFires).toBe(false);
+    await index.close();
   });
 
   sqliteIt('refuses to report a successful save of an index it never opened', async () => {

--- a/tests/features/search-corruption.test.ts
+++ b/tests/features/search-corruption.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, writeFileSync, openSync, writeSync, closeSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, openSync, writeSync, closeSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createSearchIndex, nodeSqliteAvailable, sqliteIndexPath } from '../../src/features/search/factory.js';
@@ -9,6 +9,8 @@ import {
   isCorruptionError,
 } from '../../src/features/search/corruption.js';
 import { statusSummary } from '../../src/features/search/build.js';
+import { MemorySearchIndex } from '../../src/features/search/index-manager.js';
+import { saveIndex } from '../../src/features/search/persistence.js';
 
 /**
  * A damaged search index used to take the whole MCP server with it: `open()` threw
@@ -112,8 +114,40 @@ describe('opening an index that cannot be read', () => {
     const jsonPath = await corruptedIndex();
     const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
     const summary = statusSummary(index.buildStatus());
-    expect(summary.match(/cannot be read/g)).toHaveLength(1);
+    // The recovery paragraph belongs in exactly one field; it used to land in three.
+    expect(summary.match(/To recover, delete the file/g)).toHaveLength(1);
     await index.close();
+  });
+
+  sqliteIt('recovers by deleting the file, with no rebuild when the JSON artifact remains', async () => {
+    // The recovery the message describes, carried out. `createSearchIndex` migrates a
+    // legacy search-index.json on the first open of a data dir that has no database, so a
+    // user who still has one is searchable again on the next start rather than after a
+    // full library crawl. That is why the message says restart before it says build.
+    // A user who migrated from the JSON backend: the import leaves search-index.json in
+    // place, so the database can be dropped and re-imported. Someone who only ever ran
+    // SQLite has no such artifact and does need the rebuild.
+    const jsonPath = tmpJsonPath('recover');
+    const legacy = new MemorySearchIndex({ embedder: null, logger: silentLogger, path: jsonPath });
+    await legacy.build([{ key: 'A', data: { itemType: 'book', title: 'Deep learning', abstractNote: 'neural networks' } }]);
+    await saveIndex(legacy, jsonPath);
+    const dbPath = sqliteIndexPath(jsonPath);
+    const migrated = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    await migrated.save();
+    await migrated.close();
+    const fd = openSync(dbPath, 'r+');
+    writeSync(fd, Buffer.alloc(4096, 0x5a), 0, 4096, 8192);
+    closeSync(fd);
+
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    expect(index).toBeInstanceOf(CorruptSearchIndex);
+    await index.close();
+
+    for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) rmSync(p, { force: true });
+    const healed = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    expect(healed).not.toBeInstanceOf(CorruptSearchIndex);
+    expect((await healed.query('neural', { mode: 'keyword' }))[0]?.itemKey).toBe('A');
+    await healed.close();
   });
 
   sqliteIt('refuses to report a successful save of an index it never opened', async () => {

--- a/tests/features/search-corruption.test.ts
+++ b/tests/features/search-corruption.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../src/features/search/corruption.js';
 import { statusSummary } from '../../src/features/search/build.js';
 import { MemorySearchIndex } from '../../src/features/search/index-manager.js';
-import { saveIndex } from '../../src/features/search/persistence.js';
+import type { SearchIndex } from '../../src/features/search/backend.js';
 
 /**
  * A damaged search index used to take the whole MCP server with it: `open()` threw
@@ -21,26 +21,38 @@ import { saveIndex } from '../../src/features/search/persistence.js';
  */
 
 const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
-const hasSqlite = nodeSqliteAvailable();
-const sqliteIt = hasSqlite ? it : it.skip;
+const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+const ITEM = { key: 'A', data: { itemType: 'book', title: 'Deep learning', abstractNote: 'neural networks' } };
 
 function tmpJsonPath(name: string): string {
   return join(mkdtempSync(join(tmpdir(), `zoteus-${name}-`)), 'search-index.json');
 }
 
+const openIndex = (jsonPath: string) =>
+  createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+
+/** Overwrite page 3, header intact: SQLite opens the file and fails when it reads it. */
+function scribbleOnPage3(dbPath: string): void {
+  const fd = openSync(dbPath, 'r+');
+  writeSync(fd, Buffer.alloc(4096, 0x5a), 0, 4096, 8192);
+  closeSync(fd);
+}
+
 /** A real index, closed, with one interior page overwritten: a bad sector or a torn write. */
 async function corruptedIndex(): Promise<string> {
   const jsonPath = tmpJsonPath('corrupt');
-  const dbPath = sqliteIndexPath(jsonPath);
-  const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
-  await index.build([{ key: 'A', data: { itemType: 'book', title: 'Deep learning', abstractNote: 'neural networks' } }]);
+  const index = await openIndex(jsonPath);
+  await index.build([ITEM]);
   await index.save();
   await index.close();
-  const fd = openSync(dbPath, 'r+');
-  // Page 3, leaving the header intact: SQLite opens the file and fails when it reads it.
-  writeSync(fd, Buffer.alloc(4096, 0x5a), 0, 4096, 8192);
-  closeSync(fd);
+  scribbleOnPage3(sqliteIndexPath(jsonPath));
   return jsonPath;
+}
+
+/** The CorruptSearchIndex a server would be holding, plus the path it names. */
+async function openCorrupted(): Promise<{ jsonPath: string; index: SearchIndex }> {
+  const jsonPath = await corruptedIndex();
+  return { jsonPath, index: await openIndex(jsonPath) };
 }
 
 describe('isCorruptionError', () => {
@@ -74,45 +86,46 @@ describe('isCorruptionError', () => {
 
 describe('opening an index that cannot be read', () => {
   sqliteIt('serves the rest of the server instead of failing to start', async () => {
-    const jsonPath = await corruptedIndex();
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const { index } = await openCorrupted();
     expect(index).toBeInstanceOf(CorruptSearchIndex);
     await index.close();
   });
 
   sqliteIt('refuses a query with the file, the sidecars and the command to run', async () => {
-    const jsonPath = await corruptedIndex();
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
-    await expect(index.query('neural')).rejects.toThrow(SearchIndexCorruptError);
-    await expect(index.query('neural')).rejects.toThrow(sqliteIndexPath(jsonPath));
-    await expect(index.query('neural')).rejects.toThrow(/-wal/);
-    await expect(index.query('neural')).rejects.toThrow(/zotero_index/);
-    await index.close();
-  });
-
-  sqliteIt('answers no query with an empty result set, which would read as an empty library', async () => {
     // The failure this replaces: `keywordSearch` catches everything, so a corrupt index
     // answered "No matches" forever and looked like a library holding nothing.
-    const jsonPath = await corruptedIndex();
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
-    await expect(index.query('neural')).rejects.toThrow();
+    const { jsonPath, index } = await openCorrupted();
+    await expect(index.query('neural')).rejects.toThrow(SearchIndexCorruptError);
+    const message = await index.query('neural').then(
+      () => '',
+      (e: Error) => e.message,
+    );
+    expect(message).toContain(sqliteIndexPath(jsonPath));
+    expect(message).toContain('-wal');
+    expect(message).toContain('zotero_index');
     await index.close();
   });
 
   sqliteIt('does not look like a library awaiting its first build', async () => {
     // `zotero_semantic_search` auto-builds an empty index. Reporting empty here would
     // start a full library crawl on top of the fault.
-    const jsonPath = await corruptedIndex();
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const { index } = await openCorrupted();
     expect(index.isEmpty).toBe(false);
     expect(index.updateBlocker('local')).toBeTruthy();
     expect(index.buildStatus().state).toBe('error');
     await index.close();
   });
 
+  sqliteIt('carries the fault where a caller can defer to it instead of guessing', async () => {
+    // Without this, zotero_semantic_search's 0-vector refusal fires first and reports
+    // "this index holds no vectors, rebuild it" — true, and not what is wrong.
+    const { index } = await openCorrupted();
+    expect(index.storeFault).toBeInstanceOf(SearchIndexCorruptError);
+    await index.close();
+  });
+
   sqliteIt('states the fault once, not once per status field', async () => {
-    const jsonPath = await corruptedIndex();
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const { index } = await openCorrupted();
     const summary = statusSummary(index.buildStatus());
     // The recovery paragraph belongs in exactly one field; it used to land in three.
     expect(summary.match(/To recover, delete the file/g)).toHaveLength(1);
@@ -124,35 +137,29 @@ describe('opening an index that cannot be read', () => {
     // legacy search-index.json on the first open of a data dir that has no database, so a
     // user who still has one is searchable again on the next start rather than after a
     // full library crawl. That is why the message says restart before it says build.
-    // A user who migrated from the JSON backend: the import leaves search-index.json in
-    // place, so the database can be dropped and re-imported. Someone who only ever ran
-    // SQLite has no such artifact and does need the rebuild.
     const jsonPath = tmpJsonPath('recover');
     const legacy = new MemorySearchIndex({ embedder: null, logger: silentLogger, path: jsonPath });
-    await legacy.build([{ key: 'A', data: { itemType: 'book', title: 'Deep learning', abstractNote: 'neural networks' } }]);
-    await saveIndex(legacy, jsonPath);
+    await legacy.build([ITEM]);
+    await legacy.save();
     const dbPath = sqliteIndexPath(jsonPath);
-    const migrated = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const migrated = await openIndex(jsonPath);
     await migrated.save();
     await migrated.close();
-    const fd = openSync(dbPath, 'r+');
-    writeSync(fd, Buffer.alloc(4096, 0x5a), 0, 4096, 8192);
-    closeSync(fd);
+    scribbleOnPage3(dbPath);
 
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const index = await openIndex(jsonPath);
     expect(index).toBeInstanceOf(CorruptSearchIndex);
     await index.close();
 
     for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) rmSync(p, { force: true });
-    const healed = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const healed = await openIndex(jsonPath);
     expect(healed).not.toBeInstanceOf(CorruptSearchIndex);
     expect((await healed.query('neural', { mode: 'keyword' }))[0]?.itemKey).toBe('A');
     await healed.close();
   });
 
   sqliteIt('refuses to report a successful save of an index it never opened', async () => {
-    const jsonPath = await corruptedIndex();
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const { index } = await openCorrupted();
     await expect(index.save()).rejects.toThrow(SearchIndexCorruptError);
     await index.close();
   });
@@ -160,7 +167,7 @@ describe('opening an index that cannot be read', () => {
   sqliteIt('treats a file that is not a database at all the same way', async () => {
     const jsonPath = tmpJsonPath('notadb');
     writeFileSync(sqliteIndexPath(jsonPath), 'this is not a database, it is a text file\n');
-    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    const index = await openIndex(jsonPath);
     expect(index).toBeInstanceOf(CorruptSearchIndex);
     await index.close();
   });
@@ -168,12 +175,15 @@ describe('opening an index that cannot be read', () => {
   sqliteIt('still throws when the failure is not corruption', async () => {
     // A path that cannot be opened is a fault to fix, not an index to delete: it must not
     // be dressed up as corruption with recovery instructions that would lose data.
-    const dir = mkdtempSync(join(tmpdir(), 'zoteus-blocked-'));
-    const jsonPath = join(dir, 'search-index.json');
+    const jsonPath = tmpJsonPath('blocked');
     // The database path is a directory, so SQLite cannot open it as a file.
     mkdirSync(sqliteIndexPath(jsonPath));
-    await expect(
-      createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath }),
-    ).rejects.not.toBeInstanceOf(SearchIndexCorruptError);
+    const rejection = await openIndex(jsonPath).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).not.toBeInstanceOf(SearchIndexCorruptError);
+    expect((rejection as Error).message).toMatch(/unable to open|EISDIR|ENOTDIR|EEXIST/i);
   });
 });


### PR DESCRIPTION
One damaged page in a derived cache file stops the whole MCP server from starting.

`SqliteSearchIndex.open()` throws SQLite's own sentence, `createSearchIndex` does not catch it, and neither does anything above it. Built from `main`, run against a database with one interior page overwritten:

```
[zoteus] FATAL Error: database disk image is malformed
    at SqliteSearchIndex.createSchema (sqlite-index.js:110)
    at SqliteSearchIndex.open (sqlite-index.js:71)
    at async createSearchIndex (factory.js:42)
    at async buildContext (server.js:77)
    at async main (index.js:23)
```

The client never gets a reply to `initialize`. Item lookups, bibliographies and citations go down with it, though none of them reads the search index — and nothing is left running to say what is wrong.

## What this does

`open()` closes the handle it created and throws a typed `SearchIndexCorruptError`; the factory substitutes an index that refuses. The server starts, all 30 tools register, and search alone answers with the file, its sidecars and the command to remove them — then how to get back: a legacy `search-index.json` still beside it is re-imported on the next start, otherwise `zotero_index action:"build"`.

Three details are load-bearing:

**Refusing, not answering nothing.** `keywordSearch` catches everything so one bad FTS5 term cannot take a search down — which also meant a corrupt index answered `No matches` forever: a library that looks empty rather than broken. Corruption is rethrown there now.

**`isEmpty` is false.** `zotero_semantic_search` auto-builds an empty index, so reporting empty would start a full library crawl on top of the fault.

**`storeFault` on `SearchIndex`.** `zotero_semantic_search` checks `hasVectors` *before* calling `query()`, so without it an unreadable index answered `mode:"semantic"` with "this index has 0 vectors… re-run with mode:"keyword"" — advice that fails, since keyword refuses too, and the file is never named. That branch defers to the fault now.

Detection is deliberately narrow: `database disk image is malformed`, `file is not a database` and their siblings. A locked database, a read-only file and a full disk are failures and none is corruption; widening it would tell someone to delete their index over a transient fault. Non-corruption still propagates, with a test pinning it.

## Three things I did not decide for you

**1. It does not repair itself.** (a) Refuse and report, implemented here — a rebuild re-reads the whole library, minutes to tens of minutes with full text on, plus embedding spend, and this surfaces inside somebody's query; but recovery needs a shell, which an `mcpb` desktop user may not have. (b) Let an explicit `zotero_index action:"build"` repair, since an explicit build is consent — no shell needed, costs a seam for swapping the held index. (c) Rebuild at startup, as Zotero's `addCorruptionHandler` does — seamless, but a server that silently takes ten minutes to start is worse than one that explains. I implemented (a) as the only option that destroys nothing unasked; **(b) is what I would pick** if desktop installs matter. Say which and I will push it.

**2. That catch is still inverted.** It was written for one condition — an FTS5 parse rejection of the `match` string it just built — and implemented as "swallow everything". I added corruption to an allow-list rather than narrowing it, so `disk I/O error` and `no such table: passages` still return `[]` and still read as an empty library; my own tests pin that. Narrowing it to parse errors would subsume the corruption case and fix four more classes of silent-empty-library. It is also a behaviour change well outside this fix, so it is your call.

**3. The JSON backend has the same hole, one line away.** `factory.ts` ends `loadIndex(index, jsonPath).catch(() => false)` and `persistence.ts` has a bare `catch { return false }`: a truncated `search-index.json` becomes a silently empty index. The deeper shape is not a substitute class at all but a `storeFault` on `SearchIndexBase` that `query`/`build`/`save` consult, covering the JSON backend and upgrading the existing `importJson` notices for free. I built the smaller version because it is the one I can verify end to end.

## Verified by running it

Not only by the suite. Built and driven over MCP stdio against a database with one interior page overwritten — checkpoint the WAL first, or you are corrupting a 4 KB stub while the content sits in a 136 KB `-wal` and SQLite serves it happily.

- **Before**: no reply to `initialize`, process dead. **After**: 30 tools, all three query modes refuse with the file and the command, `action:"status"` prints the recovery paragraph once.
- **Recovery**: deleted the three files, restarted, queried — the library answers. With a legacy JSON present it needed no rebuild at all, which is what sent me back to reword the message.
- **No regression**: healthy index unchanged; one with no vectors still gets the original 0-vector message; the `memory` backend is unaffected by a corrupt `.sqlite` beside it.

## Gates

`npm run typecheck` clean, `npm run lint` clean, `vitest run` **605 passed / 7 skipped** (594 on `main`). Of the 11 new cases, 7 fail on `main`.

---
_Generated by [Claude Code](https://claude.ai/code)_