### PR TITLE
fix(search): read the schema stamp before opening SQLite writable

### DIFF
--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -300,6 +300,15 @@ resets before it parses, the next clean shutdown wrote that emptiness back over 
 A JSON artifact that fails to parse is now refused, left untouched on disk, and repaired by
 the same `action:"build"`.
 
+**A database from a different schema version is moved aside, never written into.** The
+schema stamp is read before anything touches the file. A database stamped with a version
+this build does not understand — typically one written by a newer Zoteus after a downgrade
+— is renamed to `search-index.sqlite.incompatible-<timestamp>` (its write-ahead sidecars
+with it, nothing deleted), a fresh index is created in its place, and `storageNotice` says
+what moved and where. The moved file stays a complete database, readable by the build that
+stamped it; rebuild with `zotero_index action:"build"`, and a later re-upgrade finds the
+moved file intact.
+
 **Migration is automatic and lossless.** The first time the SQLite backend opens a data dir
 that holds a `search-index.json` and no database, it imports the JSON index and leaves the
 file exactly where it was (a downgrade to an older Node still finds it). If the JSON file is

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -1,11 +1,11 @@
 import { createRequire } from 'node:module';
 import type { DatabaseSync as Database, StatementSync } from 'node:sqlite';
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, stat } from 'node:fs/promises';
+import { mkdir, readFile, rename, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
 import { tokenize } from './tokenize.js';
-import { SearchIndexCorruptError, isCorruptionError, isQuerySyntaxError } from './corruption.js';
+import { SearchIndexCorruptError, isCorruptionError, isQuerySyntaxError, sidecarsOf } from './corruption.js';
 import type { ChunkRecord, IndexCounts, IndexSnapshot, RankedId, SearchIndexOptions } from './backend.js';
 
 /**
@@ -23,7 +23,11 @@ const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite') as typeof
  */
 export const MAX_MIGRATION_BYTES = 200 * 1024 * 1024;
 
-/** Bumped only when the schema below changes shape; an older file is rebuilt, not patched. */
+/**
+ * Bumped only when the schema below changes shape; a file at any other version is rebuilt,
+ * not patched. Enforced in open(): the stamp is read before any DDL or write touches the
+ * file, and a database this build does not understand is moved aside, never written into.
+ */
 const SCHEMA_VERSION = 1;
 
 /**
@@ -113,41 +117,134 @@ export class SqliteSearchIndex extends SearchIndexBase {
     if (this.file !== ':memory:') await mkdir(dirname(this.file), { recursive: true });
     // Checked before the handle is created, because creating it creates the file.
     const existed = this.file !== ':memory:' && existsSync(this.file);
-    this.db = new DatabaseSync(this.file);
     try {
-      // Before anything that takes a lock, so every statement below inherits the wait.
-      this.db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
-      // WAL rather than the rollback journal: a build commits every few hundred items, and
-      // WAL makes those commits cheap while still leaving a complete database behind a
-      // crash (an interrupted build rolls back to its last commit, never a torn file).
-      // Switching modes needs an exclusive lock that a second process can hold for as long
-      // as it is connected, past any busy timeout — but the mode is a property of the file,
-      // so that process has already set it and this one just inherits it. Failing to set a
-      // mode the database is in is not worth refusing to open over.
-      try {
-        this.db.exec('PRAGMA journal_mode = WAL');
-      } catch (err) {
-        if (isCorruptionError(err)) throw err;
-        this.opts.logger?.debug(`Could not set journal_mode=WAL on ${this.file}: ${String(err)}`);
-      }
-      // NORMAL fsyncs at checkpoints instead of on every commit. A power cut can then cost
-      // the last commits of a running build, which the next build replaces anyway, but it
-      // can never cost the database itself.
-      this.db.exec('PRAGMA synchronous = NORMAL');
+      // Read before write: the stamp of an existing file is examined before any DDL or
+      // connection pragma touches it. Doing it the other way around — createSchema first —
+      // re-stamped a database written by a newer build and then misread it, destroying the
+      // one piece of evidence the stamp exists to carry at exactly the moment it mattered.
+      if (existed) await this.sidelineIfIncompatible();
+      this.openHandle();
       this.createSchema();
       this.prepareStatements();
+      // `existed` deliberately still gates the import after a sideline: the legacy JSON
+      // was already consumed by whichever build wrote the incompatible database, and
+      // re-importing it here would resurrect stale data next to the moved-aside truth.
       if (!existed && this.migrateFrom) await this.importJson(this.migrateFrom);
       this.refreshCounts();
       this.loadMeta();
     } catch (e) {
-      if (!isCorruptionError(e)) throw e;
-      // The handle exists from the line above, so this object owns it and must release it
-      // before handing the failure on. Not housekeeping: the message names three files for
-      // the user to delete, and on Windows an open handle refuses the delete — a server
-      // holding them would block the recovery it is prescribing.
+      if (!isCorruptionError(e) && !(e instanceof SearchIndexCorruptError)) throw e;
+      // The handle may exist, so this object owns it and must release it before handing
+      // the failure on. Not housekeeping: the message names three files for the user to
+      // delete, and on Windows an open handle refuses the delete — a server holding them
+      // would block the recovery it is prescribing.
       await this.close().catch(() => {});
+      throw e instanceof SearchIndexCorruptError ? e : new SearchIndexCorruptError(this.file, e);
+    }
+  }
+
+  /** Create the writable handle and apply its connection pragmas, after the schema probe. */
+  private openHandle(): void {
+    this.db = new DatabaseSync(this.file);
+    // Before anything that takes a lock, so every statement below inherits the wait.
+    this.db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    // WAL rather than the rollback journal: a build commits every few hundred items, and
+    // WAL makes those commits cheap while still leaving a complete database behind a
+    // crash (an interrupted build rolls back to its last commit, never a torn file).
+    // Switching modes needs an exclusive lock that a second process can hold for as long
+    // as it is connected, past any busy timeout — but the mode is a property of the file,
+    // so that process has already set it and this one just inherits it. Failing to set a
+    // mode the database is in is not worth refusing to open over.
+    try {
+      this.db.exec('PRAGMA journal_mode = WAL');
+    } catch (err) {
+      if (isCorruptionError(err)) throw err;
+      this.opts.logger?.debug(`Could not set journal_mode=WAL on ${this.file}: ${String(err)}`);
+    }
+    // NORMAL fsyncs at checkpoints instead of on every commit. A power cut can then cost
+    // the last commits of a running build, which the next build replaces anyway, but it
+    // can never cost the database itself.
+    this.db.exec('PRAGMA synchronous = NORMAL');
+  }
+
+  /**
+   * What an existing database says it is, read without writing anything.
+   *
+   * 'fresh' — no tables at all (a zero-byte file from a handle opened and dropped, which
+   * SQLite treats as a valid empty database): safe to create the schema in.
+   * 'unstamped' — tables exist but no readable integer stamp: an interrupted first
+   * creation, or a file some other program put at this path. Not ours to write into.
+   * Otherwise the integer the file is stamped with.
+   */
+  private storedSchemaVersion(db: Database): number | 'fresh' | 'unstamped' {
+    const tables = db
+      .prepare("SELECT count(*) AS n FROM sqlite_master WHERE type IN ('table', 'view')")
+      .get() as { n: number };
+    if (tables.n === 0) return 'fresh';
+    // Inspect rather than catching SELECT failures: a missing or foreign-shaped meta
+    // table means "unstamped", but a lock, I/O failure or interruption must propagate.
+    // Treating every non-corruption error as an absent stamp could move a healthy database
+    // merely because another legitimate Zoteus process held it for longer than the wait.
+    const metaColumns = db.prepare('PRAGMA table_info(meta)').all() as Array<{ name: string }>;
+    const names = new Set(metaColumns.map((column) => column.name));
+    if (!names.has('key') || !names.has('value')) return 'unstamped';
+    const row = db.prepare("SELECT value FROM meta WHERE key = 'schemaVersion'").get() as
+      | { value: string }
+      | undefined;
+    const value = row?.value;
+    if (value === undefined) return 'unstamped';
+    const version = Number(value);
+    return Number.isInteger(version) ? version : 'unstamped';
+  }
+
+  /**
+   * Move a database this build must not write into out of the way, and open fresh.
+   *
+   * Sideline, never delete: the moved file is a complete database, evidence of the skew
+   * and readable by whichever build stamped it. Sidecars travel with it — a fresh database
+   * created beside an orphaned `-wal` is the one arrangement that can manufacture a
+   * corruption out of this protection, because SQLite would replay a log belonging to a
+   * file that no longer exists — and in sidecarsOf order, database last, so an interruption
+   * mid-move can only strand sidecars beside the moved file, never beside the fresh one.
+   * One notice, on the channel status already reports storage decisions on.
+   */
+  private async sidelineIfIncompatible(): Promise<void> {
+    // A genuinely read-only probe makes the ordering enforceable rather than documentary:
+    // in particular, journal_mode=WAL can rewrite bytes in the database header, so even
+    // the normal writable connection pragmas must wait until the stamp has been accepted.
+    const probe = new DatabaseSync(this.file, { readOnly: true });
+    let stored: number | 'fresh' | 'unstamped';
+    try {
+      probe.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+      stored = this.storedSchemaVersion(probe);
+    } finally {
+      probe.close();
+    }
+    if (stored === 'fresh' || stored === SCHEMA_VERSION) return;
+    const dest = `${this.file}.incompatible-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+    try {
+      for (const src of sidecarsOf(this.file)) {
+        const target = src === this.file ? dest : `${dest}${src.slice(this.file.length)}`;
+        await rename(src, target).catch((e: NodeJS.ErrnoException) => {
+          if (e?.code !== 'ENOENT') throw e;
+        });
+      }
+    } catch (e) {
+      // The file is readable — its stamp just said so — but it can neither be written into
+      // nor moved aside. That is exactly the state CorruptSearchIndex exists to hold: the
+      // server survives, search refuses naming this file, and an explicit
+      // `zotero_index action:"build"` may clear it, with the consent that implies (#21).
       throw new SearchIndexCorruptError(this.file, e);
     }
+    const said =
+      stored === 'unstamped'
+        ? 'carries tables but no schema stamp — an interrupted creation, or not a Zoteus index at all'
+        : `is stamped schema version ${stored}, which this build does not understand`;
+    this.storeNotice =
+      `The search index at ${this.file} ${said}. ` +
+      `It was moved aside to ${dest} (nothing was deleted) and a fresh index was created; ` +
+      `rebuild it with zotero_index action:"build".`;
+    this.opts.logger?.warn(this.storeNotice);
   }
 
   /**

--- a/tests/features/search-corruption.test.ts
+++ b/tests/features/search-corruption.test.ts
@@ -259,6 +259,6 @@ describe('opening an index that cannot be read', () => {
     );
     expect(rejection).toBeInstanceOf(Error);
     expect(rejection).not.toBeInstanceOf(SearchIndexCorruptError);
-    expect((rejection as Error).message).toMatch(/unable to open|EISDIR|ENOTDIR|EEXIST/i);
+    expect((rejection as Error).message).toMatch(/unable to open|disk I\/O error|EISDIR|ENOTDIR|EEXIST/i);
   });
 });

--- a/tests/features/search-schema-version.test.ts
+++ b/tests/features/search-schema-version.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join, dirname, basename } from 'node:path';
+import { createSearchIndex, nodeSqliteAvailable, sqliteIndexPath } from '../../src/features/search/factory.js';
+
+/**
+ * The schema stamp used to be written and never read: `createSchema` ran `INSERT OR
+ * REPLACE INTO meta('schemaVersion', ...)` before anything looked at what the file already
+ * said, so a database written by a newer build was silently re-stamped and misread — the
+ * one moment the stamp exists for is the moment it was destroyed. These tests pin the
+ * repaired contract: the stamp is read before any DDL or write, and a file this build does
+ * not understand is moved aside (`.incompatible-<ts>`, never deleted) with one notice,
+ * then a fresh index is created in its place.
+ */
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+const ITEM = { key: 'A', data: { itemType: 'book', title: 'Deep learning', abstractNote: 'neural networks' } };
+
+function tmpJsonPath(name: string): string {
+  return join(mkdtempSync(join(tmpdir(), `zoteus-${name}-`)), 'search-index.json');
+}
+
+const openIndex = (jsonPath: string) =>
+  createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+
+/** Raw node:sqlite access, to stamp and inspect fixture databases without the index code. */
+const sqliteModule = nodeSqliteAvailable()
+  ? (createRequire(import.meta.url)('node:sqlite') as typeof import('node:sqlite'))
+  : undefined;
+// Every call site is inside a sqliteIt case, so Node 20 loads this suite and skips those
+// cases without ever touching the unavailable constructor.
+const DatabaseSync = sqliteModule?.DatabaseSync as typeof import('node:sqlite').DatabaseSync;
+
+function stampSchemaVersion(dbPath: string, value: string): void {
+  const db = new DatabaseSync(dbPath);
+  db.prepare("UPDATE meta SET value = ? WHERE key = 'schemaVersion'").run(value);
+  db.close();
+}
+
+function readSchemaVersion(dbPath: string): string | undefined {
+  const db = new DatabaseSync(dbPath);
+  const row = db.prepare("SELECT value FROM meta WHERE key = 'schemaVersion'").get() as
+    | { value: string }
+    | undefined;
+  db.close();
+  return row?.value;
+}
+
+function passageCount(dbPath: string): number {
+  const db = new DatabaseSync(dbPath);
+  const row = db.prepare('SELECT count(*) AS n FROM passages').get() as { n: number };
+  db.close();
+  return row.n;
+}
+
+function journalMode(dbPath: string): string {
+  const db = new DatabaseSync(dbPath);
+  const row = db.prepare('PRAGMA journal_mode').get() as { journal_mode: string };
+  db.close();
+  return row.journal_mode;
+}
+
+function setJournalMode(dbPath: string, mode: 'delete' | 'wal'): void {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`PRAGMA journal_mode = ${mode}`);
+  db.close();
+}
+
+/** A real index built and closed, so the database on disk is complete and stamped. */
+async function builtIndexPath(name: string): Promise<{ jsonPath: string; dbPath: string }> {
+  const jsonPath = tmpJsonPath(name);
+  const index = await openIndex(jsonPath);
+  await index.build([ITEM]);
+  await index.save();
+  await index.close();
+  return { jsonPath, dbPath: sqliteIndexPath(jsonPath) };
+}
+
+/** The `.incompatible-<ts>` databases beside dbPath (sidecars excluded). */
+function sidelined(dbPath: string): string[] {
+  const dir = dirname(dbPath);
+  const name = basename(dbPath);
+  return readdirSync(dir)
+    .filter((f) => f.startsWith(`${name}.incompatible-`) && !/-(wal|shm|journal)$/.test(f))
+    .map((f) => join(dir, f));
+}
+
+describe('schema version is read before anything is written', () => {
+  sqliteIt('sidelines a database stamped with a newer schema version instead of re-stamping it', async () => {
+    const { jsonPath, dbPath } = await builtIndexPath('schema-newer');
+    stampSchemaVersion(dbPath, '99');
+    // The schema must be inspected before even the normal connection setup. In
+    // particular, journal_mode=WAL is a write: it changes the database header.
+    setJournalMode(dbPath, 'delete');
+
+    const index = await openIndex(jsonPath);
+    try {
+      // The incompatible file was moved aside, not deleted, and keeps its stamp and its
+      // rows: the evidence of the skew survives for whichever build understands it.
+      const aside = sidelined(dbPath);
+      expect(aside).toHaveLength(1);
+      expect(readSchemaVersion(aside[0])).toBe('99');
+      expect(passageCount(aside[0])).toBeGreaterThan(0);
+      expect(journalMode(aside[0])).toBe('delete');
+
+      // The file at the original path is a fresh, empty index stamped with THIS build's
+      // version — not the old database re-stamped.
+      expect(readSchemaVersion(dbPath)).toBe('1');
+      expect(passageCount(dbPath)).toBe(0);
+
+      // One notice, through the channel status already reports storage decisions on.
+      const notice = index.buildStatus().storageNotice ?? '';
+      expect(notice).toContain('99');
+      expect(notice).toContain('.incompatible-');
+    } finally {
+      await index.close();
+    }
+  });
+
+  sqliteIt('the sidelined database still works as an index for the build that understands it', async () => {
+    const { jsonPath, dbPath } = await builtIndexPath('schema-usable');
+    stampSchemaVersion(dbPath, '99');
+    const index = await openIndex(jsonPath);
+    await index.close();
+
+    // Version 99 does not exist, but version 1 pretending to be it is the closest
+    // available stand-in: the moved file must be a complete database, not a husk.
+    const aside = sidelined(dbPath);
+    stampSchemaVersion(aside[0], '1');
+    const db = new DatabaseSync(aside[0]);
+    const row = db.prepare("SELECT count(*) AS n FROM passages WHERE title = 'Deep learning'").get() as {
+      n: number;
+    };
+    db.close();
+    expect(row.n).toBeGreaterThan(0);
+  });
+
+  sqliteIt('a stale write-ahead log at the original name cannot poison the fresh index', async () => {
+    const { jsonPath, dbPath } = await builtIndexPath('schema-sidecars');
+    stampSchemaVersion(dbPath, '99');
+    // The poison case sidecar handling exists for: a leftover log at the name the fresh
+    // database will be created under. Whether SQLite consumes it (it belongs to the
+    // incompatible database, whose handle opens first) or the sideline moves it, it must
+    // not sit at the original name once the fresh database lives there.
+    writeFileSync(`${dbPath}-wal`, 'stale write-ahead log');
+
+    const index = await openIndex(jsonPath);
+    await index.close();
+
+    const staleWalAtOriginalName =
+      existsSync(`${dbPath}-wal`) && readFileSync(`${dbPath}-wal`, 'utf8').includes('stale write-ahead log');
+    expect(staleWalAtOriginalName).toBe(false);
+
+    // Neither database was hurt in the process: the fresh one is intact, and the
+    // moved-aside one still opens and still says what it always said.
+    const fresh = new DatabaseSync(dbPath);
+    expect((fresh.prepare('PRAGMA integrity_check').get() as { integrity_check: string }).integrity_check).toBe('ok');
+    fresh.close();
+    expect(readSchemaVersion(sidelined(dbPath)[0])).toBe('99');
+  });
+
+  sqliteIt('sidelines a database whose stamp is not a version at all', async () => {
+    const { jsonPath, dbPath } = await builtIndexPath('schema-garbled');
+    stampSchemaVersion(dbPath, 'banana');
+
+    const index = await openIndex(jsonPath);
+    try {
+      expect(sidelined(dbPath)).toHaveLength(1);
+      expect(readSchemaVersion(dbPath)).toBe('1');
+    } finally {
+      await index.close();
+    }
+  });
+
+  sqliteIt('sidelines a non-empty database that carries no stamp: an interrupted creation or a foreign file', async () => {
+    const jsonPath = tmpJsonPath('schema-unstamped');
+    const dbPath = sqliteIndexPath(jsonPath);
+    const db = new DatabaseSync(dbPath);
+    db.exec('CREATE TABLE somebody_elses (x TEXT)');
+    db.close();
+
+    const index = await openIndex(jsonPath);
+    try {
+      expect(sidelined(dbPath)).toHaveLength(1);
+      expect(readSchemaVersion(dbPath)).toBe('1');
+    } finally {
+      await index.close();
+    }
+  });
+
+  sqliteIt('leaves a database at the current version exactly where it is, with its data', async () => {
+    const { jsonPath, dbPath } = await builtIndexPath('schema-current');
+
+    const index = await openIndex(jsonPath);
+    try {
+      expect(sidelined(dbPath)).toHaveLength(0);
+      expect(passageCount(dbPath)).toBeGreaterThan(0);
+      expect(index.buildStatus().storageNotice).toBeUndefined();
+      const hits = await index.query('learning', { mode: 'keyword' });
+      expect(hits.length).toBeGreaterThan(0);
+    } finally {
+      await index.close();
+    }
+  });
+
+  sqliteIt('an empty file is a first open, not an incompatibility', async () => {
+    const jsonPath = tmpJsonPath('schema-empty');
+    const dbPath = sqliteIndexPath(jsonPath);
+    // `new DatabaseSync(path)` on a previous run that died before any DDL leaves exactly
+    // this: a zero-byte file, which SQLite treats as a valid empty database.
+    new DatabaseSync(dbPath).close();
+
+    const index = await openIndex(jsonPath);
+    try {
+      expect(sidelined(dbPath)).toHaveLength(0);
+      expect(readSchemaVersion(dbPath)).toBe('1');
+    } finally {
+      await index.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`createSchema()` writes `SCHEMA_VERSION` with `INSERT OR REPLACE` before the existing value is consulted. On a downgrade, that silently re-stamps a database created by a newer Zoteus and then attempts to use a schema this build does not understand.

## Change

- Probe an existing database through a read-only SQLite handle before writable connection pragmas or DDL.
- Leave current-version and zero-table databases in place.
- Move an incompatible, malformed, or missing-stamp database and its sidecars to `search-index.sqlite.incompatible-<timestamp>`; never delete it.
- Create a fresh index at the canonical path and report the decision through `storageNotice`.
- Distinguish a genuinely absent/foreign `meta` schema from transient SQLite errors; locks and I/O failures propagate instead of being treated as an unstamped database.
- Document the downgrade behavior.

## Tests

Seven regression cases cover newer and malformed stamps, missing metadata, preservation and usability of the sidelined database, WAL sidecars, current-version databases, and empty files. The newer-schema case also pins the strict ordering by asserting that the read-only probe does not change `journal_mode` before sidelining.