### PR TITLE
fix(search): answer a query of common words on what the user typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A query made mostly of common words returned a confident wrong answer instead of an
+  honest one.** `tokenize()` dropped 29 English function words from every query, and
+  `to be or not to be` is all of them except `not` — so the search that ran was a
+  single-term OR on a word that means nothing, and what came back was whatever prose
+  happened to contain it. Not an empty result, which would at least have been honest.
+  Pruning now stops when it would change the question rather than shorten it, and the
+  list moved off the document side: `tokenize()` is also the in-memory backend's document
+  tokenizer, so the list was deleting those terms from the index, and a term that is not
+  indexed cannot be searched for even deliberately. Both backends now index every term and
+  only queries prune; ordinary queries are unaffected.
+
 ## [1.12.0] - 2026-08-31
 
 ### Fixed

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -487,6 +487,18 @@ construction. The JS fold deliberately reproduces `unicode61` and no more — `�
 þ ß` are letters to unicode61 rather than accented forms, so they are letters here too,
 and `søren` does not answer to `soren`.
 
+**Common words.** Some words are too common in a library to rank on — searching them
+walks a long posting list to separate almost nothing — so they are dropped from the query
+before it runs. They are still indexed — only queries prune, and both backends index every
+term — so a search that needs one of these words can still reach the documents holding it.
+
+Dropping them stops when it would change the question rather than shorten it. If fewer
+terms survive the prune than were dropped, the query runs on what you typed instead: `to
+be or not to be` is otherwise answered by a single-word search for `not`, which returns a
+confidently-ranked page of unrelated results. If nothing survives at all, the search
+returns nothing, as it always has — a query of nothing but common words has no answer to
+give, and inventing one would be slower and no more useful.
+
 **Where the files are.** `<ZOTEUS_DATA_DIR>/search-index.sqlite` beside the older
 `search-index.json` (and `search-index-<userId>.*` per tenant in multi-tenant mode). SQLite
 also writes `-wal` and `-shm` sidecar files while the database is open; a clean shutdown

--- a/src/features/search/bm25.ts
+++ b/src/features/search/bm25.ts
@@ -1,8 +1,8 @@
-import { tokenize } from './tokenize.js';
+import { pruneTerms } from './query-terms.js';
+import { isStopword, tokenize } from './tokenize.js';
 
 interface Doc {
   id: string;
-  tokens: string[];
   length: number;
   tf: Map<string, number>;
 }
@@ -41,7 +41,7 @@ export class BM25Index {
     const tf = new Map<string, number>();
     for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
     for (const term of tf.keys()) this.df.set(term, (this.df.get(term) ?? 0) + 1);
-    this.docs.set(id, { id, tokens, length: tokens.length, tf });
+    this.docs.set(id, { id, length: tokens.length, tf });
     this.totalLength += tokens.length;
   }
 
