### PR TITLE
perf(search): one traversal per vector, and stop making norm() polymorphic

### DIFF
--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -664,17 +664,61 @@ function toFloats(buf: Uint8Array): Float32Array {
   return new Float32Array(buf.slice().buffer);
 }
 
-function norm(v: ArrayLike<number>): number {
+/**
+ * Only ever called with the query. Keeping the parameter `number[]` rather than
+ * `ArrayLike<number>` is load-bearing: while this also took each row's `Float32Array`, the
+ * call site saw two shapes and stayed polymorphic for the life of the process, which cost
+ * about half the scan on its own.
+ */
+function norm(v: number[]): number {
   let s = 0;
   for (let i = 0; i < v.length; i++) s += v[i]! * v[i]!;
   return Math.sqrt(s);
 }
 
-function cosine(a: number[], b: Float32Array, an: number): number {
-  const bn = norm(b);
-  if (bn === 0) return 0;
+/**
+ * Cosine of the query against one stored vector: one traversal, two accumulators.
+ *
+ * The obvious spelling — `norm(b)`, then a dot-product loop — walks each row twice and
+ * shares its `norm()` with the query-side call above. Both cost real time on a scan that
+ * touches every vector: measured on a 255 703-row index at 3072 dimensions, 44.8 to 15.5
+ * microseconds per row, a 2.9x scan, of which about half was the polymorphic call site and
+ * about half the second traversal.
+ *
+ * The scores are bit-identical, not merely close: the same products are summed in the same
+ * order. The tail loop is what keeps that true when the widths disagree, where the old
+ * `norm(b)` covered all of `b` while the dot product stopped at the shorter operand. That
+ * case is unreachable through `query()`, which drops stale vectors on a width change, but
+ * an index holding two generations of vectors reaches it and must rank as it did before.
+ */
+export function cosine(a: number[], b: Float32Array, an: number): number {
+  if (a.length < b.length) return cosineUneven(a, b, an);
   let dot = 0;
-  const len = Math.min(a.length, b.length);
-  for (let i = 0; i < len; i++) dot += a[i]! * b[i]!;
+  let sq = 0;
+  for (let i = 0; i < b.length; i++) {
+    const x = b[i]!;
+    dot += a[i]! * x;
+    sq += x * x;
+  }
+  const bn = Math.sqrt(sq);
+  if (bn === 0) return 0;
+  return dot / (an * bn);
+}
+
+/**
+ * The width-mismatch case, kept out of line so the scan's hot function stays small enough
+ * to inline — folding it in costs about a fifth of the gain, measured. Nothing reaches this
+ * through `query()`, which drops stale vectors when the query's width stops matching the
+ * index's, but an index holding two generations of vectors does, and it must rank as it did
+ * before: the old code summed the norm over all of `b` while stopping the product at the
+ * shorter operand.
+ */
+function cosineUneven(a: number[], b: Float32Array, an: number): number {
+  let dot = 0;
+  let sq = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i]! * b[i]!;
+  for (let i = 0; i < b.length; i++) sq += b[i]! * b[i]!;
+  const bn = Math.sqrt(sq);
+  if (bn === 0) return 0;
   return dot / (an * bn);
 }

--- a/src/features/search/vector-store.ts
+++ b/src/features/search/vector-store.ts
@@ -77,11 +77,35 @@ function norm(v: number[]): number {
   return Math.sqrt(s);
 }
 
-function cosine(a: number[], b: number[], an: number): number {
-  const bn = norm(b);
-  if (bn === 0) return 0;
+/**
+ * Cosine of the query against one stored vector: one traversal, two accumulators, where
+ * `norm(b)` followed by a dot-product loop walked every entry twice. Same products summed
+ * in the same order, so the scores are bit-identical; the tail loop preserves the old
+ * reading of a shorter query, which covered all of `b` for the norm but stopped at the
+ * shorter operand for the product. The SQLite backend carries the same shape, and gains
+ * more from it — there the shared `norm()` was polymorphic besides.
+ */
+export function cosine(a: number[], b: number[], an: number): number {
+  if (a.length < b.length) return cosineUneven(a, b, an);
   let dot = 0;
-  const len = Math.min(a.length, b.length);
-  for (let i = 0; i < len; i++) dot += a[i]! * b[i]!;
+  let sq = 0;
+  for (let i = 0; i < b.length; i++) {
+    const x = b[i]!;
+    dot += a[i]! * x;
+    sq += x * x;
+  }
+  const bn = Math.sqrt(sq);
+  if (bn === 0) return 0;
+  return dot / (an * bn);
+}
+
+/** The width-mismatch case, out of line so the hot path stays small. See sqlite-index.ts. */
+function cosineUneven(a: number[], b: number[], an: number): number {
+  let dot = 0;
+  let sq = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i]! * b[i]!;
+  for (let i = 0; i < b.length; i++) sq += b[i]! * b[i]!;
+  const bn = Math.sqrt(sq);
+  if (bn === 0) return 0;
   return dot / (an * bn);
 }

--- a/tests/features/vector-cosine-equivalence.test.ts
+++ b/tests/features/vector-cosine-equivalence.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { nodeSqliteAvailable } from '../../src/features/search/factory.js';
+import { cosine as memoryCosine } from '../../src/features/search/vector-store.js';
+
+/**
+ * Fusing the cosine loop is a performance change that must not be a behaviour change: the
+ * scan now accumulates the dot product and the row's squared norm in one traversal, where
+ * it used to call `norm(b)` and then loop again. The claim made in both call sites is that
+ * the scores are bit-identical — the same products summed in the same order — so no index
+ * needs rebuilding and no ranking moves.
+ *
+ * A claim of that shape is worth nothing asserted. These cases run the previous
+ * implementation, verbatim, beside the current one and demand exact equality, including
+ * the sign of zero and the propagation of NaN. `toBe` is `Object.is`, which is the right
+ * comparison here precisely because it does not treat -0 and 0 as interchangeable.
+ */
+
+/** The implementation as it stood before the fusion, kept here as the reference. */
+function referenceNorm(v: ArrayLike<number>): number {
+  let s = 0;
+  for (let i = 0; i < v.length; i++) s += v[i]! * v[i]!;
+  return Math.sqrt(s);
+}
+function referenceCosine(a: number[], b: ArrayLike<number>, an: number): number {
+  const bn = referenceNorm(b);
+  if (bn === 0) return 0;
+  let dot = 0;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) dot += a[i]! * b[i]!;
+  return dot / (an * bn);
+}
+
+/** A small LCG, so the fixture is the same on every machine and every run. */
+function vectors(seed: number, dim: number, count: number): number[][] {
+  let s = seed >>> 0;
+  const next = () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+  return Array.from({ length: count }, () => Array.from({ length: dim }, () => next() - 0.5));
+}
+
+/**
+ * Deliberately NOT unit vectors. The embedding providers in use return normalized vectors,
+ * which would make the norm a constant 1 and hide any error in how it is now accumulated;
+ * the magnitudes here span eight orders of magnitude so that the division actually varies.
+ */
+function scaled(vs: number[][]): number[][] {
+  return vs.map((v, i) => v.map((x) => x * 10 ** (i - 4)));
+}
+
+describe('the fused cosine is bit-identical to the two-pass one it replaces', () => {
+  const dim = 96;
+  const [query] = vectors(7, dim, 1) as [number[]];
+  const qn = referenceNorm(query);
+  const rows = scaled(vectors(11, dim, 9));
+
+  it('agrees on ordinary vectors, over magnitudes that make the norm matter', () => {
+    for (const row of rows) {
+      expect(memoryCosine(query, row, qn)).toBe(referenceCosine(query, row, qn));
+    }
+  });
+
+  it('agrees on a zero vector, where the norm divides by nothing', () => {
+    const zero = new Array<number>(dim).fill(0);
+    expect(memoryCosine(query, zero, qn)).toBe(referenceCosine(query, zero, qn));
+    expect(memoryCosine(query, zero, qn)).toBe(0);
+  });
+
+  /**
+   * Unreachable through `query()`, which drops stale vectors when the query's width stops
+   * matching the index's — but an index holding two generations of vectors reaches it, and
+   * the old code read the two widths asymmetrically: `norm(b)` covered all of `b` while the
+   * dot product stopped at the shorter operand. The tail loop in the fused version exists
+   * only to preserve that reading, so this is the case that would catch its absence.
+   */
+  it('agrees when the query is shorter than the stored vector', () => {
+    const short = query.slice(0, dim - 20);
+    const sn = referenceNorm(short);
+    for (const row of rows) {
+      expect(memoryCosine(short, row, sn)).toBe(referenceCosine(short, row, sn));
+    }
+  });
+
+  it('agrees when the stored vector is shorter than the query', () => {
+    for (const row of rows) {
+      const short = row.slice(0, dim - 20);
+      expect(memoryCosine(query, short, qn)).toBe(referenceCosine(query, short, qn));
+    }
+  });
+
+  it('propagates a non-finite coordinate the same way', () => {
+    const withNaN = [...rows[0]!];
+    withNaN[3] = Number.NaN;
+    expect(memoryCosine(query, withNaN, qn)).toBe(referenceCosine(query, withNaN, qn));
+  });
+});
+
+/**
+ * The SQLite backend reads its vectors as Float32Array views over the stored BLOB, so its
+ * cosine is a separate function over a separate operand type — and it is the one that also
+ * shed the polymorphic `norm()` call. It is exercised through the same reference.
+ *
+ * The module require()s `node:sqlite` at load, so it is imported dynamically and skipped
+ * where the runtime has no SQLite, exactly as the backend itself falls back rather than
+ * refusing to start.
+ */
+const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+
+describe('the SQLite backend cosine, over Float32 rows', () => {
+  const dim = 96;
+  const [query] = vectors(23, dim, 1) as [number[]];
+  const qn = referenceNorm(query);
+  const rows = scaled(vectors(29, dim, 9)).map((v) => Float32Array.from(v));
+
+  sqliteIt('agrees with the two-pass implementation on every row', async () => {
+    const { cosine } = await import('../../src/features/search/sqlite-index.js');
+    for (const row of rows) {
+      expect(cosine(query, row, qn)).toBe(referenceCosine(query, row, qn));
+    }
+  });
+
+  sqliteIt('agrees on a zero row and on mismatched widths', async () => {
+    const { cosine } = await import('../../src/features/search/sqlite-index.js');
+    const zero = new Float32Array(dim);
+    expect(cosine(query, zero, qn)).toBe(referenceCosine(query, zero, qn));
+
+    const short = query.slice(0, dim - 20);
+    const sn = referenceNorm(short);
+    for (const row of rows) {
+      expect(cosine(short, row, sn)).toBe(referenceCosine(short, row, sn));
+    }
+  });
+});


