### PR TITLE
Refuse to build one library's index over another's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A build for one library no longer erases another library's index.** The index file is
+  keyed by the data dir, never by the library — which is right, and had a sharp edge: the
+  build path clears the store before crawling, so `zotero_index` pointed at a group library
+  silently replaced the personal library's index (or any other), reported `done`, and said
+  nothing. Resume gave that a second shape: a build that finds a checkpoint carries on from
+  it instead of clearing, and the resume conditions never look at the library — so the same
+  mistake against an interrupted index appended one library's items to another's rows and
+  still reported `done`. The index now stamps the library it holds (the personal library is one identity
+  however it is addressed, `users/0` locally or by user id on the cloud, so the local/cloud
+  seam never trips it), and a build or update for a different library refuses up front,
+  naming both and the way forward. Indexes written before the stamp existed refuse nothing —
+  their first stamped build adopts them.
+
 ## [1.10.0] - 2026-08-29
 
 ### Added

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -74,6 +74,15 @@ index built against the desktop app stays valid when a later lookup goes to the 
 and the index file is keyed by the Zoteus data dir (plus the authenticated user in
 multi-tenant mode), never by the library id the read happened to use.
 
+**One index file, one library.** Because the file is keyed by the data dir, a build for a
+*different* library than the one the index holds would silently erase it — or, where an
+interrupted build left a checkpoint, resume into it and leave one file holding two
+libraries' rows. The index
+therefore stamps the library it was built for (the personal library counts as one library
+however it is addressed, `users/0` or by user id), and a build or update for another one
+refuses up front, naming both. To index a second library, run Zoteus with its own
+`ZOTEUS_DATA_DIR` for it — or delete the index file to hand the data dir over.
+
 **Incremental, crash-safe persistence.** Partial progress is persisted as the build runs
 (roughly every 200 items or 10s), so a timeout, crash, or `stop` can never leave a corrupt
 index: the JSON backend writes to a temp file and renames over the target, the SQLite one

--- a/src/features/search/backend.ts
+++ b/src/features/search/backend.ts
@@ -1,5 +1,22 @@
 import type { EmbeddingProvider } from './embeddings.js';
 import type { Logger } from '../../lib/logger.js';
+import type { LibraryRef } from '../../api/web-client.js';
+
+/**
+ * Canonical identity of a library for index stamping: `user` for the personal library,
+ * `group:<id>` for a group. The personal library is deliberately one token with no id:
+ * the desktop app serves it as users/0 while the cloud names the real user id, and the
+ * doc-comment on startIndexBuild promises that seam never splits the index — so it must
+ * never split the stamp either.
+ */
+export function canonicalLibraryToken(lib?: LibraryRef): string {
+  return lib?.type === 'group' ? `group:${lib.id}` : 'user';
+}
+
+/** The token, for humans: "the personal library", or "group 4523". */
+export function describeLibraryToken(library: string): string {
+  return library === 'user' ? 'the personal library' : library.replace(/^group:/, 'group ');
+}
 
 /**
  * Store an index lives in. `memory` is the original in-memory + JSON implementation:
@@ -122,6 +139,13 @@ export interface SearchIndexStatus {
    * `action:"update"` forever (#26). This is the cursor an update hands to `/fulltext?since=`.
    */
   fulltextVersion: number;
+  /**
+   * Canonical identity of the library whose rows this index holds (`user`, or
+   * `group:<id>` — see canonicalLibraryToken). Absent in indexes written before the
+   * stamp existed. One index file holds one library, and this is the stamp
+   * `assertLibrary` guards on.
+   */
+  library?: string;
 }
 
 /**
@@ -308,6 +332,14 @@ export interface IncrementalBuildOptions {
    * about.
    */
   fresh?: boolean;
+  /**
+   * Canonical identity of the library being indexed (see canonicalLibraryToken).
+   * Asserted against the stored stamp before anything is cleared — a build for a
+   * different library refuses instead of erasing this one — and stamped on the index
+   * with the first rows written. Callers should also assert synchronously
+   * (`assertLibrary`) so the refusal reaches them, not a fire-and-forget job's log.
+   */
+  library?: string;
 }
 
 /** What Zotero's full-text sequence has extracted since a cursor, and the new cursor. */