@@ -61,7 +61,7 @@ export class BM25Index {
 
   search(query: string, topK = 10): BM25Hit[] {
     if (this.docs.size === 0) return [];
-    const qTerms = [...new Set(tokenize(query))];
+    const qTerms = pruneTerms([...new Set(tokenize(query))], isStopword);
     const avgdl = this.totalLength / this.docs.size;
     const N = this.docs.size;
 

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -1,7 +1,8 @@
 import { BM25Index } from './bm25.js';
 import { VectorStore } from './vector-store.js';
 import { chunkText } from './chunker.js';
-import { normalizeForSearch, tokenize } from './tokenize.js';
+import { pruneTerms } from './query-terms.js';
+import { isStopword, normalizeForSearch, tokenize } from './tokenize.js';
 import { batchPause, embedderIdentity } from './embeddings.js';
 import {
   DEFAULT_EMBED_BATCH_SIZE,
@@ -160,7 +161,7 @@ export function makeSnippet(text: string, query: string, max = 240): string {
   // start at character 0.
   const folded = normalizeForSearch(clean);
   let pos = -1;
-  for (const t of tokenize(query)) {
+  for (const t of pruneTerms(tokenize(query), isStopword)) {
     const i = folded.indexOf(t);
     if (i >= 0 && (pos < 0 || i < pos)) pos = i;
   }

--- a/src/features/search/query-terms.ts
+++ b/src/features/search/query-terms.ts
@@ -1,0 +1,58 @@
+/**
+ * Which terms a query is actually answered on, and what to do when that leaves nothing.
+ *
+ * Search drops the words that appear nearly everywhere: their posting lists are long and
+ * their presence separates almost nothing. That is a good trade on an ordinary query and a
+ * silent failure on a query made entirely of such words, because what is left is not a
+ * shorter version of the question — there is no question left.
+ *
+ * `to be or not to be` is the defect in one line. Every word of it was on the list except
+ * `not`, so one term limped through and the search that ran was a single-term OR on a word
+ * that appears in a quarter of an academic library. The user got a confidently-ranked page
+ * of results unrelated to what they typed. Not an empty result, which would at least be
+ * honest; a wrong one.
+ *
+ * **The rule never fires while anything survives, and that restraint is the whole design.**
+ * A version of this fell back whenever the prune left fewer terms than it dropped, which
+ * sounds careful and is not: `in the brain` keeps one content word, drops two common ones,
+ * and would have run unpruned — putting a document that says `in the ` sixty times ahead of
+ * the one about brains. That is this defect arriving from the other direction, on a far
+ * more ordinary query. Nothing distinguishes an accidental survivor like `not` from a real
+ * one like `brain` except how common each is, and a fixed list cannot know that. So a fixed
+ * list must not guess: if a term survived, it is the query, and it is what runs.
+ *
+ * That leaves only the case where nothing survived, where there is no content word to
+ * demote and the choice is safe to make. One or two common words are not a question —
+ * `the`, `of the` — and search has always answered those with nothing, instantly. Three or
+ * more are a phrase, and a phrase the user typed is worth running even though every word of
+ * it is common. Measured, the bare query `the` costs 0 ms and returns nothing where running
+ * it costs 750 ms and returns ten unrelated documents, and the fold makes that path
+ * reachable from real words in other languages: `thé` is French for tea and lands on `the`.
+ */
+
+/** Whether a term is common enough in this index to be worth dropping from a query. */
+export type TermPredicate = (term: string) => boolean;
+
+/**
+ * Distinct terms a query needs before it is worth running unpruned when every one of them
+ * is common.
+ *
+ * Three, and the number is doing less work than it looks. It is not tuned to any query: it
+ * separates "one or two common words", which search has always answered with nothing, from
+ * "a phrase", which the user plainly meant. The rule it guards applies only when the prune
+ * left nothing at all, so no choice of this number can demote a content word.
+ */
+export const MIN_PHRASE_TERMS = 3;
+
+/**
+ * The terms to search on: the common ones removed, and the caller's own set back only when
+ * removing them left nothing and there was a phrase to recover. See the header.
+ */
+export function pruneTerms(terms: string[], prunable: TermPredicate): string[] {
+  const kept = terms.filter((t) => !prunable(t));
+  // Something survived. It is the query — never second-guess it.
+  if (kept.length) return kept;
+  // Nothing survived. A phrase runs as typed; one or two common words answer as they always
+  // have, with nothing, for free.
+  return terms.length >= MIN_PHRASE_TERMS ? terms : kept;
+}

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -4,7 +4,8 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, rename, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
-import { tokenize } from './tokenize.js';
+import { pruneTerms } from './query-terms.js';
+import { isStopword, tokenize } from './tokenize.js';
 import { SearchIndexCorruptError, isCorruptionError, isQuerySyntaxError, sidecarsOf } from './corruption.js';
 import { VectorSalvage } from './vector-salvage.js';
 import { DEFAULT_ANN_MIN_CANDIDATES, DEFAULT_ANN_OVERSAMPLE } from './limits.js';
@@ -1132,7 +1133,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * scale of their scores.
    */
   protected keywordSearch(q: string, topK: number): RankedId[] {
-    const terms = [...new Set(tokenize(q))];
+    const terms = pruneTerms([...new Set(tokenize(q))], isStopword);
     if (!terms.length) return [];
     const match = terms.map(ftsTerm).join(' OR ');
     try {

--- a/src/features/search/tokenize.ts
+++ b/src/features/search/tokenize.ts
@@ -1,7 +1,28 @@
+/**
+ * The words this search treats as too common to rank on.
+ *
+ * Consulted on the query side only, and only through `pruneTerms`, which restores the
+ * whole token set when dropping these would leave too little to answer with. It used to
+ * be applied here instead, inside `tokenize()`, which meant it also governed what the
+ * in-memory backend *indexed* — and a term absent from the index cannot be searched for
+ * even deliberately, which is what made the fallback impossible to write.
+ */
 const STOPWORDS = new Set([
   'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'is', 'are', 'was', 'were',
   'be', 'by', 'as', 'at', 'that', 'this', 'it', 'from', 'we', 'our', 'their', 'its', 'these', 'those',
+  // `not` is the thirtieth, and its absence is what made `to be or not to be` return a wrong
+  // answer rather than no answer: every other word of that line was already here, so one
+  // term limped through and the search ran as a single-term OR on it. Added alone, and
+  // deliberately — the list omits plenty of other common words (`no`, `but`, `which`,
+  // `when`), but which of them matter is a property of the corpus rather than of English,
+  // and guessing further here is the habit this list should be losing.
+  'not',
 ]);
+
+/** Whether a term is on the list above. The `TermPredicate` a query is pruned by. */
+export function isStopword(term: string): boolean {
+  return STOPWORDS.has(term);
+}
 
 /**
  * Combining marks sitting on a **Latin** base, which is the only place
@@ -140,15 +161,20 @@ function shield(chars: string, base: number): { hide: (s: string) => string; sho
 const NO_TRANSFORM_SHIELD = shield(NO_TRANSFORM, 0xfdd0);
 
 /**
- * Fold, split on non-alphanumerics, drop stopwords and 1-char tokens.
+ * Fold, split on non-alphanumerics, drop 1-char tokens.
  *
  * The token class is `\p{L}\p{N}`, not `[a-z0-9]`, and that half earns its place on its
  * own: it keeps `théorie`, `Θεωρία`, `теория` and `日本語` single tokens instead of
  * fragments, and it would have prevented this defect even without the fold — a whole token
  * misses cleanly, a fragment matches a high-frequency English string.
+ *
+ * **The stopword list no longer lives here**, and that is the point of the change rather
+ * than tidying. This function is the *document* tokenizer as well as the query one on the
+ * in-memory backend, so dropping a word here deleted it from the index, and a term the
+ * index does not hold cannot be searched for on purpose. Pruning is now a query-side
+ * decision, taken in `query-terms.ts`, where it can be undone when it would leave the
+ * query with nothing to say. Both backends index every term; only queries prune.
  */
 export function tokenize(text: string): string[] {
-  return (normalizeForSearch(text).match(/[\p{L}\p{N}]+/gu) ?? []).filter(
-    (t) => t.length > 1 && !STOPWORDS.has(t),
-  );
+  return (normalizeForSearch(text).match(/[\p{L}\p{N}]+/gu) ?? []).filter((t) => t.length > 1);
 }

--- a/tests/features/accent-folding.test.ts
+++ b/tests/features/accent-folding.test.ts
@@ -144,7 +144,11 @@ describe.each(backends)('accent folding (%s backend)', (backend) => {
     await index.close();
   });
 
-  it('still answers [] rather than throwing when nothing survives tokenization', async () => {
+  it('still answers [] rather than throwing when nothing survives tokenization or pruning', async () => {
+    // Two different emptinesses, and both must stay empty. `!!!` survives neither the
+    // token class nor anything after it; `the a an of` now survives tokenization — the
+    // list moved out of it — and is emptied one step later by the query-side prune, which
+    // deliberately does NOT fall back when nothing at all is left. See query-terms.ts.
     const index = await oneDoc('un élève très appliqué');
     expect(await hits(index, '!!! ??? ***')).toEqual([]);
     expect(await hits(index, 'the a an of')).toEqual([]);
@@ -187,8 +191,11 @@ describe('tokenize', () => {
     expect(tokenize('日本語の研究')).toEqual(['日本語の研究']);
   });
 
-  it('still drops stopwords and one-character tokens', () => {
-    expect(tokenize('the a of neural x networks')).toEqual(['neural', 'networks']);
+  it('drops one-character tokens, and nothing else', () => {
+    // The stopword list moved to the query side (`query-terms.ts`), so this function is
+    // now the document tokenizer without exception: what it returns is what gets indexed,
+    // and a term that is never indexed cannot be searched for even on purpose.
+    expect(tokenize('the a of neural x networks')).toEqual(['the', 'of', 'neural', 'networks']);
   });
 });
 

--- a/tests/features/search-backends.test.ts
+++ b/tests/features/search-backends.test.ts
@@ -343,12 +343,20 @@ describe('the SQLite backend answers the same queries as the JSON one', () => {
     await sqlite.close();
   });
 
-  sqliteIt('tokenizes the query exactly like the JSON backend, stopwords included', async () => {
+  sqliteIt('tokenizes the query exactly like the JSON backend, common words included', async () => {
     const { memory, sqlite } = await both();
-    // "of"/"the" are dropped by tokenize.ts, so a query made only of them matches nothing
-    // on either backend rather than erroring or returning everything.
+    // A query of nothing but common words matches nothing on either backend, rather than
+    // erroring or returning everything. The mechanism moved — the words are no longer
+    // dropped by tokenize(), they are pruned query-side and nothing survives the prune —
+    // but the answer is the same, and that it is the same on BOTH backends is the point.
+    // Note the fixture below does contain `for` and `and`, so this is not green for want
+    // of the words being present anywhere.
     expect(await sqlite.query('of the', { mode: 'keyword' })).toEqual([]);
     expect(await memory.query('of the', { mode: 'keyword' })).toEqual([]);
+    // The case the assertion above stood in for and could not reach: a common word that
+    // IS in the fixture. Still nothing, still the same nothing on both sides.
+    expect(await sqlite.query('for and', { mode: 'keyword' })).toEqual([]);
+    expect(await memory.query('for and', { mode: 'keyword' })).toEqual([]);
     // Punctuation is not FTS5 syntax here: every term is quoted before it is OR-ed.
     const hits = await sqlite.query('"gardening" OR (tomatoes*)', { limit: 3, mode: 'keyword' });
     expect(hits[0]!.itemKey).toBe('B');

--- a/tests/features/search-degenerate-query.test.ts
+++ b/tests/features/search-degenerate-query.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import { createSearchIndex, nodeSqliteAvailable } from '../../src/features/search/factory.js';
+import { MemorySearchIndex, makeSnippet } from '../../src/features/search/index-manager.js';
+import type { SearchIndex } from '../../src/features/search/backend.js';
+import { isStopword, tokenize } from '../../src/features/search/tokenize.js';
+import { MIN_PHRASE_TERMS, pruneTerms } from '../../src/features/search/query-terms.js';
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+
+/**
+ * Ten items, and two of them carry the whole argument.
+ *
+ * `H` is the only item holding the soliloquy, so it is the right answer to the degenerate
+ * query. `D` is the decoy that makes the defect visible rather than theoretical: `not` is
+ * the one word of `to be or not to be` that the shipped 29-word list does NOT carry, so on
+ * a stock build the query reaches MATCH as the single term `not`, and D — which says
+ * nothing else — is what comes back. A confident answer to a question nobody asked.
+ */
+const items = [
+  { key: 'H', data: { itemType: 'book', title: 'Hamlet', abstractNote: 'To be or not to be that is the question, whether tis nobler to suffer' } },
+  { key: 'D', data: { itemType: 'book', title: 'Refusals', abstractNote: 'Not not not not not: a study of negation and of refusal in the abstract' } },
+  { key: 'G', data: { itemType: 'book', title: 'Organic gardening', abstractNote: 'Growing tomatoes and herbs in the greenhouse' } },
+  { key: 'V', data: { itemType: 'journalArticle', title: 'Computer vision', abstractNote: 'Convolutional networks classify the images' } },
+  { key: 'R', data: { itemType: 'journalArticle', title: 'Reinforcement', abstractNote: 'Reward shaping for the policies of an agent' } },
+  { key: 'C', data: { itemType: 'book', title: 'Cartography', abstractNote: 'Projections of the sphere onto the plane' } },
+  { key: 'B', data: { itemType: 'book', title: 'Baking', abstractNote: 'Sourdough starters and the rye loaf' } },
+  { key: 'M', data: { itemType: 'book', title: 'Mycology', abstractNote: 'Fruiting bodies of the fungi to be catalogued' } },
+  { key: 'A', data: { itemType: 'book', title: 'Astronomy', abstractNote: 'Occultations of the outer planets to be timed' } },
+  { key: 'P', data: { itemType: 'book', title: 'Pottery', abstractNote: 'Slipware and the reduction firing of a kiln' } },
+  // The decoy for the OTHER direction: it says `in the` over and over and nothing about
+  // greenhouses, so it outranks the real answer on any query that abandons pruning.
+  { key: 'I', data: { itemType: 'book', title: 'In the', abstractNote: 'In the in the in the in the in the in the in the in the in the in the' } },
+];
+
+async function sqliteIndex(): Promise<SearchIndex> {
+  const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath: '' });
+  await index.build(items);
+  return index;
+}
+
+async function memoryIndex(): Promise<SearchIndex> {
+  const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+  await index.build(items);
+  return index;
+}
+
+const keys = async (index: SearchIndex, q: string, limit = 10): Promise<string[]> =>
+  (await index.query(q, { limit, mode: 'keyword' })).map((h) => h.itemKey);
+
+describe('pruneTerms', () => {
+  const prunable = (t: string) => ['the', 'of', 'to', 'in'].includes(t);
+
+  it('drops the common terms when any content term survives', () => {
+    expect(pruneTerms(['the', 'neural', 'networks'], prunable)).toEqual(['neural', 'networks']);
+  });
+
+  it('never abandons pruning while a term survives, however much was dropped', () => {
+    // The property the whole design rests on, and the one an earlier version of this rule
+    // got wrong. `in the brain` keeps one content word and drops two common ones; running
+    // it unpruned puts documents that merely say "in the" ahead of the one about brains.
+    // If a term survived, it is the query.
+    expect(pruneTerms(['in', 'the', 'brain'], prunable)).toEqual(['brain']);
+    expect(pruneTerms(['in', 'the', 'of', 'to', 'brain'], prunable)).toEqual(['brain']);
+  });
+
+  it('runs a phrase as typed when nothing at all survives', () => {
+    expect(pruneTerms(['to', 'be', 'or', 'not'], () => true)).toEqual(['to', 'be', 'or', 'not']);
+  });
+
+  it('answers one or two common words with nothing, as search always has', () => {
+    // Not the raw set: replacing a free honest miss with a slow arbitrary hit is not an
+    // improvement. Measured, the bare query `the` goes from 0 ms and no results to 750 ms
+    // and ten unrelated documents.
+    expect(pruneTerms(['the'], prunable)).toEqual([]);
+    expect(pruneTerms(['of', 'the'], prunable)).toEqual([]);
+    expect(MIN_PHRASE_TERMS).toBe(3);
+  });
+});
+
+describe('a query that prunes down to nothing is answered on what the user typed', () => {
+  it('reduced to a single meaningless term before `not` was on the list', () => {
+    // The control, stated where it can still be stated: with the list as it shipped, the
+    // whole line pruned down to `not` — one word, and one that means nothing — so the
+    // search that ran was a single-term OR and the decoy below is what it returned. The old
+    // list is written out here rather than imported, because the point is what it lacked.
+    const asShipped = new Set([
+      'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'is', 'are', 'was',
+      'were', 'be', 'by', 'as', 'at', 'that', 'this', 'it', 'from', 'we', 'our', 'their', 'its',
+      'these', 'those',
+    ]);
+    expect(pruneTerms([...new Set(tokenize('to be or not to be'))], (t) => asShipped.has(t))).toEqual(['not']);
+    // And with `not` on it, nothing survives — so the phrase runs as typed instead.
+    expect(pruneTerms([...new Set(tokenize('to be or not to be'))], isStopword))
+      .toEqual([...new Set(tokenize('to be or not to be'))]);
+  });
+
+  sqliteIt('returns the soliloquy, not the decoy', async () => {
+    const index = await sqliteIndex();
+    // D is what the single-term OR on `not` returned: it says nothing else, and `not` five
+    // times. H holds the line. The phrase now runs whole, and H is what comes back.
+    expect((await keys(index, 'negation refusal'))[0]).toBe('D');
+    expect((await keys(index, 'to be or not to be'))[0]).toBe('H');
+    await index.close();
+  });
+
+  sqliteIt('leaves an ordinary query with one content word pruned, whatever surrounds it', async () => {
+    const index = await sqliteIndex();
+    // The regression this rule exists to prevent, at the level a user would feel it. The
+    // fixture holds an item that says "in the" and nothing about greenhouses; if the prune
+    // were abandoned here it would rank ahead of G on the common words alone.
+    for (const q of ['the greenhouse', 'in the greenhouse', 'in the of the greenhouse']) {
+      expect((await keys(index, q))[0], q).toBe('G');
+    }
+    await index.close();
+  });
+
+  sqliteIt('sends a degenerate query exactly what an unpruned one would send', async () => {
+    const index = await sqliteIndex();
+    // The fallback's contract as an identity rather than as a spot check.
+    const degenerate = await keys(index, 'to be or not to be', 20);
+    const unfiltered = await keys(index, [...new Set(tokenize('to be or not to be'))].join(' '), 20);
+    expect(degenerate).toEqual(unfiltered);
+    expect(degenerate.length).toBeGreaterThan(1);
+    await index.close();
+  });
+
+  sqliteIt('leaves an ordinary query pruned exactly as before', async () => {
+    const index = await sqliteIndex();
+    // The other half of the contract, and the one a reviewer should care about most: three
+    // content terms survive, the floor is met, and the function words are dropped as they
+    // always were. Nothing about ordinary search changes.
+    expect(pruneTerms([...new Set(tokenize('the growing of tomatoes in the greenhouse'))], isStopword))
+      .toEqual(['growing', 'tomatoes', 'greenhouse']);
+    expect(await keys(index, 'the growing of tomatoes in the greenhouse')).toEqual(['G']);
+    await index.close();
+  });
+
+  sqliteIt('answers a bare common word with nothing, and does it for free', async () => {
+    const index = await sqliteIndex();
+    // The regression this rule exists to avoid, pinned on both spellings. `thé` is French
+    // for tea and the tokenizer folds it onto `the`, so a French tea query reaches exactly
+    // this path — and must not come back with a page of English documents.
+    expect(await keys(index, 'the', 20)).toEqual([]);
+    expect(await keys(index, 'thé', 20)).toEqual([]);
+    expect(await keys(index, 'of the', 20)).toEqual([]);
+    await index.close();
+  });
+
+  sqliteIt('leaves a short query with one content word on the pruned path', async () => {
+    const index = await sqliteIndex();
+    // One common word dropped, one content word kept, and the content word alone is the
+    // right query — not the pair. G is the only item about greenhouses.
+    expect(await keys(index, 'the greenhouse')).toEqual(['G']);
+    await index.close();
+  });
+
+  sqliteIt('answers the same on both backends', async () => {
+    const sqlite = await sqliteIndex();
+    const memory = await memoryIndex();
+    // The item SET, not its order: the two engines score differently and the existing
+    // parity suite compares them the same way. What is asserted is that the same terms
+    // reached each one.
+    for (const q of ['to be or not to be', 'the growing of tomatoes in the greenhouse', 'of the']) {
+      expect((await keys(sqlite, q, 20)).sort(), `sqlite vs memory on "${q}"`).toEqual((await keys(memory, q, 20)).sort());
+    }
+    await sqlite.close();
+  });
+});
+
+describe('both backends index every term, so the fallback has something to match', () => {
+  it('tokenize no longer consults the list', () => {
+    // The document side. It used to drop these, which is why the in-memory backend could
+    // not answer a fallback query at all: the terms were not in it.
+    expect(tokenize('the a of neural x networks')).toEqual(['the', 'of', 'neural', 'networks']);
+  });
+
+  it('the in-memory backend answers the phrase on terms it had to have indexed', async () => {
+    const memory = await memoryIndex();
+    // The index-side half of the fix, and the half a query-side-only patch would silently
+    // omit. `addDoc` used to tokenize the list away, so `to`, `be` and `or` were not in this
+    // backend at all: the phrase would have matched nothing whatever the query side did.
+    expect((await keys(memory, 'to be or not to be'))[0]).toBe('H');
+    await memory.close();
+  });
+});
+
+describe('snippets take the same rule', () => {
+  const filler = 'the of and to be '.repeat(40);
+  const text = `${filler}the tomatoes ripened in the greenhouse ${filler}`;
+
+  it('centres on the content word rather than the passage opening', () => {
+    // One term survives, and one is enough to know where to look.
+    expect(makeSnippet(text, 'the tomatoes')).toContain('tomatoes');
+  });
+
+  it('falls back to the passage opening only when nothing at all survives', () => {
+    // Nothing left to centre on: the snippet is where it has always been, at character 0,
+    // which is the pre-existing behaviour and not a regression this introduces.
+    expect(makeSnippet(text, 'the of and')).not.toContain('tomatoes');
+  });
+});


### PR DESCRIPTION
## Answer a query of common words on what the user typed

### The problem

`to be or not to be` returns a confidently-ranked page of results about nothing.
Twenty-nine English function words are dropped from every query, and every word of that
line is on the list except `not` — so the search that actually runs is a single-term OR
on a word that appears in a quarter of an academic library's passages, and what comes
back is whatever prose happens to contain it. Not an empty result, which would at least
be honest: a wrong one, with no way for the user to tell.

### What this changes

Two changes, and the second is smaller than it looks.

**`not` joins the list.** It is added alone and deliberately: the list omits plenty of
other common words — `no`, `but`, `which`, `when` — but which of them matter is a
property of the corpus rather than of English, and guessing further here is a habit this
list should be losing. With `not` on it, the line prunes to nothing rather than to one
meaningless term.

**A query that prunes to nothing runs as typed, if it was a phrase.** One or two common
words are not a question — `the`, `of the` — and search has always answered those with
nothing, instantly; the fold makes that path reachable from real words in other
languages, since `thé` is French for tea and lands on `the`. Three or more are a phrase,
and a phrase the user typed is worth running.

**The rule never fires while anything survives, and that restraint is the whole design.**
An earlier version fell back whenever the prune dropped more terms than it kept. That
sounds careful and is not: `in the brain` keeps one content word, drops two common ones,
and would have run unpruned — putting a document that says `in the` sixty times ahead of
the one about brains. That is the same defect arriving from the other direction, on a far
more ordinary query than the one being fixed. Nothing distinguishes an accidental
survivor like `not` from a real one like `brain` except how common each is, and a fixed
list cannot know that. So it must not guess: if a term survived, it is the query.

**The list also comes off the document side.** `tokenize()` was both the in-memory
backend's document tokenizer and its query tokenizer, so the list was deleting these
terms from that index — and a term that is not indexed cannot be matched even
deliberately: the phrase fallback would have had nothing to find. Both backends now index
every term, and only queries prune. On the SQLite backend nothing changes there: FTS5
tokenizes the document side itself and always held these terms. One visible consequence,
stated because "results are unchanged" would be false: on the in-memory backend
`doc.length` and `avgdl` now count common words, so BM25's length normalization shifts —
toward FTS5, which has always counted every token, so the two backends' scoring
converges rather than diverging. `Doc.tokens`, a per-document array of every token that
nothing in the tree ever read, is removed in the same commit as dead code.

### Measured

On a real 477 512-passage library, against this same build with the change reverted:
every ordinary query returns the same documents in the same order — `the brain`, `in the
brain`, `on the moon`, `is it a bird`, `of energy`, and a French query made only of
French function words. `the`, `thé` and `of the` still cost 0 ms and return nothing.
Only the soliloquy differs, which is the contract: it now runs as the phrase the user
typed.

### Tests

`tests/features/search-degenerate-query.test.ts` asserts the defect before asserting the
fix — with the list as it shipped, the line prunes to the single term `not` — and pins
the property the design rests on: a query with one content word stays pruned however many
common words surround it, with a fixture item that would outrank the real answer if it
did not.