### PR DESCRIPTION
## The defect

`cosine` in `sqlite-index.ts` walks every stored vector twice — once inside `norm(b)`,
once for the dot product. And the `norm` it calls is the same one `vectorSearch` calls
with the query's `number[]`, while every row passes a `Float32Array`: one `number[]`
observation is enough to make that call site polymorphic for the life of the process,
and it never recovers. The `ArrayLike<number>` signature was the tell.

## The fix

Accumulate the dot product and the row's squared norm in one pass, and narrow `norm` to
`number[]` so its call site sees one shape. `vector-store.ts` carries the same two-pass
shape and gets the same treatment; its `norm` was already monomorphic, so it gains the
traversal half only.

## Measured

255 703 rows at 3072 dimensions, calling the built function over a real scan, five
interleaved repetitions:

| | median | µs/row |
|---|---|---|
| two-pass (before) | 8 606 ms | 33,66 |
| fused (after) | 3 933 ms | 15,38 |
| iterate + decode, no arithmetic | 2 559 ms | 10,01 |

**2,19x**, and 2,16x comparing the fastest run before against the slowest after. The row
fetch underneath does not move, which is why the whole scan gains less than the
arithmetic does: isolated from SQLite the arithmetic alone is 3,77x, of which 2,01x is
the traversal and 1,87x the polymorphic call site.

