### PR TITLE
fix(search): move the Gemini API key from the URL to a header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- **The Gemini API key no longer travels in the URL.** Gemini embedding requests carried
+  the key as a `?key=` query parameter; it now goes in the `x-goog-api-key` header, like
+  the OpenAI key's `Authorization` header. A URL is the part of a request that gets
+  logged — by proxies, by error causes, by anything that prints which endpoint failed —
+  and a header is not. Google accepts the header everywhere `?key=` works, so nothing
+  changes about which requests succeed.
+
 ## [1.9.0] - 2026-08-28
 
 ### Added

--- a/src/features/search/embeddings.ts
+++ b/src/features/search/embeddings.ts
@@ -254,11 +254,15 @@ export class ApiEmbeddingProvider implements EmbeddingProvider {
       const json = (await res.json()) as any;
       return json.data.map((d: any) => d.embedding);
     }
+    // The key travels in a header, like the OpenAI one above, never in the URL: URLs are
+    // the part of a request that gets logged — by proxies, by error causes, by anything
+    // that prints which endpoint failed — and Google accepts x-goog-api-key everywhere
+    // ?key= works.
     const res = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:batchEmbedContents?key=${this.apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:batchEmbedContents`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': this.apiKey },
         body: JSON.stringify({
           requests: texts.map((t) => ({ model: `models/${this.model}`, content: { parts: [{ text: t }] } })),
         }),

--- a/tests/features/embedding-config.test.ts
+++ b/tests/features/embedding-config.test.ts
@@ -18,6 +18,7 @@ const silentLogger = { debug() {}, info() {}, warn() {}, error() {} } as any;
 interface Captured {
   url: string;
   body: any;
+  headers: Record<string, string>;
 }
 
 /** Stub fetch with a minimal OpenAI/Gemini embeddings endpoint, recording every request. */
@@ -26,7 +27,7 @@ function captureEmbeddingRequests(): Captured[] {
   const stub = (async (input: any, init?: RequestInit): Promise<Response> => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
     const body = JSON.parse(String(init?.body));
-    calls.push({ url, body });
+    calls.push({ url, body, headers: Object.fromEntries(new Headers(init?.headers).entries()) });
     const json = url.includes('openai')
       ? { data: (body.input as string[]).map(() => ({ embedding: [1, 0, 0] })) }
       : { embeddings: (body.requests as unknown[]).map(() => ({ values: [1, 0, 0] })) };
@@ -184,6 +185,33 @@ describe('the API providers embed with the configured model', () => {
     } finally {
       if (previous === undefined) delete process.env.OPENAI_API_KEY;
       else process.env.OPENAI_API_KEY = previous;
+    }
+  });
+});
+
+describe('the API key travels in a header, never in the URL', () => {
+  // A URL is the part of a request that gets logged — by proxies, by error causes, by
+  // anything that prints which endpoint failed — so no request may carry the key there.
+  it('sends the Gemini key as x-goog-api-key', async () => {
+    const calls = captureEmbeddingRequests();
+    await new ApiEmbeddingProvider('gemini', 'g-secret').embed(['a']);
+    expect(calls[0]!.headers['x-goog-api-key']).toBe('g-secret');
+  });
+
+  it('sends the OpenAI key as a bearer token', async () => {
+    const calls = captureEmbeddingRequests();
+    await new ApiEmbeddingProvider('openai', 'o-secret').embed(['a']);
+    expect(calls[0]!.headers['authorization']).toBe('Bearer o-secret');
+  });
+
+  it('puts the key in no URL, for either provider', async () => {
+    const calls = captureEmbeddingRequests();
+    await new ApiEmbeddingProvider('gemini', 'g-secret', { batchSize: 1 }).embed(['a', 'b']);
+    await new ApiEmbeddingProvider('openai', 'o-secret').embed(['a']);
+    for (const { url } of calls) {
+      expect(url).not.toContain('g-secret');
+      expect(url).not.toContain('o-secret');
+      expect(url).not.toContain('key=');
     }
   });
 });


### PR DESCRIPTION
Gemini embedding requests carried `GEMINI_API_KEY` as a `?key=` query parameter (`embeddings.ts`). A URL is the part of a request that gets logged — by proxies, by error causes, by anything that prints which endpoint failed — and a header is not. The key now travels in `x-goog-api-key`, matching how the OpenAI key already travels (an `Authorization` header). Google accepts the header everywhere `?key=` works, so nothing changes about which requests succeed.

The test suite's request capture now records headers, and three new cases pin the contract for both providers: the key present in the expected header, and absent from every requested URL.

`npm run typecheck`, `npm run lint`, `npm test` green (748 passed / 7 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuF9MjS1XhiKAFUugbAct7)_