@@ -379,6 +411,8 @@ export interface IndexSnapshot {
   /** Where an interrupted build stopped (absent in files written before #24, and once
    * a build has finished: a completed build has nothing to resume). */
   checkpoint?: BuildCheckpoint;
+  /** Canonical identity of the library these rows belong to (absent in older files). */
+  library?: string;
 }
 
 export interface QueryOptions {
@@ -435,6 +469,14 @@ export interface SearchIndex {
   embed(texts: string[]): Promise<number[][]>;
   build(libraryItems: any[], opts?: BuildOptions): Promise<SearchIndexStatus>;
   buildIncremental(fetchPage: PageFetcher, opts?: IncrementalBuildOptions): Promise<IndexBuildStatus>;
+  /**
+   * Refuse to index `library` over the rows of a different one. Throws, naming both,
+   * when the store is non-empty and stamped with another library; silent otherwise
+   * (same library, empty store, or a pre-stamp index). Build/update callers check this
+   * BEFORE kicking off their fire-and-forget job, so the refusal reaches the tool
+   * caller instead of the job's error log.
+   */
+  assertLibrary(library: string): void;
   /**
    * Why a delta update cannot run against this index right now, or undefined when it can.
    * Checked by the caller BEFORE any request is made, so a refusal costs nothing and can

--- a/src/features/search/build.ts
+++ b/src/features/search/build.ts
@@ -1,6 +1,7 @@
 import type { ToolContext } from '../../registry/registry.js';
 import type { LibraryRef } from '../../api/web-client.js';
 import type { IndexBuildStatus, VersionBackend } from './backend.js';
+import { canonicalLibraryToken } from './backend.js';
 import { createFulltextSource, type FulltextSource } from './fulltext-source.js';
 import { DEFAULT_INDEX_MAX_ITEMS } from './limits.js';
 
@@ -213,6 +214,11 @@ export interface BuildFulltextOptions {
  * split the index from the one built against the cloud, and a build that switched
  * backends between runs stays coherent.
  *
+ * The other face of that rule is enforced here too: one index file holds ONE library's
+ * rows. The index stamps the canonical library it holds (`canonicalLibraryToken`), and a
+ * build for a different one refuses up front — naming both — instead of reaching the
+ * clearStore() that would silently erase the first library's index.
+ *
  * A completed build also stamps the library's real Last-Modified-Version and the API that
  * issued it, which is what `startIndexUpdate` later diffs against. The two sequences are
  * never mixed: the stamp is only usable while the routing that produced it still holds, and
@@ -233,6 +239,10 @@ export function startIndexBuild(
   maxItems?: number,
   opts: BuildFulltextOptions = {},
 ): IndexBuildStatus {
+  // Synchronously, before the fire-and-forget job below: a refusal thrown inside the job
+  // would only reach the logger, and the tool caller would see a build that "started".
+  const library = canonicalLibraryToken(lib);
+  ctx.search.assertLibrary(library);
   // The configured limit is the ceiling; an explicit `maxItems` may only lower it.
   const configured = ctx.config.indexMaxItems;
   const cap = maxItems === undefined ? configured : Math.min(maxItems, configured);
@@ -258,6 +268,7 @@ export function startIndexBuild(
     maxItems: cap,
     versionBackend: backend,
     ...(opts.fresh ? { fresh: true } : {}),
+    library,
     ...crawlOptions(ctx, lib, opts, backend),
   });
   job.catch((e) => ctx.logger.error(`Index build crashed: ${e instanceof Error ? e.message : String(e)}`));
@@ -279,6 +290,10 @@ export function startIndexUpdate(
   opts: BuildFulltextOptions = {},
 ): IndexBuildStatus {
   const backend: VersionBackend = ctx.router.servesLocally(lib) ? 'local' : 'cloud';
+  // Same synchronous guard as startIndexBuild, and for the same reason: the version stamp
+  // this update would diff against belongs to the library the index holds, not to `lib`.
+  const library = canonicalLibraryToken(lib);
+  ctx.search.assertLibrary(library);
   const blocker = ctx.search.updateBlocker(backend);
   if (blocker) {
     return startIndexBuild(ctx, lib, maxItems, {
@@ -322,6 +337,7 @@ export function startIndexUpdate(
     fetchChanged,
     liveKeys,
     maxItems: cap,
+    library,
     ...crawlOptions(ctx, lib, opts, backend),
   });
   job.catch((e) => ctx.logger.error(`Index update crashed: ${e instanceof Error ? e.message : String(e)}`));

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -6,6 +6,7 @@ import { batchPause, embedderIdentity } from './embeddings.js';
 import { DEFAULT_EMBED_BATCH_SIZE } from './limits.js';
 import { Semaphore } from '../../lib/semaphore.js';
 import { progressLine } from './build.js';
+import { describeLibraryToken } from './backend.js';
 import { saveIndex } from './persistence.js';
 import type {
   BuildCheckpoint,
@@ -182,6 +183,13 @@ export abstract class SearchIndexBase implements SearchIndex {
    * resume redoes to a single persistence interval (#24).
    */
   protected checkpoint: BuildCheckpoint | undefined = undefined;
+  /**
+   * Canonical identity of the library whose rows this store holds (canonicalLibraryToken;
+   * undefined until a stamped build writes rows, or for indexes persisted before the
+   * stamp existed). Written with the first rows rather than at completion: a half-built
+   * index is already somebody's index, and assertLibrary must protect it too.
+   */
+  protected library: string | undefined = undefined;
   /** What the last update did, or why a rebuild replaced it (see IndexBuildStatus). */
   protected updateNotice: string | undefined = undefined;
   /**
@@ -233,6 +241,24 @@ export abstract class SearchIndexBase implements SearchIndex {
   /** Refuse rather than answer from a store that is known to be unreadable. */
   protected refuseIfFaulted(): void {
     if (this.fault) throw this.fault;
+  }
+
+  /**
+   * The guard on the single-library assumption startIndexBuild documents: one index
+   * file, one library. A build or update for another library would reach clearStore()
+   * and erase this one's rows, so it refuses instead, naming both. An empty store or a
+   * pre-stamp index guards nothing — there is either nothing to lose, or no way to know
+   * whose rows these are.
+   */
+  assertLibrary(library: string): void {
+    const held = this.library;
+    if (!held || held === library) return;
+    if (this.counts().documents === 0) return;
+    throw new Error(
+      `This index holds ${describeLibraryToken(held)}; building for ${describeLibraryToken(library)} ` +
+        `would erase it. One index file holds one library. To index ${describeLibraryToken(library)}, ` +
+        'run Zoteus with its own data directory (ZOTEUS_DATA_DIR), or delete the index file and rebuild.',
+    );
   }
 
   /**
@@ -506,6 +532,7 @@ export abstract class SearchIndexBase implements SearchIndex {
       fulltextVersion: this.fulltextVersion,
     };
     if (this.libraryBackend) s.libraryBackend = this.libraryBackend;
+    if (this.library) s.library = this.library;
     const reason = this.embedderReason;
     if (reason) s.embedderReason = reason;
     if (this.opts.embedder?.model) s.embedderModel = this.opts.embedder.model;
@@ -538,6 +565,9 @@ export abstract class SearchIndexBase implements SearchIndex {
     // indexed, and the checkpoint names a crawl whose committed rows have just been erased.
     this.fulltextVersion = 0;
     this.checkpoint = undefined;
+    // And the library stamp: an emptied store holds nobody's rows. The build that called
+    // this restamps its own library immediately after (the guard already ran before it).
+    this.library = undefined;
   }
 
   async build(libraryItems: any[], opts: BuildOptions = {}): Promise<SearchIndexStatus> {
@@ -637,6 +667,10 @@ export abstract class SearchIndexBase implements SearchIndex {
    */
   async buildIncremental(fetchPage: PageFetcher, opts: IncrementalBuildOptions = {}): Promise<IndexBuildStatus> {
     this.refuseIfFaulted();
+    // Before anything is cleared: a build for a different library than the rows held must
+    // refuse here rather than reach reset() below (startIndexBuild also asserts this
+    // synchronously, so tool callers see the refusal rather than a logged rejection).
+    if (opts.library) this.assertLibrary(opts.library);
     if (this.isBuilding) throw new Error('Index build already in progress; poll action:"status".');
     // Read before anything is reset, and in the synchronous prologue, so the status the
     // fire-and-forget caller returns to its user already says a resume is what started.
@@ -684,6 +718,11 @@ export abstract class SearchIndexBase implements SearchIndex {
     // A resumed build inherits the body passages the interrupted one committed, so it is a
     // full-text index whether or not this run was asked to crawl any more of them.
     this.fulltextEnabled = Boolean(opts.fulltextFor) || (resume ? this.counts().fulltextPassages > 0 : false);
+    // Stamped before the first row, not at completion: every partial persist carries the
+    // identity of the library it belongs to, so even an interrupted build stays guarded.
+    // After the resume branch above, so a continued build restamps the identity it was
+    // already asserted against rather than leaving a resumed store unstamped.
+    this.library = opts.library;
     this.vectorEmbedderId = this.embedderId;
 
     const embedBatchSize = opts.embedBatchSize ?? DEFAULT_EMBED_BATCH_SIZE;
@@ -1054,6 +1093,9 @@ export abstract class SearchIndexBase implements SearchIndex {
    */
   async updateIncremental(opts: IncrementalUpdateOptions): Promise<IndexBuildStatus> {
     this.refuseIfFaulted();
+    // Same guard as the full build: a delta for a different library would splice its
+    // changes into — and delete "missing" items from — rows that were never its own.
+    if (opts.library) this.assertLibrary(opts.library);
     if (this.isBuilding) throw new Error('Index build already in progress; poll action:"status".');
     const fromVersion = this.libraryVersion;
     this.buildState = 'building';
@@ -1184,6 +1226,9 @@ export abstract class SearchIndexBase implements SearchIndex {
       if (!token.cancelled && reconciled && crawlVersion) {
         this.libraryVersion = crawlVersion;
         this.libraryBackend = opts.backend;
+        // An index stamped before the library stamp existed gets one here: the update just
+        // asserted (or trivially holds) that these rows are this library's.
+        if (opts.library) this.library = opts.library;
       }
       // The full-text cursor advances under the same rule as the stamp, and for the same
       // reason: an update that did not finish must repeat this delta, not skip past it.
@@ -1696,6 +1741,7 @@ export class MemorySearchIndex extends SearchIndexBase {
     // Present only while a build is unfinished, which is exactly when the next one has
     // somewhere to pick up from (#24).
     if (this.checkpoint) snapshot.checkpoint = this.checkpoint;
+    if (this.library) snapshot.library = this.library;
     return snapshot;
   }
 
@@ -1728,5 +1774,8 @@ export class MemorySearchIndex extends SearchIndexBase {
     // Absent in files written before resume existed, and in any file a finished build
     // wrote: both mean there is nothing to resume, which is what undefined says (#24).
     this.checkpoint = data.checkpoint;
+    // Absent in files written before the library stamp existed: an unstamped index
+    // refuses nothing (assertLibrary), which is the only workable answer for it.
+    this.library = data.library;
   }
 }

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -509,6 +509,9 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // coverage gap is unknown, which the first update closes once (#26).
     this.fulltextVersion = Number(this.meta('fulltextVersion') ?? 0) || 0;
     this.checkpoint = parseCheckpoint(this.meta('checkpoint'));
+    // Absent in databases written before the library stamp: an unstamped index refuses
+    // nothing (assertLibrary), so old files keep building rather than stranding.
+    this.library = this.meta('library') || undefined;
     // An index that HOLDS full-text passages counts as full-text-enabled, even before this
     // process runs a build of its own (same rule as the JSON backend's load).
     this.fulltextEnabled = this.c.fulltextPassages > 0;
@@ -529,6 +532,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // place a value can be added without a schema version bump: an older build ignores a
     // key it does not know, so a database written here still opens there.
     set.run('checkpoint', this.checkpoint ? JSON.stringify(this.checkpoint) : '');
+    set.run('library', this.library ?? '');
   }
 
   private refreshCounts(): void {

--- a/tests/features/search-library-guard.test.ts
+++ b/tests/features/search-library-guard.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startIndexBuild, PAGE_SIZE } from '../../src/features/search/build.js';
+import { MemorySearchIndex } from '../../src/features/search/index-manager.js';
+import { createSearchIndex, nodeSqliteAvailable } from '../../src/features/search/factory.js';
+import { canonicalLibraryToken } from '../../src/features/search/backend.js';
+import { LibraryRouter } from '../../src/router/library-router.js';
+import { loadConfig } from '../../src/config.js';
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+
+const hasSqlite = nodeSqliteAvailable();
+const sqliteIt = hasSqlite ? it : it.skip;
+
+function makeItems(n: number, prefix: string): any[] {
+  return Array.from({ length: n }, (_, i) => ({
+    key: `${prefix}${i}`,
+    data: { itemType: 'journalArticle', title: `${prefix} item ${i}`, abstractNote: `abstract body ${i}` },
+  }));
+}
+
+/** One-page fetcher over a fixed item list, the shape buildIncremental crawls. */
+function pageFetcher(items: any[], version = 42) {
+  return async (start: number) => ({
+    items: items.slice(start, start + PAGE_SIZE),
+    totalResults: items.length,
+    lastModifiedVersion: version,
+  });
+}
+
+async function finished(index: { buildStatus(): { state: string } }): Promise<void> {
+  for (let i = 0; i < 500 && index.buildStatus().state === 'building'; i++) {
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
+describe('canonicalLibraryToken', () => {
+  it('normalizes the personal library to one token, however it is addressed', () => {
+    // The desktop app serves the personal library as users/0; the cloud names the real
+    // user id. Same library, so same token — otherwise the guard would refuse the
+    // legitimate rebuild that crosses the local/cloud seam.
+    expect(canonicalLibraryToken(undefined)).toBe('user');
+    expect(canonicalLibraryToken({ type: 'user', id: 0 })).toBe('user');
+    expect(canonicalLibraryToken({ type: 'user', id: 19552201 })).toBe('user');
+  });
+
+  it('keys each group by its id', () => {
+    expect(canonicalLibraryToken({ type: 'group', id: 4523 })).toBe('group:4523');
+    expect(canonicalLibraryToken({ type: 'group', id: 7 })).toBe('group:7');
+  });
+});
+
+describe('the cross-library wipe guard (engine)', () => {
+  it('refuses a build for a different library instead of erasing the index', async () => {
+    const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    await index.buildIncremental(pageFetcher(makeItems(5, 'U')), { library: 'user' });
+    expect(index.buildStatus().items).toBe(5);
+
+    // The repro: on a tree without the guard this second build reaches clearStore(),
+    // silently replaces the personal library's index with the group's, and "succeeds".
+    await expect(
+      index.buildIncremental(pageFetcher(makeItems(2, 'G')), { library: 'group:4523' }),
+    ).rejects.toThrow(/personal library[\s\S]*group 4523/);
+
+    // Refused means untouched: the first library's rows are all still there and queryable.
+    const status = index.buildStatus();
+    expect(status.items).toBe(5);
+    expect(status.library).toBe('user');
+    expect(await index.query('abstract body', { mode: 'keyword' })).not.toHaveLength(0);
+  });
+
+  it('lets the same library rebuild, and a legacy unstamped index build for anyone', async () => {
+    const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    await index.buildIncremental(pageFetcher(makeItems(3, 'U')), { library: 'user' });
+    // A rebuild of the library the index already holds is the ordinary retry path.
+    await index.buildIncremental(pageFetcher(makeItems(4, 'U')), { library: 'user' });
+    expect(index.buildStatus().items).toBe(4);
+
+    // An index persisted before the stamp existed carries no library. It guards nothing:
+    // there is no way to know whose rows these are, and refusing would strand every
+    // existing index behind an error no rebuild could clear.
+    const legacy = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    const snapshot = index.toJSON();
+    delete (snapshot as any).library;
+    legacy.loadFromJSON(snapshot);
+    await legacy.buildIncremental(pageFetcher(makeItems(2, 'G')), { library: 'group:9' });
+    expect(legacy.buildStatus().items).toBe(2);
+    expect(legacy.buildStatus().library).toBe('group:9');
+  });
+
+  it('guards the update path with the same stamp', async () => {
+    const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    await index.buildIncremental(pageFetcher(makeItems(3, 'U')), { library: 'user', versionBackend: 'local' });
+
+    await expect(
+      index.updateIncremental({
+        library: 'group:4523',
+        backend: 'local',
+        fetchChanged: pageFetcher([], 43),
+        liveKeys: async () => new Set<string>(),
+      }),
+    ).rejects.toThrow(/group 4523/);
+    expect(index.buildStatus().items).toBe(3);
+  });
+
+  it('survives the JSON save/load roundtrip', async () => {
+    const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    await index.buildIncremental(pageFetcher(makeItems(3, 'U')), { library: 'user' });
+
+    const reloaded = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    reloaded.loadFromJSON(index.toJSON());
+    expect(reloaded.buildStatus().library).toBe('user');
+    await expect(
+      reloaded.buildIncremental(pageFetcher(makeItems(2, 'G')), { library: 'group:12' }),
+    ).rejects.toThrow(/would erase/);
+  });
+
+  sqliteIt('survives an SQLite close and reopen', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zoteus-libguard-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const open = () =>
+      createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+
+    const first = await open();
+    await first.buildIncremental(pageFetcher(makeItems(3, 'U')), { library: 'user' });
+    await first.save();
+    await first.close();
+
+    const second = await open();
+    expect(second.buildStatus().library).toBe('user');
+    await expect(
+      second.buildIncremental(pageFetcher(makeItems(2, 'G')), { library: 'group:4523' }),
+    ).rejects.toThrow(/would erase/);
+    expect(second.buildStatus().items).toBe(3);
+    await second.close();
+  });
+});
+
+describe('the cross-library wipe guard (tool path)', () => {
+  function makeCtx(items: number) {
+    const web = {
+      listItems: vi.fn(async (_lib: any, q: { limit?: number; start?: number }) => ({
+        data: makeItems(items, 'W').slice(q.start ?? 0, (q.start ?? 0) + (q.limit ?? PAGE_SIZE)),
+        totalResults: items,
+        lastModifiedVersion: 2114,
+      })),
+    };
+    const local = {
+      listItems: vi.fn(async (q: { limit?: number; start?: number }) => ({
+        data: makeItems(items, 'L').slice(q.start ?? 0, (q.start ?? 0) + (q.limit ?? PAGE_SIZE)),
+        totalResults: items,
+        lastModifiedVersion: 13,
+      })),
+    };
+    const config = loadConfig({ ZOTEUS_LOCAL: 'auto' } as any);
+    const capabilities = {
+      cloud: { userID: 19552201, username: 'oscardvs', access: {} } as any,
+      localApi: true,
+      localGroupIds: [4523],
+    };
+    const router = new LibraryRouter({ config, capabilities, web: web as any, local: local as any });
+    const search = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    const ctx: any = { config, capabilities, router, web, local, search, searchIndexPath: '', logger: silentLogger };
+    return { ctx, search };
+  }
+
+  it('refuses synchronously, so the refusal reaches the tool caller, and leaves the index intact', async () => {
+    const { ctx, search } = makeCtx(6);
+    startIndexBuild(ctx);
+    await finished(search);
+    expect(search.buildStatus().items).toBe(6);
+
+    // On a tree without the guard this wipes the personal index and indexes the group
+    // over it — the erase the refusal exists to prevent. The throw must be synchronous:
+    // the build job is fire-and-forget, so a rejection there only reaches the log.
+    expect(() => startIndexBuild(ctx, { type: 'group', id: 4523 })).toThrow(/personal library[\s\S]*group 4523/);
+    expect(search.buildStatus().items).toBe(6);
+    expect(search.buildStatus().library).toBe('user');
+  });
+
+  it('never refuses the personal library across the local/cloud seam', async () => {
+    const { ctx, search } = makeCtx(4);
+    // Built via the desktop app (users/0 addressing) ...
+    startIndexBuild(ctx);
+    await finished(search);
+    expect(search.buildStatus().library).toBe('user');
+    // ... rebuilt with the personal library named by its cloud user id: same library,
+    // same token, no refusal — the seam the startIndexBuild doc-comment promises away.
+    startIndexBuild(ctx, { type: 'user', id: 19552201 });
+    await finished(search);
+    expect(search.buildStatus().state).toBe('done');
+    expect(search.buildStatus().library).toBe('user');
+  });
+});
+
+describe("the wipe guard and a resumed build (the second shape, since 1.10.0)", () => {
+  it("refuses a different library rather than resuming into the index it holds", async () => {
+    // Resume (#24) made the hazard two-shaped. A build no longer always clears the store:
+    // where an interrupted run left a checkpoint, it CARRIES ON from it, and resumeFrom()
+    // gates on `fresh`, the checkpoint, a non-empty store and the embedder — never on the
+    // library. So without the guard a build for another library skips reset() entirely and
+    // appends its items to the rows already there: not the erase this PR started from, but
+    // the same defect one turn worse, since the index then holds two libraries at once and
+    // still reports `done`. offsetStillHolds() cannot catch it — it only ever invalidates
+    // the crawl OFFSET, and keeps the committed rows either way.
+    const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+
+    // Interrupt a personal-library build, so a checkpoint is left with the rows.
+    const items = makeItems(120, "U");
+    await index.buildIncremental(async (start: number) => {
+      if (start >= PAGE_SIZE) index.requestStop();
+      return { items: items.slice(start, start + PAGE_SIZE), totalResults: items.length, lastModifiedVersion: 42 };
+    }, { library: "user" });
+    const indexed = index.buildStatus().items;
+    expect(indexed).toBeGreaterThan(0);
+    expect(indexed).toBeLessThan(items.length);
+
+    // The same build again resumes — the path this case is about is live, not skipped.
+    await expect(
+      index.buildIncremental(pageFetcher(makeItems(2, "G")), { library: "group:4523" }),
+    ).rejects.toThrow(/personal library[\s\S]*group 4523/);
+
+    // Refused before resumeFrom(), so neither shape ran: nothing erased, nothing mixed.
+    const status = index.buildStatus();
+    expect(status.items).toBe(indexed);
+    expect(status.library).toBe("user");
+    const hits = await index.query("abstract body", { mode: "keyword", limit: 200 });
+    expect(hits.every((h: any) => String(h.itemKey ?? h.key ?? "").startsWith("U"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## The defect

The index file is keyed by the data dir, never by the library — which is right, and
documented on `startIndexBuild` — but nothing records *which* library the rows belong to.
So `zotero_index` pointed at a second library damages the first one, silently, and since
1.10.0 it can do that in two different ways.

**The erase.** The build path clears the store before crawling (`reset()` → `clearStore()`),
so a group build replaces the personal library's index (or any group's), reports `done`, and
says nothing. Build the personal library, then `zotero_index` with a group's `library_id`:
the index holds the group's items, the personal rows are gone, no notice was ever shown.

**The mix, new in 1.10.0 and the worse of the two.** A build no longer always clears the
store: where an interrupted run left a checkpoint it carries on from it (#24), and
`resumeFrom()` gates on `fresh`, the checkpoint, a non-empty store and the embedder — never
on the library. So the same mistake against an *interrupted* index skips the clear entirely
and appends one library's items to another's rows. Measured on 1.10.0 as it stands, a group
build against a personal index interrupted at 100 items:

```
state: done   resumedFrom: 100   itemsFetched: 102   passages: 102   itemsTotal: 2
```

One index file holding two libraries, its counters describing whichever library asked last,
and a `done` on top. `offsetStillHolds()` cannot catch this — by its own comment it
invalidates the crawl *offset* and keeps the committed rows either way, which is correct for
the resume it was written for and is exactly what makes the identity check missing.

## The fix

The guard on the documented single-library assumption — not a multi-library feature.

- The index stamps the canonical identity of the library it holds (`user`, or `group:<id>`)
  with the first rows written, riding the existing seams: the `meta` table on SQLite, the
  JSON snapshot on memory, `library` in status output. Written with the first rows rather
  than at completion, because a half-built index is already somebody's index.
- A build or update for a different library than stamped refuses up front, naming both and
  the way forward (a separate `ZOTEUS_DATA_DIR` per library, or delete the index file to
  hand the data dir over). The refusal is asserted synchronously in
  `startIndexBuild`/`startIndexUpdate` — the job is fire-and-forget, so a rejection inside
  it only reaches the log — and the engine asserts again **ahead of `resumeFrom()`**, which
  is what covers both shapes above with one check.
- The personal library is one token with no id: the desktop app serves it as `users/0` while
  the cloud names the real user id, and the `startIndexBuild` doc-comment promises that seam
  never splits the index — so it must never split the stamp either. A rebuild of the personal
  library across the local/cloud seam is tested to never refuse.
- An index persisted before the stamp existed refuses nothing: there is no way to know whose
  rows it holds, and refusing would strand every existing index behind an error no rebuild
  could clear. Its first stamped build (or completed update) adopts it.

## Testing

Ten cases in `tests/features/search-library-guard.test.ts`: token normalization (both
`users/0` and cloud-id addressing of the personal library), the engine guard on build and
update, stamp persistence across a JSON save/load and an SQLite close/reopen, the
synchronous tool-path refusal with the index left intact, the local/cloud seam that must
never refuse, and the resumed-build shape.

All ten were run against 1.10.0 without the fix and **all ten fail there** — the erase case
shows the personal index replaced and gone with `state: done`, the resume case shows the
mixed index quoted above. Full suite on this branch: 857 passed / 7 skipped; typecheck,
lint and build clean.
