### PR TITLE
fix(search): cache on-device model weights under the data directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **On-device model weights now cache under the data directory** (`<ZOTEUS_DATA_DIR>/models`)
+  instead of inside the transformers package's own install, so deleting the data directory
+  removes everything the index ever wrote — including its largest artifact, and including
+  weights that previously landed in a global `node_modules` outliving even an extension
+  uninstall. Existing installs re-download the model (~25 MB) once, into the new location;
+  the old copy stays where the package left it.
+
 ## [1.9.0] - 2026-08-28
 
 ### Added

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -274,7 +274,8 @@ and `søren` does not answer to `soren`.
 **Where the files are.** `<ZOTEUS_DATA_DIR>/search-index.sqlite` beside the older
 `search-index.json` (and `search-index-<userId>.*` per tenant in multi-tenant mode). SQLite
 also writes `-wal` and `-shm` sidecar files while the database is open; a clean shutdown
-folds them back in.
+folds them back in. On-device model weights are cached under `<ZOTEUS_DATA_DIR>/models`,
+so removing the data directory removes everything the index ever wrote.
 
 **If the index is damaged.** A search index that cannot be read no longer stops the server
 from starting: it is a derived cache, and no other tool reads it, so item lookups,
@@ -377,7 +378,9 @@ width from the stored ones.
 npm i @huggingface/transformers
 ```
 
-The first local build downloads the model (~25 MB) once.
+The first local build downloads the model (~25 MB) once, into
+`<ZOTEUS_DATA_DIR>/models` — so deleting the data directory removes the weights along
+with the index.
 
 ### Why it is not bundled
 
@@ -434,7 +437,8 @@ A few things to know when indexing a big Zotero library:
   your CPU, so embedding thousands of passages takes real time. If you just want fast
   keyword search, set `ZOTEUS_EMBEDDINGS=off` for a quick keyword-only (BM25) index.
 - **First local run downloads the model** (~25 MB) before embedding begins — expect a
-  one-time delay (and a slower first build) while it fetches and caches.
+  one-time delay (and a slower first build) while it fetches and caches (under
+  `<ZOTEUS_DATA_DIR>/models`).
 - **Builds stop at `ZOTEUS_INDEX_MAX_ITEMS`, 5000 by default** (both Zotero APIs page
   100-at-a-time). A build that hits the cap reports how many items it left out, in status
   and in every later `zotero_semantic_search` result, so a bigger library never looks

--- a/src/features/search/embeddings.ts
+++ b/src/features/search/embeddings.ts
@@ -148,6 +148,8 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
     private readonly opts: {
       transformersPath?: string;
       dist?: string;
+      /** Where downloaded model weights live (see modelCacheDir); unset keeps the package's default. */
+      modelCacheDir?: string;
       /** Texts per pipeline call (defaults to BATCH_SIZE). */
       batchSize?: number;
       /** Pause between batches in ms (see batchPause). */
@@ -179,6 +181,13 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
     if (typeof pipeline !== 'function') {
       throw new Error(`${TRANSFORMERS_MODULE} loaded but exposes no pipeline(). Is the install complete?`);
     }
+    // Pin the model cache before the pipeline downloads anything. The package's default
+    // caches weights inside its own install directory, which outlives the data directory —
+    // and for a bundled desktop install pointed at a global module via
+    // ZOTEUS_TRANSFORMERS_PATH, outlives the extension too. Deleting the data directory
+    // is supposed to be the whole uninstall, and the weights are its largest artifact.
+    const env = transformers.env ?? transformers.default?.env;
+    if (env && this.opts.modelCacheDir) env.cacheDir = this.opts.modelCacheDir;
     this.extractor = await pipeline('feature-extraction', this.model);
     return this.extractor;
   }
@@ -327,6 +336,7 @@ export function createEmbeddingProvider(config: ZoteusConfig, logger?: Logger): 
         provider: new LocalEmbeddingProvider(undefined, undefined, {
           transformersPath: config.transformersPath,
           dist: config.dist,
+          modelCacheDir: join(config.dataDir, 'models'),
           batchSize: config.embedBatchSize,
           batchDelayMs: config.embedBatchDelayMs,
         }),

--- a/tests/features/embedding-model-cache.test.ts
+++ b/tests/features/embedding-model-cache.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig } from '../../src/config.js';
+import { createEmbeddingProvider, LocalEmbeddingProvider, resolveTransformers } from '../../src/features/search/embeddings.js';
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} } as any;
+
+/**
+ * The weights are the index's largest artifact, and the transformers package caches them
+ * inside its own install by default — which outlives the data directory, whose deletion is
+ * supposed to be the whole uninstall. These tests pin the contract: the cache directory is
+ * set under <dataDir> BEFORE the pipeline is constructed, i.e. before anything downloads.
+ *
+ * The package itself is an optional dependency and not installed here, so the tests plant
+ * a stub of it in a temp directory and point ZOTEUS_TRANSFORMERS_PATH at it — the same
+ * resolution path a real out-of-bundle install takes. The stub's pipeline() records what
+ * env.cacheDir held at construction time.
+ */
+
+const DEFAULT_STUB_CACHE = '/stub/default/.cache';
+let root: string; // temp dir handed to ZOTEUS_TRANSFORMERS_PATH
+let stubModule: any; // the one live instance of the stub (ESM module cache)
+
+beforeAll(async () => {
+  root = mkdtempSync(join(tmpdir(), 'zoteus-model-cache-'));
+  const pkg = join(root, 'node_modules', '@huggingface', 'transformers');
+  mkdirSync(pkg, { recursive: true });
+  writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@huggingface/transformers', main: 'index.cjs' }));
+  writeFileSync(
+    join(pkg, 'index.cjs'),
+    `const env = { cacheDir: ${JSON.stringify(DEFAULT_STUB_CACHE)} };
+const seen = [];
+async function pipeline() {
+  seen.push(env.cacheDir); // what the cache pointed at when the pipeline was constructed
+  return async (input) => {
+    const batch = Array.isArray(input) ? input : [input];
+    return { data: new Float32Array(batch.length * 2).fill(0.5), dims: [batch.length, 2] };
+  };
+}
+module.exports = { env, pipeline, seen };
+`,
+  );
+  const specifier = resolveTransformers(root);
+  expect(specifier).not.toBeNull();
+  const mod = await import(specifier!);
+  stubModule = mod.default ?? mod;
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // One module instance serves every test (ESM cache): reset what a previous test set.
+  stubModule.env.cacheDir = DEFAULT_STUB_CACHE;
+  stubModule.seen.length = 0;
+});
+
+describe('model weights land under the data directory', () => {
+  it('pins the cache under <dataDir>/models before the pipeline is constructed', async () => {
+    const dataDir = join(root, 'data');
+    const config = loadConfig({
+      ZOTEUS_EMBEDDINGS: 'local',
+      ZOTEUS_TRANSFORMERS_PATH: root,
+      ZOTEUS_DATA_DIR: dataDir,
+    } as any);
+    const { provider, unavailable } = createEmbeddingProvider(config, silentLogger);
+    expect(unavailable).toBeUndefined();
+
+    const vecs = await provider!.embed(['a passage']);
+    expect(vecs).toEqual([[0.5, 0.5]]);
+    // Deleting dataDir now removes the weights along with the index.
+    expect(stubModule.seen).toEqual([join(dataDir, 'models')]);
+    expect(stubModule.env.cacheDir).toBe(join(dataDir, 'models'));
+  });
+
+  it('leaves the package default alone when no cache directory is given', async () => {
+    // Direct construction without the option: existing callers see no behaviour change.
+    const provider = new LocalEmbeddingProvider(undefined, undefined, { transformersPath: root });
+    await provider.embed(['a passage']);
+    expect(stubModule.seen).toEqual([DEFAULT_STUB_CACHE]);
+    expect(stubModule.env.cacheDir).toBe(DEFAULT_STUB_CACHE);
+  });
+});


### PR DESCRIPTION
`@huggingface/transformers` caches downloaded model weights inside its own install by default — outside `ZOTEUS_DATA_DIR`, and for a bundled desktop install pointed at a global module via `ZOTEUS_TRANSFORMERS_PATH`, in a global `node_modules` that outlives even an extension uninstall. Deleting the data directory is the documented uninstall for everything the index writes, and the weights are its largest artifact — ~25 MB for the default model, more for larger ones.

This pins the package's `env.cacheDir` to `<ZOTEUS_DATA_DIR>/models` before the pipeline is constructed, i.e. before anything downloads. A `LocalEmbeddingProvider` constructed without the new option keeps the package default, so direct callers see no behaviour change. Existing installs re-download the model once into the new location; the old copy stays where the package left it (said in the changelog entry).

The test plants a stub `@huggingface/transformers` in a temp directory and resolves it through `ZOTEUS_TRANSFORMERS_PATH` — the same resolution path a real out-of-bundle install takes — and asserts what `env.cacheDir` held at pipeline-construction time: pinned to `<dataDir>/models` when configured through `createEmbeddingProvider`, untouched when the provider is constructed without the option.

`npm run typecheck`, `npm run lint`, `npm test` green (747 passed / 7 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuF9MjS1XhiKAFUugbAct7)_