### PR TITLE
Give the search index a migration path, and salvage its vectors (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to Zoteus are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **The search index has a migration path, so the next schema bump does not re-embed every
+  library from zero (#34).** `SCHEMA_VERSION` has been 1 since the SQLite backend landed,
+  and the open path accepted exactly two states: no tables, or this build's own stamp.
+  Everything else was moved aside and rebuilt — *including a database stamped with an older
+  version of our own schema*. That has never fired for anyone, which is exactly why it was
+  worth fixing now: the first bump is the one that charges every index in the field a full
+  rebuild, and the expensive half of a rebuild is re-embedding (a measured 5.5 hours of
+  local CPU for 255k passages, or a hosted provider's bill). Two things change. A ladder of
+  upgrade steps now carries an older index forward in place: each step runs inside the one
+  transaction that stamps the new version, so a database is either fully upgraded or fully
+  untouched, and a step that throws rolls back and falls through to the sideline. And where
+  a sideline is still the right answer — a newer build's database, an unstamped file, a gap
+  in the ladder — the moved-aside index becomes a read-only vector source for the rebuild
+  that replaces it: any passage that comes back with the same id and byte-identical text
+  takes its stored vector instead of being embedded again, so only genuinely new or edited
+  text costs embedding time. Reuse is refused when the embedder identity (provider *and*
+  model) differs, and `storageNotice` now prices the rebuild it prescribes — how many
+  passages, how many vectors, and whether they must be paid for — instead of only saying
+  where the old file went.
+
 ### Fixed
 - **A build for one library no longer erases another library's index.** The index file is
   keyed by the data dir, never by the library — which is right, and had a sharp edge: the

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -385,14 +385,33 @@ resets before it parses, the next clean shutdown wrote that emptiness back over 
 A JSON artifact that fails to parse is now refused, left untouched on disk, and repaired by
 the same `action:"build"`.
 
-**A database from a different schema version is moved aside, never written into.** The
+**An older schema version is upgraded in place.** When Zoteus bumps the index schema, a
+database stamped with an earlier version of *this* schema is migrated where it lies: the
+ladder of upgrade steps runs inside one transaction with the new stamp, so the file is
+either fully upgraded or fully unchanged, and nothing is re-crawled or re-embedded.
+`storageNotice` says what moved it forward. A step that fails rolls the whole thing back
+and the database is moved aside instead, exactly as an unmigratable one is.
+
+**A database from an unreachable schema version is moved aside, never written into.** The
 schema stamp is read before anything touches the file. A database stamped with a version
-this build does not understand — typically one written by a newer Zoteus after a downgrade
-— is renamed to `search-index.sqlite.incompatible-<timestamp>` (its write-ahead sidecars
-with it, nothing deleted), a fresh index is created in its place, and `storageNotice` says
-what moved and where. The moved file stays a complete database, readable by the build that
-stamped it; rebuild with `zotero_index action:"build"`, and a later re-upgrade finds the
-moved file intact.
+this build cannot reach — one written by a newer Zoteus after a downgrade, a file with no
+stamp at all, or a version no ladder covers — is renamed to
+`search-index.sqlite.incompatible-<timestamp>` (its write-ahead sidecars with it, nothing
+deleted), a fresh index is created in its place, and `storageNotice` says what moved and
+where. The moved file stays a complete database, readable by the build that stamped it;
+rebuild with `zotero_index action:"build"`, and a later re-upgrade finds the moved file
+intact.
+
+**A sideline hands its vectors to the rebuild that replaces it.** The expensive half of a
+rebuild is not the crawl but the embedding — hours of local CPU on a large library, or real
+spend on a hosted provider — and none of that cost is inherent: an embedding is a function
+of the passage text and the model, neither of which a schema change touches. So the
+moved-aside database stays open as a read-only vector source, and every passage the rebuild
+re-reads with the same id and byte-identical text takes its vector from there instead of
+being embedded again. Only genuinely new or edited text costs embedding time. The reuse is
+refused outright when the embedder has changed (`embedderId` covers provider *and* model),
+and `storageNotice` prices the rebuild either way: how many passages must be re-indexed, how
+many vectors that involves, and whether they have to be paid for.
 
 **Migration is automatic and lossless.** The first time the SQLite backend opens a data dir
 that holds a `search-index.json` and no database, it imports the JSON index and leaves the

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -343,6 +343,19 @@ export abstract class SearchIndexBase implements SearchIndex {
   abstract readonly supportsDelete: boolean;
   /** Attach a vector to an already-stored passage. */
   protected abstract putVector(id: string, vector: number[]): void;
+  /**
+   * Give the store a chance to answer a passage's vector from something it already holds,
+   * before the embedder is asked for one. True means the passage now carries a vector and
+   * must not be queued for embedding.
+   *
+   * The one implementation today is the SQLite backend reading an index a schema change
+   * moved aside: an embedding is a function of the text and the model, so a rebuild forced
+   * by a table-layout change would otherwise re-buy vectors it already owns (#34). Default
+   * false, because a backend with nothing to reuse must not be made to pretend otherwise.
+   */
+  protected adoptVector(_rec: ChunkRecord): boolean {
+    return false;
+  }
   /** Discard every stored vector, keeping the passages. */
   protected abstract clearVectors(): void;
   /**
@@ -593,8 +606,11 @@ export abstract class SearchIndexBase implements SearchIndex {
       const text = extra ? `${base}. ${extra}` : base;
       for (const ch of chunkText(text)) {
         const rec: ChunkRecord = { id: `${key}#${ch.index}`, itemKey: key, title: d.title ?? '(untitled)', text: ch.text };
-        records.push(rec);
         this.putPassage(rec);
+        // Same rule as the incremental path: a vector the store can produce for itself is
+        // never bought from the embedder a second time (#34).
+        if (this.hasEmbedder && this.adoptVector(rec)) continue;
+        records.push(rec);
       }
     }
     if (this.opts.embedder && records.length) {
@@ -1479,7 +1495,7 @@ export abstract class SearchIndexBase implements SearchIndex {
     for (const ch of chunkText(itemText(d))) {
       const rec: ChunkRecord = { id: `${key}#${ch.index}`, itemKey: key, title, text: ch.text };
       this.putPassage(rec);
-      if (this.hasEmbedder) pending.push(rec);
+      if (this.hasEmbedder && !this.adoptVector(rec)) pending.push(rec);
     }
     return { key, title };
   }
@@ -1499,7 +1515,7 @@ export abstract class SearchIndexBase implements SearchIndex {
         source: 'fulltext',
       };
       this.putPassage(rec);
-      if (this.hasEmbedder) pending.push(rec);
+      if (this.hasEmbedder && !this.adoptVector(rec)) pending.push(rec);
     }
   }
 

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -6,6 +6,7 @@ import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
 import { tokenize } from './tokenize.js';
 import { SearchIndexCorruptError, isCorruptionError, isQuerySyntaxError, sidecarsOf } from './corruption.js';
+import { VectorSalvage } from './vector-salvage.js';
 import { DEFAULT_ANN_MIN_CANDIDATES, DEFAULT_ANN_OVERSAMPLE } from './limits.js';
 import type {
   BuildCheckpoint,
@@ -46,6 +47,44 @@ export const MAX_MIGRATION_BYTES = 200 * 1024 * 1024;
  * can rebuild from what is already on disk.
  */
 const SCHEMA_VERSION = 1;
+
+/**
+ * One rung of the upgrade ladder: how a database stamped `to - 1` becomes one stamped `to`.
+ *
+ * The stamp above says what a build must not misread. This says what it can read anyway,
+ * and it exists because the two are not the same question. Most schema changes add a
+ * column or an index, neither of which invalidates a single stored row — yet without a
+ * rung to carry them across, the bump that adds one costs every user in the field a full
+ * rebuild, and the expensive half of a rebuild is re-embedding: five and a half hours of
+ * local CPU on a 255k-passage library, or real spend on a hosted embedder (#34).
+ *
+ * The contract for whoever bumps SCHEMA_VERSION next:
+ *
+ *  - add a rung whose `to` is the new version, or deliberately do not, and understand
+ *    that not adding one sidelines every existing index and charges it a re-embed;
+ *  - `up` runs inside the transaction that stamps the new version, so a step that throws
+ *    leaves the database exactly as it was, at its old stamp, and the sideline takes over;
+ *  - the ladder must be contiguous. A database is migrated only when every rung from its
+ *    stamp to this one exists, because a gap means some version's rows were never
+ *    accounted for by anything.
+ */
+export interface SchemaMigration {
+  /** Version this rung produces. It upgrades a database stamped `to - 1`. */
+  to: number;
+  /** What it changes, in a few words, for the notice a migrated index reports. */
+  what: string;
+  /** DDL and backfill. Runs inside the transaction that stamps `to`. */
+  up(db: Database): void;
+}
+
+/**
+ * The ladder, in ascending order. Empty because SCHEMA_VERSION has never been bumped: the
+ * stamp was introduced as 1 with the SQLite backend and is still 1. That is precisely why
+ * this is here now — a migration path is cheap to build before the first bump and
+ * expensive to wish for afterwards, when every index in the field has already been
+ * sidelined by it.
+ */
+export const SCHEMA_MIGRATIONS: SchemaMigration[] = [];
 
 /**
  * Passage rowids per rescore statement. The exact stage fetches its candidates by rowid in
@@ -91,6 +130,14 @@ export interface SqliteSearchIndexOptions extends SearchIndexOptions {
   migrateFrom?: string;
   /** Override for MAX_MIGRATION_BYTES (tests exercise the refusal without a 200 MB fixture). */
   maxMigrationBytes?: number;
+  /**
+   * Schema stamp this instance writes and upgrades to, with the ladder that gets there.
+   * Overridable because SCHEMA_VERSION has never been bumped, so the only way to exercise
+   * a bump — the migration, its rollback, and the sideline that catches what cannot
+   * migrate — is for a test to play the part of the build that makes one.
+   */
+  schemaVersion?: number;
+  migrations?: SchemaMigration[];
   /** Two-stage vector search; false forces the exact scan (ZOTEUS_INDEX_ANN). */
   annEnabled?: boolean;
   /** Candidates the code stage hands the rescore, per hit asked for (ZOTEUS_INDEX_ANN_OVERSAMPLE). */
@@ -189,6 +236,16 @@ export class SqliteSearchIndex extends SearchIndexBase {
   private readonly file: string;
   private readonly migrateFrom: string | undefined;
   private readonly maxMigrationBytes: number;
+  private readonly schemaVersion: number;
+  private readonly migrations: SchemaMigration[];
+  /**
+   * Vectors from an index this open had to move aside, kept as a source for the rebuild
+   * that follows. Armed only when the sidelined file was written by the same embedder;
+   * see VectorSalvage for the rest of the identity a reused vector has to satisfy.
+   */
+  private salvage: VectorSalvage | undefined;
+  /** The sideline's own sentence, so the reuse count can be appended without repeating it. */
+  private sidelineNotice: string | undefined;
   private readonly annEnabled: boolean;
   private readonly annOversample: number;
   private readonly annMinCandidates: number;
@@ -210,6 +267,8 @@ export class SqliteSearchIndex extends SearchIndexBase {
     this.file = opts.path;
     this.migrateFrom = opts.migrateFrom;
     this.maxMigrationBytes = opts.maxMigrationBytes ?? MAX_MIGRATION_BYTES;
+    this.schemaVersion = opts.schemaVersion ?? SCHEMA_VERSION;
+    this.migrations = opts.migrations ?? SCHEMA_MIGRATIONS;
     this.annEnabled = opts.annEnabled ?? true;
     this.annOversample = Math.max(1, Math.trunc(opts.annOversample ?? DEFAULT_ANN_OVERSAMPLE));
     this.annMinCandidates = Math.max(1, Math.trunc(opts.annMinCandidates ?? DEFAULT_ANN_MIN_CANDIDATES));
@@ -225,8 +284,9 @@ export class SqliteSearchIndex extends SearchIndexBase {
       // connection pragma touches it. Doing it the other way around — createSchema first —
       // re-stamped a database written by a newer build and then misread it, destroying the
       // one piece of evidence the stamp exists to carry at exactly the moment it mattered.
-      if (existed) await this.sidelineIfIncompatible();
-      this.openHandle();
+      // A migration may leave the handle already open, having earned the right to write.
+      if (existed) await this.reconcileSchema();
+      if (!this.db) this.openHandle();
       this.createSchema();
       this.prepareStatements();
       // `existed` deliberately still gates the import after a sideline: the legacy JSON
@@ -235,6 +295,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
       if (!existed && this.migrateFrom) await this.importJson(this.migrateFrom);
       this.refreshCounts();
       this.loadMeta();
+      this.syncSalvage();
     } catch (e) {
       if (!isCorruptionError(e) && !(e instanceof SearchIndexCorruptError)) throw e;
       // The handle may exist, so this object owns it and must release it before handing
@@ -301,6 +362,129 @@ export class SqliteSearchIndex extends SearchIndexBase {
   }
 
   /**
+   * What an existing database holds, for the sentence a sideline owes its owner.
+   *
+   * Read from the same read-only probe as the stamp, because it answers the question the
+   * old notice left the user to discover by watching: what a rebuild is going to cost.
+   * The counts are what must be re-indexed and the embedder id is what says whether the
+   * expensive half — re-embedding — can be avoided by reusing the vectors already here.
+   */
+  private probeContents(db: Database): { passages: number; vectors: number; embedderId?: string } {
+    try {
+      const row = db
+        .prepare('SELECT COUNT(*) AS p, COUNT(vector) AS v FROM passages')
+        .get() as { p: number; v: number };
+      const id = db.prepare("SELECT value FROM meta WHERE key = 'embedderId'").get() as
+        | { value?: string }
+        | undefined;
+      return { passages: Number(row?.p ?? 0), vectors: Number(row?.v ?? 0), ...(id?.value ? { embedderId: id.value } : {}) };
+    } catch {
+      // A file whose shape this build cannot read is exactly the file being moved aside;
+      // it owes no census, and failing the open over one would be absurd.
+      return { passages: 0, vectors: 0 };
+    }
+  }
+
+  /**
+   * Decide what an existing database is to this build — current, upgradable, or foreign —
+   * and act on it, leaving either a migrated file (handle open) or a moved-aside one.
+   *
+   * The read-only probe comes first and stays genuinely read-only: journal_mode=WAL can
+   * rewrite bytes in the database header, so even the normal writable connection pragmas
+   * must wait until the stamp has been accepted. What is new is that "accepted" now has
+   * two forms. A database at an OLDER version of this schema is ours, we know exactly what
+   * it holds, and a ladder of migrations exists to bring it forward without re-reading a
+   * single item from Zotero (#34). Only a version nothing on the ladder reaches — a newer
+   * build's, an unstamped file, a gap in the ladder — is still moved aside.
+   */
+  private async reconcileSchema(): Promise<void> {
+    const probe = new DatabaseSync(this.file, { readOnly: true });
+    let stored: number | 'fresh' | 'unstamped';
+    let contents: { passages: number; vectors: number; embedderId?: string };
+    try {
+      probe.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+      stored = this.storedSchemaVersion(probe);
+      contents = stored === 'fresh' || stored === this.schemaVersion ? { passages: 0, vectors: 0 } : this.probeContents(probe);
+    } finally {
+      probe.close();
+    }
+    if (stored === 'fresh' || stored === this.schemaVersion) return;
+    const ladder = typeof stored === 'number' ? this.migrationPath(stored) : undefined;
+    if (ladder) {
+      const failure = this.runMigrations(stored as number, ladder);
+      if (!failure) return;
+      // A migration that threw rolled itself back, so the file is untouched at its old
+      // stamp — which is the one state the sideline below was written for.
+      await this.sideline(stored, contents, failure);
+      return;
+    }
+    await this.sideline(stored, contents);
+  }
+
+  /**
+   * The contiguous run of rungs from `stored` up to this build's version, or undefined
+   * when there is no complete one. Contiguity is the whole check: a missing rung means
+   * some version's rows were never accounted for, and stepping over it would hand this
+   * build rows nothing ever claimed to understand.
+   */
+  private migrationPath(stored: number): SchemaMigration[] | undefined {
+    // Only forwards. A database from a NEWER build may hold columns and rows this one
+    // cannot read at all, and no downgrade step exists to consult about them.
+    if (stored >= this.schemaVersion || stored < 0) return undefined;
+    const steps: SchemaMigration[] = [];
+    for (let v = stored + 1; v <= this.schemaVersion; v++) {
+      const step = this.migrations.find((m) => m.to === v);
+      if (!step) return undefined;
+      steps.push(step);
+    }
+    return steps;
+  }
+
+  /**
+   * Run the ladder, and stamp the new version in the same transaction. Returns undefined
+   * on success, or the reason to sideline instead.
+   *
+   * One transaction over every rung, and the stamp inside it: a database is either fully
+   * at the new version or still fully at the old one, never at some half-applied state
+   * between two that no build has a schema for. The handle is opened here (and kept, so
+   * open() does not open a second one) because migrating IS writing, and the ordering
+   * rule the probe protects is "do not write into a database this build does not
+   * understand" — a rung that exists is this build saying it understands this one.
+   */
+  private runMigrations(stored: number, steps: SchemaMigration[]): string | undefined {
+    this.openHandle();
+    const db = this.handle;
+    try {
+      db.exec('BEGIN IMMEDIATE');
+      for (const step of steps) step.up(db);
+      db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run(
+        'schemaVersion',
+        String(this.schemaVersion),
+      );
+      db.exec('COMMIT');
+    } catch (e) {
+      try {
+        db.exec('ROLLBACK');
+      } catch {
+        // Nothing to roll back (the BEGIN itself failed), which is the same outcome.
+      }
+      // Released before the sideline that follows: on Windows an open handle refuses the
+      // rename, and this object must not block the recovery it is about to prescribe.
+      // Closed raw rather than through close(), which would flush through statements this
+      // failure means were never prepared.
+      this.db?.close();
+      this.db = undefined;
+      return e instanceof Error ? e.message : String(e);
+    }
+    const what = steps.map((s) => s.what).join('; ');
+    this.storeNotice =
+      `The search index at ${this.file} was upgraded in place from schema version ${stored} to ` +
+      `${this.schemaVersion} (${what}). Nothing was re-indexed and no vectors were re-computed.`;
+    this.opts.logger?.info(this.storeNotice);
+    return undefined;
+  }
+
+  /**
    * Move a database this build must not write into out of the way, and open fresh.
    *
    * Sideline, never delete: the moved file is a complete database, evidence of the skew
@@ -310,20 +494,18 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * file that no longer exists — and in sidecarsOf order, database last, so an interruption
    * mid-move can only strand sidecars beside the moved file, never beside the fresh one.
    * One notice, on the channel status already reports storage decisions on.
+   *
+   * The moved file is also, from here on, a vector source. Its embeddings were computed
+   * from text and a model, neither of which a schema change touches, so every passage the
+   * rebuild re-reads unchanged can take its vector from here instead of paying for it a
+   * second time (#34). Armed only when the same embedder wrote it, and only then does the
+   * notice promise it.
    */
-  private async sidelineIfIncompatible(): Promise<void> {
-    // A genuinely read-only probe makes the ordering enforceable rather than documentary:
-    // in particular, journal_mode=WAL can rewrite bytes in the database header, so even
-    // the normal writable connection pragmas must wait until the stamp has been accepted.
-    const probe = new DatabaseSync(this.file, { readOnly: true });
-    let stored: number | 'fresh' | 'unstamped';
-    try {
-      probe.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
-      stored = this.storedSchemaVersion(probe);
-    } finally {
-      probe.close();
-    }
-    if (stored === 'fresh' || stored === SCHEMA_VERSION) return;
+  private async sideline(
+    stored: number | 'unstamped',
+    contents: { passages: number; vectors: number; embedderId?: string },
+    migrationFailure?: string,
+  ): Promise<void> {
     const dest = `${this.file}.incompatible-${new Date().toISOString().replace(/[:.]/g, '-')}`;
     try {
       for (const src of sidecarsOf(this.file)) {
@@ -342,12 +524,123 @@ export class SqliteSearchIndex extends SearchIndexBase {
     const said =
       stored === 'unstamped'
         ? 'carries tables but no schema stamp — an interrupted creation, or not a Zoteus index at all'
-        : `is stamped schema version ${stored}, which this build does not understand`;
+        : `is stamped schema version ${stored}, which this build does not understand` +
+          (migrationFailure ? ` and could not be upgraded (${migrationFailure})` : '');
     this.storeNotice =
       `The search index at ${this.file} ${said}. ` +
       `It was moved aside to ${dest} (nothing was deleted) and a fresh index was created; ` +
-      `rebuild it with zotero_index action:"build".`;
+      `rebuild it with zotero_index action:"build".` +
+      this.priceOf(dest, contents);
+    this.sidelineNotice = this.storeNotice;
     this.opts.logger?.warn(this.storeNotice);
+  }
+
+  /**
+   * What the rebuild a sideline just prescribed is going to cost, and how much of it the
+   * moved-aside file can pay.
+   *
+   * The old notice said an index had been moved and a rebuild was needed, and stopped
+   * there — leaving the one number that matters (five hours of local embedding on a large
+   * library, or a hosted provider's bill) to be discovered by watching a progress line
+   * (#34). Re-embedding is the expensive half, so this says how many passages it covers,
+   * and whether they have to be paid for at all: the salvage is armed here, and only when
+   * it is does the sentence promise anything.
+   */
+  private priceOf(dest: string, contents: { passages: number; vectors: number; embedderId?: string }): string {
+    if (contents.passages === 0) return '';
+    const scale = ` That rebuild re-indexes ${contents.passages} passage(s)`;
+    if (contents.vectors === 0) {
+      return `${scale}, none of which carried vectors, so it costs a crawl of the library and no embedding.`;
+    }
+    const embedder = contents.embedderId ?? 'an unrecorded embedder';
+    if (!contents.embedderId || contents.embedderId !== this.embedderId) {
+      return (
+        `${scale} and re-computes ${contents.vectors} vector(s), which is the expensive half: the moved-aside ` +
+        `index was embedded by ${embedder} and this server embeds with ${this.embedderId ?? 'no embedder'}, so ` +
+        'its vectors cannot be reused. Budget for a full re-embed.'
+      );
+    }
+    this.salvage = VectorSalvage.openIfUsable(dest, this.opts.logger);
+    if (!this.salvage) {
+      return (
+        `${scale} and re-computes ${contents.vectors} vector(s): the moved-aside index was embedded by the same ` +
+        'provider, but its vectors could not be opened for reuse. Budget for a full re-embed.'
+      );
+    }
+    return (
+      `${scale}, but not their vectors: ${contents.vectors} of them were embedded by ${embedder}, which is what ` +
+      'this server still uses, so every passage whose text is unchanged takes its vector from the moved-aside ' +
+      'index instead of being embedded again. Only genuinely new or edited text costs embedding time.'
+    );
+  }
+
+  /**
+   * Carry the salvage across process lifetimes, in both directions.
+   *
+   * The rebuild a sideline prescribes is not usually run by the process that prescribed
+   * it: the notice reaches a user through `zotero_index action:"status"`, and by the time
+   * they act the server may well have restarted. An in-process-only salvage would then
+   * have quietly expired between the sentence promising reuse and the rebuild that needed
+   * it — the worst version of this, because the promise was made in writing.
+   *
+   * So the sideline's destination is recorded in the fresh index's own meta table, and a
+   * later open re-arms from it. Two rules keep the pointer honest: it is only followed
+   * while the embedder is still the one that wrote those vectors, and a pointer that no
+   * longer resolves (the user deleted the moved-aside file, as they were told they may)
+   * is cleared rather than retried on every open.
+   */
+  private syncSalvage(): void {
+    if (this.salvage) {
+      this.storeSalvagePointer(this.salvage.path, this.embedderId);
+      return;
+    }
+    const from = this.meta('salvageFrom');
+    if (!from) return;
+    // Kept, not cleared, when the embedder differs: switching ZOTEUS_EMBEDDING_MODEL back
+    // makes those vectors usable again, and nothing about the file has changed meanwhile.
+    if ((this.meta('salvageEmbedderId') || undefined) !== this.embedderId) return;
+    this.salvage = VectorSalvage.openIfUsable(from, this.opts.logger);
+    if (!this.salvage) this.storeSalvagePointer(undefined, undefined);
+  }
+
+  /**
+   * Write (or clear) the pointer. Outside the build's transaction deliberately: it is one
+   * fact about where this index came from, and it has to be durable the moment the
+   * sideline happens rather than whenever the next build commits.
+   */
+  private storeSalvagePointer(path: string | undefined, embedderId: string | undefined): void {
+    try {
+      this.stmts.setMeta.run('salvageFrom', path ?? '');
+      this.stmts.setMeta.run('salvageEmbedderId', embedderId ?? '');
+    } catch (e) {
+      // A pointer that could not be stored costs a re-embed if the server restarts before
+      // the rebuild, which is the outcome that existed before it. Not worth an open().
+      this.opts.logger?.debug(`Could not record the vector salvage pointer: ${String(e)}`);
+    }
+  }
+
+  /**
+   * Take a passage's vector from the sidelined index rather than embedding it, when that
+   * file holds one for this exact id and this exact text. See VectorSalvage.
+   */
+  protected adoptVector(rec: ChunkRecord): boolean {
+    if (!this.salvage) return false;
+    const blob = this.salvage.vectorFor(rec.id, rec.text);
+    if (!blob) return false;
+    this.begin();
+    // The same write putVector makes, minus the float round-trip: the blob is already in
+    // the storage encoding, and decoding it to re-encode it byte-for-byte would only be a
+    // way to introduce a difference. The code bookkeeping is identical, because what makes
+    // a code stale is the vector changing, not where the vector came from.
+    if (Number(this.stmts.setVector.run(blob, rec.id).changes) > 0) this.c.vectors++;
+    if (this.hasCodes) this.stmts.deletePassageCode.run(rec.id);
+    this.invalidateCodes();
+    return true;
+  }
+
+  /** Vectors this open reused from a sidelined index instead of re-embedding them. */
+  get salvagedVectors(): number {
+    return this.salvage?.reused ?? 0;
   }
 
   /**
@@ -405,7 +698,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     `);
     this.handle
       .prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)')
-      .run('schemaVersion', String(SCHEMA_VERSION));
+      .run('schemaVersion', String(this.schemaVersion));
   }
 
   private prepareStatements(): void {
@@ -1172,6 +1465,16 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * index, and failing a build over it would be losing the library to save the cache.
    */
   protected finalizeVectors(): void {
+    // What the salvage actually spared, reported where the numbers are final rather than
+    // promised in the future tense the sideline had to use. Rewritten from the sideline's
+    // own sentence each time, so a second job over the same index updates the figure
+    // instead of appending a second one.
+    if (this.salvage && this.salvagedVectors > 0) {
+      const preamble = this.sidelineNotice ? `${this.sidelineNotice} ` : '';
+      this.storeNotice =
+        `${preamble}So far ${this.salvagedVectors} vector(s) have been reused from ${this.salvage.path} rather ` +
+        'than re-embedded.';
+    }
     // An index too small for the codes to narrow anything never reads them, so it is not
     // made to carry them either: below the candidate floor, every query scans exactly.
     if (!this.db || !this.annEnabled || this.c.vectors <= this.annMinCandidates) return;
@@ -1223,6 +1526,11 @@ export class SqliteSearchIndex extends SearchIndexBase {
   }
 
   async close(): Promise<void> {
+    // Released whether or not this object ever opened a database of its own: the salvage
+    // is a second handle on a second file, and a server that keeps it would keep a lock
+    // on the very file it told the user they may delete.
+    this.salvage?.close();
+    this.salvage = undefined;
     if (!this.db) return;
     // Whatever was indexed is worth keeping; an abandoned transaction would discard it.
     try {

--- a/src/features/search/vector-salvage.ts
+++ b/src/features/search/vector-salvage.ts
@@ -1,0 +1,110 @@
+import { createRequire } from 'node:module';
+import type { DatabaseSync as Database, StatementSync } from 'node:sqlite';
+import type { Logger } from '../../lib/logger.js';
+
+/**
+ * Required the same way the SQLite backend requires it, and for the same reason: `sqlite`
+ * is absent from `module.builtinModules` while it is experimental, so a bare import is
+ * resolved from disk by bundlers and test runners and fails. This module is only ever
+ * imported from sqlite-index.ts, which the factory loads after confirming the runtime.
+ */
+const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite') as typeof import('node:sqlite');
+
+/**
+ * Vectors read back out of an index this build had to move aside.
+ *
+ * A schema stamp this build does not understand costs the user a rebuild, and the
+ * expensive half of a rebuild is not the crawl but the embedding: 255k passages is five
+ * and a half hours on the local model, or real money on a hosted one (#34). None of that
+ * cost is inherent. An embedding is a function of exactly two things, the text and the
+ * model, and a table-layout change touches neither — so the vectors in the moved-aside
+ * file are still the right vectors for whatever the rebuild re-reads.
+ *
+ * This hands them back under three conditions, all of which must hold together:
+ *
+ *  - the moved-aside index was written by the SAME embedder (its `embedderId`, which
+ *    names provider and model, is what the caller compares before opening this at all);
+ *  - the rebuilt passage has the same id, i.e. it is the same chunk of the same item;
+ *  - and the same TEXT, byte for byte, so an item whose abstract was edited in the
+ *    meantime is re-embedded rather than given the vector of what it used to say.
+ *
+ * Read-only, and it never writes to or deletes the file it reads: the sidelined database
+ * stays exactly what the sideline promised it would be, a complete index nothing removed.
+ */
+export class VectorSalvage {
+  private db: Database | undefined;
+  private lookup: StatementSync | undefined;
+  private reusedCount = 0;
+  private readonly logger: Logger | undefined;
+  readonly path: string;
+
+  private constructor(path: string, db: Database, lookup: StatementSync, logger?: Logger) {
+    this.path = path;
+    this.db = db;
+    this.lookup = lookup;
+    this.logger = logger;
+  }
+
+  /**
+   * Open a sidelined database as a vector source, or answer undefined when it cannot serve
+   * as one. Never throws: a salvage that does not work costs a re-embed, which is exactly
+   * what would have happened anyway, so nothing here is worth failing an open over.
+   *
+   * The columns are inspected rather than assumed. The file this reads was written by a
+   * build whose schema this one does not know — that is the whole reason it was moved
+   * aside — so `passages` may have a different shape, or not exist at all.
+   */
+  static openIfUsable(path: string, logger?: Logger): VectorSalvage | undefined {
+    let db: Database | undefined;
+    try {
+      db = new DatabaseSync(path, { readOnly: true });
+      const columns = new Set(
+        (db.prepare('PRAGMA table_info(passages)').all() as Array<{ name: string }>).map((c) => c.name),
+      );
+      if (!columns.has('id') || !columns.has('text') || !columns.has('vector')) {
+        db.close();
+        return undefined;
+      }
+      // Both halves of the identity in one point lookup: `id` is UNIQUE, so this is an
+      // index seek, and the text comparison rejects a passage whose words have moved on.
+      const lookup = db.prepare('SELECT vector FROM passages WHERE id = ? AND text = ? AND vector IS NOT NULL');
+      return new VectorSalvage(path, db, lookup, logger);
+    } catch (e) {
+      db?.close();
+      logger?.debug(`Vectors could not be salvaged from ${path}: ${e instanceof Error ? e.message : String(e)}`);
+      return undefined;
+    }
+  }
+
+  /** The stored vector for this exact passage text, or undefined when there is none. */
+  vectorFor(id: string, text: string): Uint8Array | undefined {
+    if (!this.lookup) return undefined;
+    try {
+      const row = this.lookup.get(id, text) as { vector?: Uint8Array } | undefined;
+      if (!row?.vector) return undefined;
+      this.reusedCount++;
+      return row.vector;
+    } catch (e) {
+      // One unreadable row must not take a rebuild down: the passage is embedded instead,
+      // and a file that has gone bad under us stops being consulted at all.
+      this.logger?.debug(`Vector salvage stopped at ${id}: ${e instanceof Error ? e.message : String(e)}`);
+      this.close();
+      return undefined;
+    }
+  }
+
+  /** Vectors handed back so far, i.e. passages this rebuild did not have to embed. */
+  get reused(): number {
+    return this.reusedCount;
+  }
+
+  close(): void {
+    this.lookup = undefined;
+    try {
+      this.db?.close();
+    } catch {
+      // Closing a read-only handle cannot lose anything, so a failure here is not news.
+    }
+    this.db = undefined;
+  }
+}

--- a/tests/features/search-schema-migration.test.ts
+++ b/tests/features/search-schema-migration.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { nodeSqliteAvailable, sqliteIndexPath } from '../../src/features/search/factory.js';
+import type { EmbeddingProvider } from '../../src/features/search/embeddings.js';
+import type { SchemaMigration } from '../../src/features/search/sqlite-index.js';
+
+/**
+ * The upgrade path a SCHEMA_VERSION bump takes (#34).
+ *
+ * Until this existed the stamp had exactly two accepted states — no tables, or this
+ * build's own version — and everything else was moved aside and rebuilt from zero,
+ * re-embedding included. That has never fired for anyone, because the stamp has been 1
+ * since the SQLite backend landed, which is the entire point: the next bump is the
+ * expensive one, and it costs a 255k-passage library five and a half hours of local
+ * embedding (or a hosted provider's bill) for what is usually an added column.
+ *
+ * These cases play the part of the build that makes that bump, through the schemaVersion /
+ * migrations options, and pin both halves of the answer: a database at an older version of
+ * OUR schema is upgraded in place with nothing re-read and nothing re-embedded, and one
+ * nothing on the ladder reaches is still moved aside — but hands its vectors to the
+ * rebuild that replaces it, since an embedding is a function of the text and the model and
+ * a schema change touches neither.
+ */
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+
+const sqliteModule = nodeSqliteAvailable()
+  ? (createRequire(import.meta.url)('node:sqlite') as typeof import('node:sqlite'))
+  : undefined;
+const DatabaseSync = sqliteModule?.DatabaseSync as typeof import('node:sqlite').DatabaseSync;
+
+const ITEMS = [
+  { key: 'AAAAAAAA', data: { itemType: 'book', title: 'Deep learning', abstractNote: 'neural networks at scale' } },
+  { key: 'BBBBBBBB', data: { itemType: 'book', title: 'Shallow water', abstractNote: 'tidal models of estuaries' } },
+];
+
+/** Counts every text it is asked to embed, which is the cost the salvage exists to avoid. */
+class CountingEmbedder implements EmbeddingProvider {
+  readonly name = 'counting-fake';
+  calls = 0;
+  texts = 0;
+  async embed(texts: string[]): Promise<number[][]> {
+    this.calls++;
+    this.texts += texts.length;
+    return texts.map((t) => {
+      let s = 2166136261;
+      for (let i = 0; i < t.length; i++) s = (Math.imul(s ^ t.charCodeAt(i), 16777619) >>> 0) || 1;
+      return Array.from({ length: 16 }, () => {
+        s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+        return s / 4294967296 - 0.5;
+      });
+    });
+  }
+}
+
+function tmpDbPath(name: string): string {
+  return sqliteIndexPath(join(mkdtempSync(join(tmpdir(), `zoteus-${name}-`)), 'search-index.json'));
+}
+
+async function openIndex(
+  path: string,
+  opts: { embedder?: EmbeddingProvider | null; schemaVersion?: number; migrations?: SchemaMigration[] } = {},
+) {
+  const { SqliteSearchIndex } = await import('../../src/features/search/sqlite-index.js');
+  const index = new SqliteSearchIndex({
+    embedder: opts.embedder ?? null,
+    logger: silentLogger,
+    path,
+    ...(opts.schemaVersion === undefined ? {} : { schemaVersion: opts.schemaVersion }),
+    ...(opts.migrations === undefined ? {} : { migrations: opts.migrations }),
+  });
+  await index.open();
+  return index;
+}
+
+function stampSchemaVersion(dbPath: string, value: string): void {
+  const db = new DatabaseSync(dbPath);
+  db.prepare("UPDATE meta SET value = ? WHERE key = 'schemaVersion'").run(value);
+  db.close();
+}
+
+function readColumn(dbPath: string, sql: string): any {
+  const db = new DatabaseSync(dbPath);
+  const row = db.prepare(sql).get();
+  db.close();
+  return row;
+}
+
+function sidelined(dbPath: string): string[] {
+  const dir = dirname(dbPath);
+  const name = basename(dbPath);
+  return readdirSync(dir)
+    .filter((f) => f.startsWith(`${name}.incompatible-`) && !/-(wal|shm|journal)$/.test(f))
+    .map((f) => join(dir, f));
+}
+
+/** The shape of a routine bump: a column nothing already stored has to be re-derived for. */
+const ADD_COLUMN: SchemaMigration = {
+  to: 2,
+  what: 'added passages.language',
+  up: (db) => db.exec('ALTER TABLE passages ADD COLUMN language TEXT'),
+};
+
+describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
+  sqliteIt('upgrades an older index in place, keeping every passage and every vector', async () => {
+    const path = tmpDbPath('migrate-inplace');
+    const embedder = new CountingEmbedder();
+    const first = await openIndex(path, { embedder });
+    await first.build(ITEMS);
+    await first.save();
+    const before = first.status();
+    await first.close();
+    expect(before.vectors).toBeGreaterThan(0);
+    const embeddedByBuild = embedder.texts;
+
+    // The next build: same file, one version further on, with the rung that gets there.
+    const second = await openIndex(path, { embedder, schemaVersion: 2, migrations: [ADD_COLUMN] });
+    try {
+      expect(sidelined(path)).toHaveLength(0);
+      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('2');
+      // The rows themselves are untouched: same passages, same vectors, still searchable.
+      const after = second.status();
+      expect(after.documents).toBe(before.documents);
+      expect(after.vectors).toBe(before.vectors);
+      expect((await second.query('estuaries', { mode: 'keyword' })).length).toBeGreaterThan(0);
+      // And the migration is what the column change was for.
+      const columns = readColumn(path, "SELECT COUNT(*) AS n FROM pragma_table_info('passages') WHERE name = 'language'");
+      expect(columns.n).toBe(1);
+      // Nothing was re-embedded to get here.
+      expect(embedder.texts).toBe(embeddedByBuild);
+      expect(second.buildStatus().storageNotice).toMatch(/upgraded in place from schema version 1 to 2/);
+    } finally {
+      await second.close();
+    }
+  });
+
+  sqliteIt('walks every rung when a database is more than one version behind', async () => {
+    const path = tmpDbPath('migrate-ladder');
+    const first = await openIndex(path);
+    await first.build(ITEMS);
+    await first.save();
+    await first.close();
+
+    const ran: number[] = [];
+    const ladder: SchemaMigration[] = [
+      { to: 2, what: 'added passages.language', up: (db) => { ran.push(2); db.exec('ALTER TABLE passages ADD COLUMN language TEXT'); } },
+      { to: 3, what: 'indexed passages.language', up: (db) => { ran.push(3); db.exec('CREATE INDEX passages_language ON passages(language)'); } },
+    ];
+    const second = await openIndex(path, { schemaVersion: 3, migrations: ladder });
+    try {
+      expect(ran).toEqual([2, 3]);
+      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('3');
+      expect(second.status().documents).toBeGreaterThan(0);
+    } finally {
+      await second.close();
+    }
+  });
+
+  sqliteIt('sidelines rather than migrating when the ladder has a gap', async () => {
+    const path = tmpDbPath('migrate-gap');
+    const first = await openIndex(path);
+    await first.build(ITEMS);
+    await first.save();
+    await first.close();
+
+    // Version 3 exists, version 2 does not: nothing accounts for what version 2's rows
+    // were, so stepping over it would be a guess rather than a migration.
+    const gapped: SchemaMigration[] = [{ to: 3, what: 'added a column', up: (db) => db.exec('ALTER TABLE passages ADD COLUMN language TEXT') }];
+    const second = await openIndex(path, { schemaVersion: 3, migrations: gapped });
+    try {
+      expect(sidelined(path)).toHaveLength(1);
+      expect(second.status().documents).toBe(0);
+    } finally {
+      await second.close();
+    }
+  });
+
+  sqliteIt('leaves the database exactly as it was when a rung throws, then sidelines it', async () => {
+    const path = tmpDbPath('migrate-failure');
+    const first = await openIndex(path);
+    await first.build(ITEMS);
+    await first.save();
+    const documents = first.status().documents;
+    await first.close();
+
+    const broken: SchemaMigration[] = [
+      {
+        to: 2,
+        what: 'added passages.language',
+        up: (db) => {
+          db.exec('ALTER TABLE passages ADD COLUMN language TEXT');
+          throw new Error('rung failed halfway');
+        },
+      },
+    ];
+    const second = await openIndex(path, { schemaVersion: 2, migrations: broken });
+    try {
+      // The moved-aside file is the ORIGINAL: still at version 1, still holding its rows,
+      // and without the half-applied column — the rung and the stamp share one transaction.
+      const aside = sidelined(path);
+      expect(aside).toHaveLength(1);
+      expect(readColumn(aside[0], "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('1');
+      expect(readColumn(aside[0], 'SELECT COUNT(*) AS n FROM passages').n).toBe(documents);
+      expect(readColumn(aside[0], "SELECT COUNT(*) AS n FROM pragma_table_info('passages') WHERE name = 'language'").n).toBe(0);
+      // And the fresh index at the original path says why it is empty.
+      expect(second.status().documents).toBe(0);
+      expect(second.buildStatus().storageNotice).toMatch(/could not be upgraded \(rung failed halfway\)/);
+    } finally {
+      await second.close();
+    }
+  });
+
+  sqliteIt('never migrates downwards: a newer build\'s database is still moved aside', async () => {
+    const path = tmpDbPath('migrate-newer');
+    const first = await openIndex(path);
+    await first.build(ITEMS);
+    await first.save();
+    await first.close();
+    stampSchemaVersion(path, '99');
+
+    const second = await openIndex(path, { schemaVersion: 2, migrations: [ADD_COLUMN] });
+    try {
+      expect(sidelined(path)).toHaveLength(1);
+      expect(readColumn(sidelined(path)[0], "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('99');
+      expect(second.status().documents).toBe(0);
+    } finally {
+      await second.close();
+    }
+  });
+});
+
+describe('a sideline hands its vectors to the rebuild that replaces it', () => {
+  sqliteIt('reuses a vector for a passage whose text is unchanged, and re-embeds one whose text moved', async () => {
+    const path = tmpDbPath('salvage-reuse');
+    const embedder = new CountingEmbedder();
+    const first = await openIndex(path, { embedder });
+    await first.build(ITEMS);
+    await first.save();
+    const built = first.status();
+    await first.close();
+    expect(built.vectors).toBeGreaterThan(0);
+
+    // A stamp this build cannot reach: the sideline, and the full rebuild behind it.
+    stampSchemaVersion(path, '99');
+    const embedded = embedder.texts;
+    const second = await openIndex(path, { embedder });
+    try {
+      expect(sidelined(path)).toHaveLength(1);
+      expect(second.buildStatus().storageNotice).toMatch(/takes its vector from the moved-aside index/);
+
+      // One item comes back unchanged and one comes back with a new abstract.
+      const edited = [ITEMS[0], { key: 'BBBBBBBB', data: { itemType: 'book', title: 'Shallow water', abstractNote: 'a completely different subject' } }];
+      await second.build(edited);
+      await second.save();
+
+      const after = second.status();
+      expect(after.vectors).toBe(built.vectors);
+      // Only the passages whose text actually changed were bought again.
+      expect(embedder.texts).toBeGreaterThan(embedded);
+      expect(embedder.texts - embedded).toBeLessThan(built.vectors);
+      expect(after.storageNotice).toMatch(/vector\(s\) have been reused from .*incompatible-.* rather than re-embedded/);
+      // The reused vectors are the same numbers, not merely the same count: a semantic
+      // query still ranks the untouched item first for its own words.
+      const hits = await second.query('neural networks at scale', { mode: 'semantic' });
+      expect(hits[0]?.itemKey).toBe('AAAAAAAA');
+    } finally {
+      await second.close();
+    }
+  });
+
+  sqliteIt('still reuses them when the server restarts between the sideline and the rebuild', async () => {
+    const path = tmpDbPath('salvage-restart');
+    const embedder = new CountingEmbedder();
+    const first = await openIndex(path, { embedder });
+    await first.build(ITEMS);
+    await first.save();
+    const built = first.status();
+    await first.close();
+    stampSchemaVersion(path, '99');
+
+    // The process that sidelines is rarely the one that rebuilds: the notice reaches a
+    // user through action:"status", and by the time they act the server may have restarted.
+    const sidelining = await openIndex(path, { embedder });
+    await sidelining.close();
+
+    const embedded = embedder.texts;
+    const rebuilding = await openIndex(path, { embedder });
+    try {
+      await rebuilding.build(ITEMS);
+      expect(rebuilding.status().vectors).toBe(built.vectors);
+      expect(embedder.texts).toBe(embedded);
+    } finally {
+      await rebuilding.close();
+    }
+  });
+
+  sqliteIt('stops pointing at a moved-aside index the user has since deleted', async () => {
+    const path = tmpDbPath('salvage-deleted');
+    const first = await openIndex(path, { embedder: new CountingEmbedder() });
+    await first.build(ITEMS);
+    await first.save();
+    await first.close();
+    stampSchemaVersion(path, '99');
+
+    const sidelining = await openIndex(path, { embedder: new CountingEmbedder() });
+    await sidelining.close();
+    // "nothing was deleted" is the promise; deleting it afterwards is the user's right.
+    rmSync(sidelined(path)[0]);
+
+    const embedder = new CountingEmbedder();
+    const after = await openIndex(path, { embedder });
+    try {
+      await after.build(ITEMS);
+      expect(after.status().vectors).toBe(2);
+      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'salvageFrom'").v).toBe('');
+    } finally {
+      await after.close();
+    }
+  });
+
+  sqliteIt('refuses to reuse vectors another embedder produced, and says the rebuild must pay', async () => {
+    const path = tmpDbPath('salvage-embedder');
+    const first = await openIndex(path, { embedder: new CountingEmbedder() });
+    await first.build(ITEMS);
+    await first.save();
+    await first.close();
+    stampSchemaVersion(path, '99');
+
+    const other = new CountingEmbedder();
+    (other as { name: string }).name = 'another-fake';
+    const second = await openIndex(path, { embedder: other });
+    try {
+      const notice = second.buildStatus().storageNotice ?? '';
+      expect(notice).toMatch(/cannot be reused/);
+      expect(notice).toMatch(/Budget for a full re-embed/);
+      const before = other.texts;
+      await second.build(ITEMS);
+      // Every passage was embedded by the new provider: nothing was taken from the old file.
+      expect(other.texts - before).toBe(second.status().vectors);
+    } finally {
+      await second.close();
+    }
+  });
+
+  sqliteIt('prices the rebuild it prescribes even when there is nothing to salvage', async () => {
+    const path = tmpDbPath('salvage-priced');
+    const first = await openIndex(path);
+    await first.build(ITEMS);
+    await first.save();
+    const documents = first.status().documents;
+    await first.close();
+    stampSchemaVersion(path, '99');
+
+    const second = await openIndex(path);
+    try {
+      const notice = second.buildStatus().storageNotice ?? '';
+      expect(notice).toMatch(new RegExp(`re-indexes ${documents} passage\\(s\\)`));
+      expect(notice).toMatch(/no embedding/);
+    } finally {
+      await second.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #34.

The stamp had two accepted states — no tables, or this build's own version — and everything else was moved aside and rebuilt from zero, **including a database stamped with an older version of our own schema**. Nothing has ever hit it, because `SCHEMA_VERSION` has been 1 since the SQLite backend landed, and that is exactly the point: the next bump is the one that charges every index in the field a full re-embed (a measured 5.5 hours of local CPU at 255k passages, or a hosted provider's bill) for what is usually an added column.

Two answers, because a bump has two kinds.

**A ladder of upgrade steps** carries an older index forward in place. Each step runs inside the one transaction that stamps the new version, so a database is either fully upgraded or fully untouched, and a step that throws rolls back and falls through to the sideline. The ladder must be contiguous: a gap means some version's rows were never accounted for, so that sidelines rather than guesses. The ladder is empty today — the contract for whoever bumps next is written on `SchemaMigration`.

**A sideline hands its vectors to the rebuild that replaces it.** Where moving the file aside is still right (a newer build's database, an unstamped file, a gap in the ladder), the moved-aside index stays open as a read-only vector source: a passage that comes back with the same id and byte-identical text takes its stored vector rather than being embedded again, since an embedding is a function of the text and the model and a schema change touches neither. Reuse is refused outright when the embedder identity (provider *and* model) differs, and the pointer is persisted in the fresh index's meta, because the process that sidelines is rarely the one that rebuilds — the notice reaches a user through `action:"status"`, and by then the server may have restarted.

`storageNotice` now also **prices** the rebuild it prescribes: how many passages, how many vectors, and whether they must be paid for.

10 new cases in `tests/features/search-schema-migration.test.ts`, which play the part of the build that makes the bump through test-only `schemaVersion` / `migrations` options: migration in place, a multi-rung ladder, the gap, a rung that throws (the moved file is the original, at its old stamp, without the half-applied column), no downgrades, vector reuse with an edited item re-embedded, reuse across a restart, a deleted sidelined file, and a different embedder refusing to reuse. Suite: 867 passing.