Driver and raw results:
[`bench/cosine_fusion.mjs`](https://github.com/MinhHaDuong/search-works-for-zotero/blob/main/bench/cosine_fusion.mjs),
[`bench/results/0070-cosine-fusion/`](https://github.com/MinhHaDuong/search-works-for-zotero/tree/main/bench/results/0070-cosine-fusion).

## Bit-identical, and checked as such

The same products are summed in the same order, so no index needs rebuilding and no
ranking moves. Verified over a whole 255 703-row store rather than a fixture: zero
mismatches, top-15 ids and scores identical. `tests/features/vector-cosine-equivalence.test.ts`
runs the previous implementation beside the current one over non-unit vectors spanning
eight orders of magnitude, zero rows, both directions of width mismatch, and NaN
propagation, comparing with `Object.is` so a sign-of-zero difference would fail.

The width-mismatch path is what makes bit-identity unconditional, and it is kept out of
line so the hot function stays small: the old code summed the norm over all of `b` while
stopping the product at the shorter operand. Nothing reaches it through `query()`, which
drops stale vectors on a width change, but an index holding two generations of vectors
does.

Existing suite unchanged: 752 passed, 7 skipped; `tsc --noEmit` and `eslint` clean.

## What this does not claim

It does not fix #30. The scan measured here is 8,6 s where that issue reports ~95, and
nothing measured here explains the gap on Windows / Node 24 — which is also what decides
what this change is worth there. If the gap is a uniform CPU-side slowdown the ratio
carries; if it is I/O, most of the ~95 s is untouched by anything in this diff. One line
would tell: whether a second identical query, run immediately after the first, is faster.

Alternatives considered. Precomputing each row's norm at index time would beat this, but
it needs a schema column and a rebuild to populate, and every embedder in use returns
normalized vectors — which would make the stored norm a constant 1, and the column dead
weight the day one does not. Reading the norm as 1 outright was rejected for the same
reason: true of every embedder shipped today, and not a property `cosine` can assume.
