### PR TITLE
Replace the 29-word stoplist with a droplist measured from the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ All notable changes to Zoteus are documented here. The format is based on
   A migrated index cannot be opened by an older build — downgrading sidelines it and
   starts an empty one, so the library would need a rebuild there.
 
+- **The common-word list is measured from the library instead of shipped with the code.**
+  The 29 hard-coded English function words are gone. At the end of a full build the SQLite
+  backend scans the keyword index's own term vocabulary (`fts5vocab`) and stores, in
+  `meta`, the terms appearing in 30% or more of the passages; a delta update rederives the
+  list only when the passage count has drifted by more than 10%. The list is applied to
+  queries only — both backends keep indexing every term — and the in-memory backend
+  answers from its resident document frequencies, storing nothing. An index built by an
+  earlier version prunes nothing until its next build or update, at which point it adopts
+  a list of its own: nothing is stranded, no rebuild is forced, and the schema version
+  does not change. One behavior changes with the list's provenance: a query in which no
+  term survives the prune now runs as typed instead of returning nothing, because a
+  measured list can hold the library's own subject words, and silence would be a worse
+  answer than a slow one.
+
 ### Fixed
 - **A migration that failed for a transient reason discarded an intact index.** Any
   error inside the schema-upgrade ladder — a full disk as much as a corrupt page — used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A query made mostly of common words returned a confident wrong answer instead of an
+  honest one.** `tokenize()` dropped 29 English function words from every query, and
+  `to be or not to be` is all of them except `not` — so the search that ran was a
+  single-term OR on a word that means nothing, and what came back was whatever prose
+  happened to contain it. Not an empty result, which would at least have been honest.
+  Pruning now stops when it would change the question rather than shorten it, and the
+  list moved off the document side: `tokenize()` is also the in-memory backend's document
+  tokenizer, so the list was deleting those terms from the index, and a term that is not
+  indexed cannot be searched for even deliberately. Both backends now index every term and
+  only queries prune; ordinary queries are unaffected.
+
 ## [1.12.0] - 2026-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ All notable changes to Zoteus are documented here. The format is based on
   indexed exactly as written (`remove_diacritics 0`), an accented query is answered
   exactly, and an unaccented query still reaches accented documents by expanding to the
   accented spellings the library's vocabulary holds (`theorie` runs as
-  `theorie OR théorie`). Nothing extra is indexed, so ranking is untouched for queries
-  that need no expansion. Search semantics change accordingly: `thé` no longer answers as
+  `theorie OR théorie`) — but only where those spellings dominate the typed one in this
+  library, so a common word is never dragged toward its rare accented siblings. Nothing
+  extra is indexed, so ranking is untouched for queries that need no expansion. Search semantics change accordingly: `thé` no longer answers as
   `the`, and `soren` still does not answer to `søren` (`ø` is a letter, not an accent).
   **Existing SQLite indexes are migrated in place** on first open (schema 1 → 2: the
   keyword table is re-tokenized; no vectors are re-computed and nothing re-reads Zotero).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,29 @@ All notable changes to Zoteus are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+- **The keyword index keeps diacritics.** It used to strip them from every token on both
+  sides (`remove_diacritics 2`), which in a multilingual library merges distinct words
+  rather than normalizing spelling: Vietnamese `án`, `bé`, `thể` and `thế` all landed on
+  English `an`, `be` and `the` and could not be searched for at all. Each word is now
+  indexed exactly as written (`remove_diacritics 0`), an accented query is answered
+  exactly, and an unaccented query still reaches accented documents by expanding to the
+  accented spellings the library's vocabulary holds (`theorie` runs as
+  `theorie OR théorie`). Nothing extra is indexed, so ranking is untouched for queries
+  that need no expansion. Search semantics change accordingly: `thé` no longer answers as
+  `the`, and `soren` still does not answer to `søren` (`ø` is a letter, not an accent).
+  **Existing SQLite indexes are migrated in place** on first open (schema 1 → 2: the
+  keyword table is re-tokenized; no vectors are re-computed and nothing re-reads Zotero).
+  A migrated index cannot be opened by an older build — downgrading sidelines it and
+  starts an empty one, so the library would need a rebuild there.
+
 ### Fixed
+- **A migration that failed for a transient reason discarded an intact index.** Any
+  error inside the schema-upgrade ladder — a full disk as much as a corrupt page — used
+  to be treated as a foreign schema: the database was moved aside and a fresh empty one
+  silently took its place. A non-corruption failure now leaves the file untouched at its
+  old version and search refuses with the reason; the upgrade is retried on the next
+  open. Only corruption still sidelines the file.
 - **A query made mostly of common words returned a confident wrong answer instead of an
   honest one.** `tokenize()` dropped 29 English function words from every query, and
   `to be or not to be` is all of them except `not` — so the search that ran was a

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -472,20 +472,40 @@ about 5.4 GB of heap to parse and OOMs stock Node. Measured on the same 7540-ite
 | JSON (`memory`) | 337 s | 5370 MB | 370-500 ms | re-parses the whole file |
 | SQLite (`sqlite`) | 46.6 s | 162 MB | 1-76 ms | opens the file |
 
-The SQLite backend stores passages in an **FTS5** table (`unicode61 remove_diacritics 2`,
+The SQLite backend stores passages in an **FTS5** table (`unicode61 remove_diacritics 0`,
 ranked with `bm25()`) and vectors as per-passage `BLOB`s, so a keyword search reads only
 the rows it ranks and never materializes the library. The semantic path used to be the one
 that grew with the library, because it read every vector; it now reads a binary code per
 vector instead and fetches the float32 vectors of a few hundred candidates. See
 [Two-stage vector search](#two-stage-vector-search).
 
-**Diacritics.** Searches are diacritics-insensitive in both directions and on both
-backends: `Bronte` finds `Brontë` and `Brontë` finds `Bronte`. The document side of the
-FTS5 index is folded by SQLite (`remove_diacritics 2`); the query side is folded in JS by
-`tokenize.ts`, which is also what the JSON backend tokenizes with, so the two agree by
-construction. The JS fold deliberately reproduces `unicode61` and no more — `ø œ æ ł đ ð
-þ ß` are letters to unicode61 rather than accented forms, so they are letters here too,
-and `søren` does not answer to `soren`.
+**Diacritics.** An unaccented search finds accented words: `Bronte` finds `Brontë`, and
+`theorie` finds `théorie`, on both backends. An accented search is answered exactly:
+`Brontë` finds documents that spell it `Brontë`.
+
+The index holds each word exactly as it was written — the FTS5 table is declared
+`remove_diacritics 0` and nothing strips marks on the way in. The tolerant direction is
+paid on the **query** side instead: an unaccented query term is expanded to the accented
+spellings the library's vocabulary actually holds (`theorie` runs as
+`theorie OR théorie`), through a small folded-form → spellings map each backend derives
+from its own vocabulary. Because nothing extra is indexed, document length, term
+frequency and idf are what the text says they are, and ranking is untouched for every
+query that needs no expansion.
+
+It used to strip marks from everything on both sides, and that is a different thing from
+being insensitive to them. In a library holding more than one language it merges
+vocabulary rather than normalizing spelling: Vietnamese `án`, `bé`, `thể` and `thế` all
+land on English `an`, `be` and `the`, and a tone mark in Vietnamese is part of the word,
+not an accent on it — `ma má mà mả mã mạ` are six words. Once merged into a token that
+common, they could not be searched for at all.
+
+The remaining asymmetry is deliberate: an accented query does **not** find a document that
+spells the word without its accents. Expansion runs one way only, because expanding `thể`
+toward `the` is exactly the merge above.
+
+Marks are stripped (for the expansion map's keys) the way `unicode61` strips them and no
+further — `ø œ æ ł đ ð þ ß` are letters to it rather than accented forms, so they are
+letters here too, and `søren` does not answer to `soren`.
 
 **Common words.** Some words are too common in a library to rank on — searching them
 walks a long posting list to separate almost nothing — so they are dropped from the query

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -492,6 +492,13 @@ from its own vocabulary. Because nothing extra is indexed, document length, term
 frequency and idf are what the text says they are, and ranking is untouched for every
 query that needs no expansion.
 
+Expansion is **dominance-gated**: a term expands only when the accented spellings
+outweigh the typed one in this library (by document frequency, compared at derivation
+time). `theorie` expands because the library overwhelmingly writes `théorie`; `trong`
+does not, because the library holds it 25 771 times as typed and its accented siblings
+(`trọng`, `trồng`, …) are different, rarer words whose high idf would otherwise outrank
+what the user asked for. The gate is corpus-derived — there is no threshold to tune.
+
 It used to strip marks from everything on both sides, and that is a different thing from
 being insensitive to them. In a library holding more than one language it merges
 vocabulary rather than normalizing spelling: Vietnamese `án`, `bé`, `thể` and `thế` all

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -514,17 +514,32 @@ Marks are stripped (for the expansion map's keys) the way `unicode61` strips the
 further — `ø œ æ ł đ ð þ ß` are letters to it rather than accented forms, so they are
 letters here too, and `søren` does not answer to `soren`.
 
-**Common words.** Some words are too common in a library to rank on — searching them
-walks a long posting list to separate almost nothing — so they are dropped from the query
-before it runs. They are still indexed — only queries prune, and both backends index every
-term — so a search that needs one of these words can still reach the documents holding it.
+**Common words.** A keyword query is answered by OR-ing its terms, so a term that occurs
+in most of the library costs a full posting-list walk and separates nothing. Zoteus used to
+handle that with 29 hard-coded English function words, dropped from every query and every
+document. That list is wrong for a multilingual library — German `die` and English `die`
+are one string in the index, so no list can drop one and keep the other — and it is a guess
+about frequency rather than a measurement of it: `energy` sits at 26% document frequency in
+one real library, higher than several words that were on the list.
 
-Dropping them stops when it would change the question rather than shorten it. If fewer
-terms survive the prune than were dropped, the query runs on what you typed instead: `to
-be or not to be` is otherwise answered by a single-word search for `not`, which returns a
-confidently-ranked page of unrelated results. If nothing survives at all, the search
-returns nothing, as it always has — a query of nothing but common words has no answer to
-give, and inventing one would be slower and no more useful.
+Zoteus now measures the library instead. At the end of a full build it scans the keyword
+index's own term vocabulary (`fts5vocab`, a view over the index — no new tables, no
+rebuild) and records the terms that appear in **30% or more** of the passages. That list is
+applied to queries only, never to documents, and it is stored in the index, so it costs
+nothing at query time and nothing at startup. On a 477 512-passage library it is 23 terms
+and 75 bytes, and deriving it costs one scan of 639 888 vocabulary terms — a couple of
+seconds against a build that takes minutes. A delta update does not redo it unless the
+passage count has moved by more than 10%, since a handful of new items cannot change a
+30% threshold.
+
+Two consequences worth knowing. A query in which **no term survives** the prune is sent
+unpruned: a measured list can hold the library's own subject words (`economics` reaches 35%
+of the English passages of one real library), so answering such a query with silence would
+look like an empty library. While any term survives, the survivors are what runs — they
+are, by measurement, the words this library can discriminate on, and the prune is never
+abandoned on their account. And an index built by an earlier version prunes nothing
+until its next build or update, at which point it adopts a list of its own; nothing is
+stranded and no rebuild is forced.
 
 **Where the files are.** `<ZOTEUS_DATA_DIR>/search-index.sqlite` beside the older
 `search-index.json` (and `search-index-<userId>.*` per tenant in multi-tenant mode). SQLite

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -487,6 +487,18 @@ construction. The JS fold deliberately reproduces `unicode61` and no more — `�
 þ ß` are letters to unicode61 rather than accented forms, so they are letters here too,
 and `søren` does not answer to `soren`.
 
+**Common words.** Some words are too common in a library to rank on — searching them
+walks a long posting list to separate almost nothing — so they are dropped from the query
+before it runs. They are still indexed — only queries prune, and both backends index every
+term — so a search that needs one of these words can still reach the documents holding it.
+
+Dropping them stops when it would change the question rather than shorten it. If fewer
+terms survive the prune than were dropped, the query runs on what you typed instead: `to
+be or not to be` is otherwise answered by a single-word search for `not`, which returns a
+confidently-ranked page of unrelated results. If nothing survives at all, the search
+returns nothing, as it always has — a query of nothing but common words has no answer to
+give, and inventing one would be slower and no more useful.
+
 **Where the files are.** `<ZOTEUS_DATA_DIR>/search-index.sqlite` beside the older
 `search-index.json` (and `search-index-<userId>.*` per tenant in multi-tenant mode). SQLite
 also writes `-wal` and `-shm` sidecar files while the database is open; a clean shutdown

--- a/src/features/search/bm25.ts
+++ b/src/features/search/bm25.ts
@@ -84,11 +84,20 @@ export class BM25Index {
   search(query: string, topK = 10): BM25Hit[] {
     if (this.docs.size === 0) return [];
     const pruned = pruneTerms([...new Set(tokenize(query))], isStopword);
-    // The same asymmetric expansion as the SQLite backend's `expandTerm`: an unaccented
-    // term also scores the accented spellings the vocabulary holds, each with its own
-    // idf; an accented term runs exactly as typed.
+    // The same asymmetric, dominance-gated expansion as the SQLite backend's
+    // `expandTerm` (the direction and the gate are explained there): an unaccented term
+    // also scores the accented spellings the vocabulary holds — but only when those
+    // spellings outweigh the typed one in this corpus. An accented term runs as typed.
     const qTerms = [
-      ...new Set(pruned.flatMap((t) => (accentKey(t) === t ? [t, ...(this.variants.get(t) ?? [])] : [t]))),
+      ...new Set(
+        pruned.flatMap((t) => {
+          if (accentKey(t) !== t) return [t];
+          const vs = [...(this.variants.get(t) ?? [])];
+          if (!vs.length) return [t];
+          const variantsDf = vs.reduce((s, v) => s + (this.df.get(v) ?? 0), 0);
+          return variantsDf > (this.df.get(t) ?? 0) ? [t, ...vs] : [t];
+        }),
+      ),
     ];
     const avgdl = this.totalLength / this.docs.size;
     const N = this.docs.size;

--- a/src/features/search/bm25.ts
+++ b/src/features/search/bm25.ts
@@ -1,4 +1,4 @@
-import { pruneTerms } from './query-terms.js';
+import { MAX_ACCENT_VARIANTS, pruneTerms } from './query-terms.js';
 import { accentKey, isStopword, tokenize } from './tokenize.js';
 
 interface Doc {
@@ -95,7 +95,10 @@ export class BM25Index {
           const vs = [...(this.variants.get(t) ?? [])];
           if (!vs.length) return [t];
           const variantsDf = vs.reduce((s, v) => s + (this.df.get(v) ?? 0), 0);
-          return variantsDf > (this.df.get(t) ?? 0) ? [t, ...vs] : [t];
+          if (variantsDf <= (this.df.get(t) ?? 0)) return [t];
+          // Same cap as the SQLite backend's MAX_ACCENT_VARIANTS, best spellings first.
+          const kept = vs.sort((a, b) => (this.df.get(b) ?? 0) - (this.df.get(a) ?? 0)).slice(0, MAX_ACCENT_VARIANTS);
+          return [t, ...kept];
         }),
       ),
     ];

--- a/src/features/search/bm25.ts
+++ b/src/features/search/bm25.ts
@@ -1,5 +1,5 @@
 import { pruneTerms } from './query-terms.js';
-import { isStopword, tokenize } from './tokenize.js';
+import { accentKey, isStopword, tokenize } from './tokenize.js';
 
 interface Doc {
   id: string;
@@ -22,6 +22,14 @@ export interface BM25Hit {
 export class BM25Index {
   private readonly docs = new Map<string, Doc>();
   private readonly df = new Map<string, number>();
+  /**
+   * folded form → the accented spellings currently in the vocabulary, so an unaccented
+   * query term can be expanded to the variants the index actually holds — the same
+   * asymmetric expansion the SQLite backend runs through its `accent_variants` table
+   * (see `expandTerm` there for the direction and why). Maintained beside `df`, and
+   * pruned with it, so a deleted document's spellings do not stay searchable.
+   */
+  private readonly variants = new Map<string, Set<string>>();
   private totalLength = 0;
 
   constructor(
@@ -40,7 +48,15 @@ export class BM25Index {
     const tokens = tokenize(text);
     const tf = new Map<string, number>();
     for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
-    for (const term of tf.keys()) this.df.set(term, (this.df.get(term) ?? 0) + 1);
+    for (const term of tf.keys()) {
+      this.df.set(term, (this.df.get(term) ?? 0) + 1);
+      const folded = accentKey(term);
+      if (folded !== term && folded.length > 1) {
+        let set = this.variants.get(folded);
+        if (!set) this.variants.set(folded, (set = new Set()));
+        set.add(term);
+      }
+    }
     this.docs.set(id, { id, length: tokens.length, tf });
     this.totalLength += tokens.length;
   }
@@ -52,7 +68,13 @@ export class BM25Index {
     for (const term of doc.tf.keys()) {
       const n = (this.df.get(term) ?? 0) - 1;
       if (n > 0) this.df.set(term, n);
-      else this.df.delete(term);
+      else {
+        this.df.delete(term);
+        // Its last occurrence is gone, so the spelling leaves the expansion map too.
+        const folded = accentKey(term);
+        const set = this.variants.get(folded);
+        if (set?.delete(term) && set.size === 0) this.variants.delete(folded);
+      }
     }
     this.totalLength -= doc.length;
     this.docs.delete(id);
@@ -61,7 +83,13 @@ export class BM25Index {
 
   search(query: string, topK = 10): BM25Hit[] {
     if (this.docs.size === 0) return [];
-    const qTerms = pruneTerms([...new Set(tokenize(query))], isStopword);
+    const pruned = pruneTerms([...new Set(tokenize(query))], isStopword);
+    // The same asymmetric expansion as the SQLite backend's `expandTerm`: an unaccented
+    // term also scores the accented spellings the vocabulary holds, each with its own
+    // idf; an accented term runs exactly as typed.
+    const qTerms = [
+      ...new Set(pruned.flatMap((t) => (accentKey(t) === t ? [t, ...(this.variants.get(t) ?? [])] : [t]))),
+    ];
     const avgdl = this.totalLength / this.docs.size;
     const N = this.docs.size;
 

--- a/src/features/search/bm25.ts
+++ b/src/features/search/bm25.ts
@@ -1,8 +1,8 @@
-import { tokenize } from './tokenize.js';
+import { pruneTerms } from './query-terms.js';
+import { isStopword, tokenize } from './tokenize.js';
 
 interface Doc {
   id: string;
-  tokens: string[];
   length: number;
   tf: Map<string, number>;
 }
@@ -41,7 +41,7 @@ export class BM25Index {
     const tf = new Map<string, number>();
     for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
     for (const term of tf.keys()) this.df.set(term, (this.df.get(term) ?? 0) + 1);
-    this.docs.set(id, { id, tokens, length: tokens.length, tf });
+    this.docs.set(id, { id, length: tokens.length, tf });
     this.totalLength += tokens.length;
   }
 
@@ -61,7 +61,7 @@ export class BM25Index {
 
   search(query: string, topK = 10): BM25Hit[] {
     if (this.docs.size === 0) return [];
-    const qTerms = [...new Set(tokenize(query))];
+    const qTerms = pruneTerms([...new Set(tokenize(query))], isStopword);
     const avgdl = this.totalLength / this.docs.size;
     const N = this.docs.size;
 

--- a/src/features/search/bm25.ts
+++ b/src/features/search/bm25.ts
@@ -1,5 +1,5 @@
-import { MAX_ACCENT_VARIANTS, pruneTerms } from './query-terms.js';
-import { accentKey, isStopword, tokenize } from './tokenize.js';
+import { highDfMinimum, MAX_ACCENT_VARIANTS, MIN_DERIVATION_PASSAGES, pruneTerms } from './query-terms.js';
+import { accentKey, tokenize } from './tokenize.js';
 
 interface Doc {
   id: string;
@@ -30,6 +30,8 @@ export class BM25Index {
    * pruned with it, so a deleted document's spellings do not stay searchable.
    */
   private readonly variants = new Map<string, Set<string>>();
+  /** Cleared whenever `df` moves; see `commonTerms`. */
+  private common: Set<string> | undefined;
   private totalLength = 0;
 
   constructor(
@@ -58,6 +60,7 @@ export class BM25Index {
       }
     }
     this.docs.set(id, { id, length: tokens.length, tf });
+    this.common = undefined;
     this.totalLength += tokens.length;
   }
 
@@ -78,12 +81,59 @@ export class BM25Index {
     }
     this.totalLength -= doc.length;
     this.docs.delete(id);
+    this.common = undefined;
     return true;
+  }
+
+  /**
+   * Whether a term appears in enough documents to be worth pruning off a query.
+   *
+   * This backend needs no stored droplist and no cadence rule, unlike the SQLite one: `df`
+   * is already exact and already resident, and it is rebuilt from the raw passage text on
+   * every load exactly as the postings are. So the answer is live by construction — an
+   * index written before this existed adopts it the moment it is read back, with no
+   * migration and nothing to recompute.
+   *
+   * Query side only. `addDoc` keeps indexing every term, because dropping them from the
+   * documents would both destroy the df this reads and make the degeneracy fallback — which
+   * exists precisely to search on those terms — unable to match anything.
+   */
+  isHighDf(term: string): boolean {
+    return this.commonTerms().has(term);
+  }
+
+  /**
+   * The terms this backend considers common, computed once per change to the index.
+   *
+   * Memoised because `search` asks per query term and the answer only moves when a document
+   * is added or removed. Guarded the same way the SQLite side guards its stored list: a set
+   * naming every term in the vocabulary is not a list of common terms, it is the vocabulary,
+   * and pruning by it empties every query. That happens whenever the corpus is too small for
+   * a document frequency to mean anything — three documents put the bar at one.
+   */
+  private commonTerms(): ReadonlySet<string> {
+    if (!this.common) {
+      const set = new Set<string>();
+      if (this.docs.size >= MIN_DERIVATION_PASSAGES) {
+        const floor = highDfMinimum(this.docs.size);
+        for (const [term, n] of this.df) if (n >= floor) set.add(term);
+      }
+      this.common = set.size >= this.df.size ? new Set<string>() : set;
+    }
+    return this.common;
   }
 
   search(query: string, topK = 10): BM25Hit[] {
     if (this.docs.size === 0) return [];
-    const pruned = pruneTerms([...new Set(tokenize(query))], isStopword);
+    // Prune first, then expand the survivors — the order is a decision, stated once here
+    // for both backends. The droplist judges the TYPED terms: they are the question, and
+    // which of them this corpus can discriminate on is decided before any spelling
+    // variation enters. Expansion then serves the survivors (and, when nothing survived,
+    // the raw fallback set, which flows through the same path): a variant is another
+    // spelling of a term the prune already ruled worth running, not a query term of its
+    // own, so variants are never re-pruned — the dominance gate below already requires
+    // them to outweigh the typed spelling in this corpus.
+    const pruned = pruneTerms([...new Set(tokenize(query))], (t) => this.isHighDf(t), 'raw');
     // The same asymmetric, dominance-gated expansion as the SQLite backend's
     // `expandTerm` (the direction and the gate are explained there): an unaccented term
     // also scores the accented spellings the vocabulary holds — but only when those

--- a/src/features/search/corruption.ts
+++ b/src/features/search/corruption.ts
@@ -1,5 +1,5 @@
 import { SearchIndexBase } from './index-manager.js';
-import { SearchIndexCorruptError, UNREADABLE } from './store-faults.js';
+import { SearchIndexCorruptError, SearchIndexUnreadableError, UNREADABLE } from './store-faults.js';
 import type {
   IndexCounts,
   IndexBuildStatus,
@@ -41,7 +41,7 @@ export class CorruptSearchIndex extends SearchIndexBase {
   /** No store to delete from, and never a delta: see `updateBlocker`. */
   readonly supportsDelete = false;
 
-  constructor(readonly failure: SearchIndexCorruptError, opts: SearchIndexOptions) {
+  constructor(readonly failure: SearchIndexCorruptError | SearchIndexUnreadableError, opts: SearchIndexOptions) {
     super(opts);
     // The channel the store already uses to explain what opening it did or refused to do,
     // so this reaches `status().storageNotice` and `statusSummary` the same way a refused

--- a/src/features/search/factory.ts
+++ b/src/features/search/factory.ts
@@ -76,7 +76,12 @@ export async function createSearchIndex(opts: CreateSearchIndexOptions): Promise
         // why. Anything else still throws: a permission error or a full disk is not a
         // reason to tell someone their index is beyond saving, and the store is the only
         // thing that knows which is which.
-        if (!(e instanceof SearchIndexCorruptError)) throw e;
+        // SearchIndexUnreadableError joins the degradation for one path: a migration that
+        // failed for a transient, non-corruption reason (a full disk, a size limit) now
+        // leaves the database untouched at its old stamp and refuses instead of sidelining
+        // it. That refusal must not take the server down either — the retry it prescribes
+        // is the next open.
+        if (!(e instanceof SearchIndexCorruptError) && !(e instanceof SearchIndexUnreadableError)) throw e;
         opts.logger?.error(e.message);
         return new CorruptSearchIndex(e, indexOpts);
       }

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -2,7 +2,7 @@ import { BM25Index } from './bm25.js';
 import { VectorStore } from './vector-store.js';
 import { chunkText } from './chunker.js';
 import { pruneTerms } from './query-terms.js';
-import { isStopword, normalizeForSearch, tokenize } from './tokenize.js';
+import { accentKey, isStopword, normalizeForSearch, tokenize } from './tokenize.js';
 import { batchPause, embedderIdentity } from './embeddings.js';
 import {
   DEFAULT_EMBED_BATCH_SIZE,
@@ -159,11 +159,28 @@ export function makeSnippet(text: string, query: string, max = 240): string {
   // Folded, not merely lowercased, because the terms being looked for are folded: an
   // accented query would otherwise never find its own passage and every snippet would
   // start at character 0.
-  const folded = normalizeForSearch(clean);
+  // Walk the passage's own tokens and normalize each one, rather than normalizing the whole
+  // passage and searching inside the result. The offset then comes from `clean` itself and
+  // needs no assumption at all about whether normalizing preserved length.
+  //
+  // An earlier version did assume that — "stripping a mark from precomposed text is
+  // length-preserving" — and it is false twice over. `foldMarks` shortens any base+mark pair
+  // that has no precomposed form (`n̈` is two codepoints and folds to one), and lowercasing
+  // can lengthen (`İ` becomes `i` plus a combining dot). Either way the position found in
+  // one string was being sliced out of another, and the snippet came back centred hundreds
+  // of characters from the match, without it.
+  //
+  // The stripped form is compared too, because query expansion lets an unaccented query
+  // reach an accented document: a passage spelling `théorie` answers a query for
+  // `theorie`, and the snippet must be able to find what the search found.
+  const wanted = new Set(pruneTerms(tokenize(query), isStopword));
   let pos = -1;
-  for (const t of pruneTerms(tokenize(query), isStopword)) {
-    const i = folded.indexOf(t);
-    if (i >= 0 && (pos < 0 || i < pos)) pos = i;
+  for (const m of clean.matchAll(/[\p{L}\p{N}]+/gu)) {
+    const token = normalizeForSearch(m[0]);
+    if (wanted.has(token) || wanted.has(accentKey(token))) {
+      pos = m.index;
+      break;
+    }
   }
   let start = pos < 0 ? 0 : Math.max(0, pos - Math.floor(max / 3));
   if (start > 0) {

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -1,8 +1,8 @@
 import { BM25Index } from './bm25.js';
 import { VectorStore } from './vector-store.js';
 import { chunkText } from './chunker.js';
-import { pruneTerms } from './query-terms.js';
-import { accentKey, isStopword, normalizeForSearch, tokenize } from './tokenize.js';
+import { pruneTerms, type TermPredicate } from './query-terms.js';
+import { accentKey, normalizeForSearch, tokenize } from './tokenize.js';
 import { batchPause, embedderIdentity } from './embeddings.js';
 import {
   DEFAULT_EMBED_BATCH_SIZE,
@@ -147,8 +147,16 @@ function rrf(lists: Array<Array<{ id: string }>>, k = 60): Array<{ id: string; s
   return [...scores.entries()].map(([id, score]) => ({ id, score })).sort((a, b) => b.score - a.score);
 }
 
-/** Build a readable, query-centred snippet trimmed to word boundaries. */
-export function makeSnippet(text: string, query: string, max = 240): string {
+/**
+ * Build a readable, query-centred snippet trimmed to word boundaries.
+ *
+ * `highDf` is the index's droplist, and passing it is not optional polish. This function
+ * centres on the EARLIEST query term it finds, so a term the corpus is saturated with is
+ * found at or near character 0 of almost every passage and every snippet becomes the
+ * passage's opening words. With the 29-word stoplist gone from `tokenize()`, that is what
+ * `the theory of games` would do to every result it returned.
+ */
+export function makeSnippet(text: string, query: string, max = 240, highDf?: TermPredicate): string {
   // NFC changes no character the reader sees, and it is what the token comparison below
   // normalizes to.
   const clean = text.replace(/\s+/g, ' ').trim().normalize('NFC');
@@ -167,7 +175,7 @@ export function makeSnippet(text: string, query: string, max = 240): string {
   // The stripped form is compared too, because query expansion lets an unaccented query
   // reach an accented document: a passage spelling `théorie` answers a query for
   // `theorie`, and the snippet must be able to find what the search found.
-  const wanted = new Set(pruneTerms(tokenize(query), isStopword));
+  const wanted = new Set(pruneTerms(tokenize(query), highDf, 'raw'));
   let pos = -1;
   for (const m of clean.matchAll(/[\p{L}\p{N}]+/gu)) {
     const token = normalizeForSearch(m[0]);
@@ -440,6 +448,26 @@ export abstract class SearchIndexBase implements SearchIndex {
    * never a failed build.
    */
   protected finalizeVectors(): void {}
+  /**
+   * Bring this index's droplist level with the passages it is derived from.
+   *
+   * Called beside `finalizeVectors` and for the same reason — after the writing, before the
+   * persist, so a derived fact commits with the rows it was derived from. `force` says a
+   * full build has just walked the whole corpus, which is the declared recompute point; an
+   * update passes false and the store decides for itself whether the corpus has drifted far
+   * enough to be worth rescanning.
+   *
+   * Must not throw, on the same rule as `finalizeVectors`: a droplist that could not be
+   * derived is a slower index, never a failed build.
+   */
+  protected refreshDroplist(_force: boolean): void {}
+  /**
+   * The terms this index's corpus cannot discriminate on, or undefined where the store has
+   * no droplist — which must mean "prune nothing", never "prune everything".
+   */
+  protected highDf(): TermPredicate | undefined {
+    return undefined;
+  }
   /** Width of the stored vectors (undefined when none are stored). Their embedder's fingerprint. */
   protected abstract vectorDimension(): number | undefined;
   /** Keyword candidates, best first. */
@@ -737,6 +765,7 @@ export abstract class SearchIndexBase implements SearchIndex {
     }
     this.builtFromVersion = opts.version ?? 0;
     this.finalizeVectors();
+    this.refreshDroplist(true);
     return this.status();
   }
 
@@ -1171,6 +1200,10 @@ export abstract class SearchIndexBase implements SearchIndex {
       // its partial index stays searchable, and it would otherwise pay for them on the
       // first query instead.
       this.finalizeVectors();
+      // A stopped build gets one too, for the same reason its codes are built: its partial
+      // index stays queryable, and a droplist derived from most of the corpus is a far
+      // better answer for it than none at all.
+      this.refreshDroplist(true);
       await persistNow();
       this.buildState = 'done';
       if (resume) noteResumed();
@@ -1408,6 +1441,12 @@ export abstract class SearchIndexBase implements SearchIndex {
       // adds codes for the passages it added and nothing else, and a failure below rolls
       // them back with the rest.
       this.finalizeVectors();
+      // Not forced: a delta of a few items cannot move a 30% threshold, and the scan that
+      // derives the droplist is the one cost in this whole feature a user could feel. The
+      // store rescans only when the corpus has drifted far enough to change the answer —
+      // or when it holds no droplist at all, which is how an index built by an older
+      // version adopts one without waiting for a rebuild.
+      this.refreshDroplist(false);
       // Persisted once, at the end: the delta is small by construction, and one commit is
       // what makes "the stamp advanced" and "the rows are on disk" a single durable fact.
       try {
@@ -1894,11 +1933,14 @@ export abstract class SearchIndexBase implements SearchIndex {
     const fused = rrf([keyword, vector]);
     const seen = new Set<string>();
     const hits: SearchHit[] = [];
+    // Read once rather than per hit: on the SQLite backend it is a set lookup, on the JSON
+    // one a closure over the live postings, and neither wants to be rebuilt ten times.
+    const highDf = this.highDf();
     for (const { id, score } of fused) {
       const rec = this.passage(id);
       if (!rec || seen.has(rec.itemKey)) continue;
       seen.add(rec.itemKey);
-      const hit: SearchHit = { itemKey: rec.itemKey, title: rec.title, snippet: makeSnippet(rec.text, q), score };
+      const hit: SearchHit = { itemKey: rec.itemKey, title: rec.title, snippet: makeSnippet(rec.text, q, 240, highDf), score };
       // Worth surfacing: a body-text snippet is a passage the caller can go and cite with
       // zotero_get_fulltext, whereas a metadata one is just the abstract — and a note or
       // annotation is the reader's own, which is a different thing again to be told.
@@ -2084,6 +2126,17 @@ export class MemorySearchIndex extends SearchIndexBase {
 
   protected vectorDimension(): number | undefined {
     return this.vectors.dimension;
+  }
+
+  /**
+   * Live off the resident postings, so this backend stores no droplist and needs no cadence
+   * rule: `df` is exact, it is rebuilt from the raw passage text on every load exactly as
+   * the postings are, and a JSON artifact written before this change therefore adopts the
+   * pruning the moment it is read back. `refreshDroplist` stays a no-op here for the same
+   * reason — there is nothing to derive and nothing to persist.
+   */
+  protected highDf(): TermPredicate {
+    return (t) => this.bm25.isHighDf(t);
   }
 
   protected keywordSearch(q: string, topK: number): RankedId[] {

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -1,7 +1,8 @@
 import { BM25Index } from './bm25.js';
 import { VectorStore } from './vector-store.js';
 import { chunkText } from './chunker.js';
-import { normalizeForSearch, tokenize } from './tokenize.js';
+import { pruneTerms } from './query-terms.js';
+import { isStopword, normalizeForSearch, tokenize } from './tokenize.js';
 import { batchPause, embedderIdentity } from './embeddings.js';
 import {
   DEFAULT_EMBED_BATCH_SIZE,
@@ -160,7 +161,7 @@ export function makeSnippet(text: string, query: string, max = 240): string {
   // start at character 0.
   const folded = normalizeForSearch(clean);
   let pos = -1;
-  for (const t of tokenize(query)) {
+  for (const t of pruneTerms(tokenize(query), isStopword)) {
     const i = folded.indexOf(t);
     if (i >= 0 && (pos < 0 || i < pos)) pos = i;
   }

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -149,16 +149,10 @@ function rrf(lists: Array<Array<{ id: string }>>, k = 60): Array<{ id: string; s
 
 /** Build a readable, query-centred snippet trimmed to word boundaries. */
 export function makeSnippet(text: string, query: string, max = 240): string {
-  // NFC first: the fold below is length-preserving on precomposed text, so folded
-  // offsets carry straight over — on decomposed text every stripped mark shifts them,
-  // and a passage with a few hundred marks before the hit (ordinary NFD Vietnamese at
-  // full-text chunk size) would push the match clean out of the returned window.
-  // Canonical composition changes no character the reader sees.
+  // NFC changes no character the reader sees, and it is what the token comparison below
+  // normalizes to.
   const clean = text.replace(/\s+/g, ' ').trim().normalize('NFC');
   if (clean.length <= max) return clean;
-  // Folded, not merely lowercased, because the terms being looked for are folded: an
-  // accented query would otherwise never find its own passage and every snippet would
-  // start at character 0.
   // Walk the passage's own tokens and normalize each one, rather than normalizing the whole
   // passage and searching inside the result. The offset then comes from `clean` itself and
   // needs no assumption at all about whether normalizing preserved length.

--- a/src/features/search/query-terms.ts
+++ b/src/features/search/query-terms.ts
@@ -1,0 +1,58 @@
+/**
+ * Which terms a query is actually answered on, and what to do when that leaves nothing.
+ *
+ * Search drops the words that appear nearly everywhere: their posting lists are long and
+ * their presence separates almost nothing. That is a good trade on an ordinary query and a
+ * silent failure on a query made entirely of such words, because what is left is not a
+ * shorter version of the question — there is no question left.
+ *
+ * `to be or not to be` is the defect in one line. Every word of it was on the list except
+ * `not`, so one term limped through and the search that ran was a single-term OR on a word
+ * that appears in a quarter of an academic library. The user got a confidently-ranked page
+ * of results unrelated to what they typed. Not an empty result, which would at least be
+ * honest; a wrong one.
+ *
+ * **The rule never fires while anything survives, and that restraint is the whole design.**
+ * A version of this fell back whenever the prune left fewer terms than it dropped, which
+ * sounds careful and is not: `in the brain` keeps one content word, drops two common ones,
+ * and would have run unpruned — putting a document that says `in the ` sixty times ahead of
+ * the one about brains. That is this defect arriving from the other direction, on a far
+ * more ordinary query. Nothing distinguishes an accidental survivor like `not` from a real
+ * one like `brain` except how common each is, and a fixed list cannot know that. So a fixed
+ * list must not guess: if a term survived, it is the query, and it is what runs.
+ *
+ * That leaves only the case where nothing survived, where there is no content word to
+ * demote and the choice is safe to make. One or two common words are not a question —
+ * `the`, `of the` — and search has always answered those with nothing, instantly. Three or
+ * more are a phrase, and a phrase the user typed is worth running even though every word of
+ * it is common. Measured, the bare query `the` costs 0 ms and returns nothing where running
+ * it costs 750 ms and returns ten unrelated documents, and the fold makes that path
+ * reachable from real words in other languages: `thé` is French for tea and lands on `the`.
+ */
+
+/** Whether a term is common enough in this index to be worth dropping from a query. */
+export type TermPredicate = (term: string) => boolean;
+
+/**
+ * Distinct terms a query needs before it is worth running unpruned when every one of them
+ * is common.
+ *
+ * Three, and the number is doing less work than it looks. It is not tuned to any query: it
+ * separates "one or two common words", which search has always answered with nothing, from
+ * "a phrase", which the user plainly meant. The rule it guards applies only when the prune
+ * left nothing at all, so no choice of this number can demote a content word.
+ */
+export const MIN_PHRASE_TERMS = 3;
+
+/**
+ * The terms to search on: the common ones removed, and the caller's own set back only when
+ * removing them left nothing and there was a phrase to recover. See the header.
+ */
+export function pruneTerms(terms: string[], prunable: TermPredicate): string[] {
+  const kept = terms.filter((t) => !prunable(t));
+  // Something survived. It is the query — never second-guess it.
+  if (kept.length) return kept;
+  // Nothing survived. A phrase runs as typed; one or two common words answer as they always
+  // have, with nothing, for free.
+  return terms.length >= MIN_PHRASE_TERMS ? terms : kept;
+}

--- a/src/features/search/query-terms.ts
+++ b/src/features/search/query-terms.ts
@@ -26,8 +26,9 @@
  * `the`, `of the` — and search has always answered those with nothing, instantly. Three or
  * more are a phrase, and a phrase the user typed is worth running even though every word of
  * it is common. Measured, the bare query `the` costs 0 ms and returns nothing where running
- * it costs 750 ms and returns ten unrelated documents, and the fold makes that path
- * reachable from real words in other languages: `thé` is French for tea and lands on `the`.
+ * it costs 750 ms and returns ten unrelated documents. (An accented word no longer folds
+ * onto a common one — `thé`, French for tea, used to land on `the` and is its own term
+ * now — so this path is reached by genuinely common words, which is what it was for.)
  */
 
 /** Whether a term is common enough in this index to be worth dropping from a query. */

--- a/src/features/search/query-terms.ts
+++ b/src/features/search/query-terms.ts
@@ -57,3 +57,11 @@ export function pruneTerms(terms: string[], prunable: TermPredicate): string[] {
   // have, with nothing, for free.
   return terms.length >= MIN_PHRASE_TERMS ? terms : kept;
 }
+
+/**
+ * Most accented spellings one expanded query term may carry, highest document frequency
+ * first (see the SQLite backend's expandTerm and the memory backend's search). Bounds
+ * the expanded query against a corpus seeded with crafted spellings; comfortably above
+ * the widest real group measured (15, the Vietnamese syllables under `to`).
+ */
+export const MAX_ACCENT_VARIANTS = 24;

--- a/src/features/search/query-terms.ts
+++ b/src/features/search/query-terms.ts
@@ -1,60 +1,167 @@
 /**
- * Which terms a query is actually answered on, and what to do when that leaves nothing.
+ * Which terms a query is actually answered on, and what to do when that set collapses.
  *
- * Search drops the words that appear nearly everywhere: their posting lists are long and
- * their presence separates almost nothing. That is a good trade on an ordinary query and a
- * silent failure on a query made entirely of such words, because what is left is not a
- * shorter version of the question — there is no question left.
+ * Search drops some of a query's terms before it runs — the words that appear nearly
+ * everywhere, whose posting lists are expensive to walk and whose presence discriminates
+ * between almost nothing. Two separate decisions live here: **which** terms those are,
+ * and **when** dropping them has gone too far.
  *
- * `to be or not to be` is the defect in one line. Every word of it was on the list except
- * `not`, so one term limped through and the search that ran was a single-term OR on a word
- * that appears in a quarter of an academic library. The user got a confidently-ranked page
- * of results unrelated to what they typed. Not an empty result, which would at least be
- * honest; a wrong one.
+ * **Which.** They are read off the library rather than shipped with the code. The
+ * alternative, a list of English function words, is wrong in three ways and only the first
+ * is about English. It is a *language* rule applied to a token space that holds every
+ * language at once: German `die` and English `die` are the same string in the index, so no
+ * such list can drop one and keep the other, and nothing at the point of consultation
+ * knows which was meant. It is a *guess* about frequency rather than a measurement of it —
+ * measured on a real library, `energy` sits at 26,2% document frequency, above several
+ * words the shipped list carries, and dropping it would be a catastrophic answer to a
+ * query about energy. And it is *silent about its own cost*: a term is worth dropping
+ * because a posting list is not walked, which is a property of this corpus and not of the
+ * word. So the question the list answered badly — what does this string cost to retrieve
+ * on here? — is asked of the corpus instead, where it has exactly one answer.
  *
- * **The rule never fires while anything survives, and that restraint is the whole design.**
- * A version of this fell back whenever the prune left fewer terms than it dropped, which
- * sounds careful and is not: `in the brain` keeps one content word, drops two common ones,
- * and would have run unpruned — putting a document that says `in the ` sixty times ahead of
- * the one about brains. That is this defect arriving from the other direction, on a far
- * more ordinary query. Nothing distinguishes an accidental survivor like `not` from a real
- * one like `brain` except how common each is, and a fixed list cannot know that. So a fixed
- * list must not guess: if a term survived, it is the query, and it is what runs.
+ * So the rule is not "drop the common words". It is "drop the common words **unless that
+ * changes the question**", and the line is drawn at whether anything survives.
  *
- * That leaves only the case where nothing survived, where there is no content word to
- * demote and the choice is safe to make. One or two common words are not a question —
- * `the`, `of the` — and search has always answered those with nothing, instantly. Three or
- * more are a phrase, and a phrase the user typed is worth running even though every word of
- * it is common. Measured, the bare query `the` costs 0 ms and returns nothing where running
- * it costs 750 ms and returns ten unrelated documents. (An accented word no longer folds
- * onto a common one — `thé`, French for tea, used to land on `the` and is its own term
- * now — so this path is reached by genuinely common words, which is what it was for.)
+ * While a term survives, the survivors are the query. `the brain` keeps one word of two,
+ * and that word is the question: measured, it is 3,3 ms pruned against 716,5 ms unpruned,
+ * and the pruned answer is the better of the two. An earlier rule fell back whenever the
+ * prune dropped more than it kept, which sounds careful and is not — it put a document
+ * saying `in the` sixty times ahead of the one about brains. If a term got through, the
+ * corpus said it discriminates, and second-guessing that measurement re-imports the
+ * guesswork the measurement replaced.
+ *
+ * When nothing survives, there is no question left to run, and what to do then depends on
+ * where the list came from — which is why the caller says, rather than this deciding.
+ *
+ * A curated list holds function words and nothing else, so a query it empties was made of
+ * function words and has no answer to give. Saying so instantly is what search has always
+ * done, and running the raw set instead would replace a free honest miss with a slow
+ * arbitrary hit: measured, the bare query `the` goes from 0 ms and no results to 750 ms and
+ * ten unrelated documents.
+ *
+ * A list measured from a corpus is not like that. It contains whatever that library is
+ * saturated with, and that can be a content word: derived over the English passages of a
+ * real library, `economics` reaches 35%. A query of nothing but such words is a real
+ * question about the library's own subject, and answering it with silence is a worse
+ * failure than answering it slowly — silence looks like an empty library. So there the raw
+ * set runs. (An accented word no longer folds onto a common one — `thé`, French for tea,
+ * used to land on `the` and is its own term now — so these paths are reached by genuinely
+ * common words, which is what they are for.)
  */
 
 /** Whether a term is common enough in this index to be worth dropping from a query. */
 export type TermPredicate = (term: string) => boolean;
 
 /**
- * Distinct terms a query needs before it is worth running unpruned when every one of them
- * is common.
+ * A term is common enough to prune once it appears in this fraction of the passages.
  *
- * Three, and the number is doing less work than it looks. It is not tuned to any query: it
- * separates "one or two common words", which search has always answered with nothing, from
- * "a phrase", which the user plainly meant. The rule it guards applies only when the prune
- * left nothing at all, so no choice of this number can demote a content word.
+ * Measured over a real 477,512-passage library by sweeping the threshold: at 50% only nine
+ * terms drop and the latency barely moves; at 20% the list reaches `energy`, a content
+ * term in that library. The working window is roughly 25-35% and this is the middle of it.
+ *
+ * Judge it on cost alone and keep it high. BM25 already down-weights common terms
+ * continuously and does it better than any step function, so the justification for a hard
+ * cutoff is never ranking quality — it is the posting list not walked.
+ *
+ * **Where this is known to be wrong.** The cutoff assumes a library broad enough that no
+ * subject word saturates it. Derived over the English-language passages of that same
+ * library alone, `economics` reaches 35.1% — a term a specialist searches on, pruned for
+ * being what the library is about. The narrower the library, the closer this gets, and
+ * nothing here detects it.
+ */
+/**
+ * Distinct terms a query needs before it is worth running unpruned when every one of them
+ * is common — the `phrase` answer below.
+ *
+ * Three, and the number is doing less work than it looks: it separates "one or two common
+ * words", which search has always answered with nothing, from "a phrase", which the user
+ * plainly meant. It applies only when the prune left nothing at all, so no choice of it can
+ * demote a content word.
  */
 export const MIN_PHRASE_TERMS = 3;
 
+export const HIGH_DF_RATIO = 0.3;
+
 /**
- * The terms to search on: the common ones removed, and the caller's own set back only when
- * removing them left nothing and there was a phrase to recover. See the header.
+ * Passages a corpus needs before a document frequency says anything about it.
+ *
+ * Below this the rule declines to prune at all, and that is a correctness guard rather
+ * than a nicety. On five passages the 30% bar rounds to two, so an ordinary content word
+ * appearing in two of them is "common" and is dropped from every query that uses it —
+ * and once every term of a query is dropped, the search returns nothing. A small library
+ * would go silent, which is a far worse failure than the slow query pruning exists to
+ * avoid.
+ *
+ * A hundred is not a statistical guarantee, and no threshold here would be. It is the
+ * point below which the proportion is plainly meaningless, chosen to be obviously safe
+ * rather than tight: a real library reaches it within a handful of documents, and the
+ * cost of being wrong on the low side is silence.
  */
-export function pruneTerms(terms: string[], prunable: TermPredicate): string[] {
+export const MIN_DERIVATION_PASSAGES = 100;
+
+/**
+ * How far the passage count may move before the list is derived again.
+ *
+ * A handful of new items cannot move the threshold, and the derivation costs a full scan
+ * of the term vocabulary — seconds on a large index. Paying that on every small delta is
+ * the one way this becomes visible to a user, so the cost is amortised against the drift
+ * that could change the answer. Drift in COUNT only: a library that replaces its subject
+ * without changing size does not trigger a rescan.
+ */
+export const REDERIVE_DRIFT = 0.1;
+
+/**
+ * The document frequency at which a term becomes prunable, in passages.
+ *
+ * Rounded up, so a corpus of three passages puts the bar at one and every term clears it.
+ * That does NOT fall out harmlessly, and an earlier version of this comment claimed it
+ * did: a list naming the whole vocabulary prunes every query to nothing, and nothing is
+ * then what the search returns. The derivation guards against it by declining to store a
+ * list that covers the entire vocabulary — see `refreshDroplist`.
+ */
+export function highDfMinimum(passages: number): number {
+  return Math.ceil(passages * HIGH_DF_RATIO);
+}
+
+/**
+ * What to answer when pruning leaves nothing at all.
+ *
+ * `phrase` is the answer a curated list earns: it holds function words and nothing else, so
+ * a query it empties was made of function words. One or two of them are not a question and
+ * are answered with nothing, instantly; three or more are a phrase the user typed, and that
+ * is worth running.
+ *
+ * `raw` is the answer a measured list requires, and the difference is the whole reason this
+ * is a parameter. A list read off a corpus holds whatever that library is saturated with,
+ * and that can be its own subject: derived over the English passages of a real library,
+ * `economics` reaches 35%. `economics`, typed alone into a library about economics, is a
+ * real question, and answering it with silence because the word is common would be a worse
+ * failure than answering it slowly. So there, whatever is left of the query runs.
+ *
+ * No production call site currently passes `phrase`: both backends measure their lists, so
+ * both pass `raw`. The mode is kept because it is the correct answer for any future caller
+ * holding a curated list, and only the call site can know which kind of list it holds.
+ */
+export type WhenNothingSurvives = 'phrase' | 'raw';
+
+/**
+ * The terms to search on. See the header: the prune is never undone while a term survives,
+ * and what happens when none does is the caller's to say.
+ *
+ * `prunable` is undefined where an index has nothing to prune by — one written before this
+ * existed, or one whose derivation failed — and then this is the identity. An index that has
+ * not been told which terms are common must not guess.
+ */
+export function pruneTerms(
+  terms: string[],
+  prunable: TermPredicate | undefined,
+  whenNothingSurvives: WhenNothingSurvives = 'phrase',
+): string[] {
+  if (!prunable) return terms;
   const kept = terms.filter((t) => !prunable(t));
   // Something survived. It is the query — never second-guess it.
   if (kept.length) return kept;
-  // Nothing survived. A phrase runs as typed; one or two common words answer as they always
-  // have, with nothing, for free.
+  if (whenNothingSurvives === 'raw') return terms;
   return terms.length >= MIN_PHRASE_TERMS ? terms : kept;
 }
 

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -4,7 +4,8 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, rename, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
-import { tokenize } from './tokenize.js';
+import { pruneTerms } from './query-terms.js';
+import { isStopword, tokenize } from './tokenize.js';
 import { SearchIndexCorruptError, isCorruptionError, isQuerySyntaxError, sidecarsOf } from './corruption.js';
 import { VectorSalvage } from './vector-salvage.js';
 import { DEFAULT_ANN_MIN_CANDIDATES, DEFAULT_ANN_OVERSAMPLE } from './limits.js';
@@ -1132,7 +1133,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * scale of their scores.
    */
   protected keywordSearch(q: string, topK: number): RankedId[] {
-    const terms = [...new Set(tokenize(q))];
+    const terms = pruneTerms([...new Set(tokenize(q))], isStopword);
     if (!terms.length) return [];
     const match = terms.map(ftsTerm).join(' OR ');
     try {

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -5,8 +5,14 @@ import { mkdir, readFile, rename, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
 import { pruneTerms } from './query-terms.js';
-import { isStopword, tokenize } from './tokenize.js';
-import { SearchIndexCorruptError, isCorruptionError, isQuerySyntaxError, sidecarsOf } from './corruption.js';
+import { accentKey, isStopword, normalizeForSearch, tokenize } from './tokenize.js';
+import {
+  SearchIndexCorruptError,
+  SearchIndexUnreadableError,
+  isCorruptionError,
+  isQuerySyntaxError,
+  sidecarsOf,
+} from './corruption.js';
 import { VectorSalvage } from './vector-salvage.js';
 import { DEFAULT_ANN_MIN_CANDIDATES, DEFAULT_ANN_OVERSAMPLE } from './limits.js';
 import type {
@@ -47,7 +53,54 @@ export const MAX_MIGRATION_BYTES = 200 * 1024 * 1024;
  * charged its owner a full re-embed (hours, and real API spend) for a cache the server
  * can rebuild from what is already on disk.
  */
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
+
+/**
+ * How the keyword index tokenizes, in one place because the migration rung has to declare
+ * exactly what `createSchema` declares.
+ *
+ * `remove_diacritics 0`, not 2, and the difference is a correctness fix rather than a
+ * preference. Stripping marks from every token does not normalize spelling in a library
+ * that holds more than one language, it merges vocabulary: `án` onto `an`, `bé` onto `be`,
+ * two distinct Vietnamese words onto `the`. The recall that stripping bought — typing
+ * `theorie` and finding the accented spelling — is kept on the QUERY side instead: an
+ * unaccented query term is expanded to the accented variants the vocabulary actually
+ * holds (`accent_variants`), so the index itself stores each word exactly once, as
+ * written. See tokenize.ts.
+ */
+const FTS_TOKENIZER = 'unicode61 remove_diacritics 0';
+
+/**
+ * Rebuild the folded-form → accented-spelling map from the keyword index's own vocabulary.
+ *
+ * `fts5vocab` is a virtual table over the existing FTS index — nothing is stored until
+ * this SELECT materialises it — and the scan is the only full read: on a 477 512-passage
+ * library it visits 639 888 terms in about two seconds, which is why the map is derived
+ * state with a home (this table) rather than a query-time computation. Incremental inserts
+ * keep it current afterwards (`addRecord`); deletions may leave a variant behind, which
+ * costs one zero-hit term in an expanded MATCH and never a wrong result, and the next
+ * full build recreates the map from scratch through this same function.
+ */
+function deriveAccentVariants(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS accent_variants (
+      folded TEXT NOT NULL,
+      term TEXT NOT NULL,
+      PRIMARY KEY (folded, term)
+    ) WITHOUT ROWID;
+    DELETE FROM accent_variants;
+    CREATE VIRTUAL TABLE temp.accent_vocab USING fts5vocab('main', 'passages_fts', 'row');
+  `);
+  const insert = db.prepare('INSERT OR IGNORE INTO accent_variants(folded, term) VALUES (?, ?)');
+  for (const row of db.prepare('SELECT term FROM temp.accent_vocab').iterate() as Iterable<{ term: string }>) {
+    const folded = accentKey(row.term);
+    if (folded !== row.term && folded.length > 1) insert.run(folded, row.term);
+  }
+  db.exec('DROP TABLE temp.accent_vocab');
+  // The stamp `ensureAccentVariants` checks, so an all-ASCII library (map legitimately
+  // empty) is not re-scanned on every open.
+  db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run('accentVariantsDerived', '1');
+}
 
 /**
  * One rung of the upgrade ladder: how a database stamped `to - 1` becomes one stamped `to`.
@@ -79,13 +132,42 @@ export interface SchemaMigration {
 }
 
 /**
- * The ladder, in ascending order. Empty because SCHEMA_VERSION has never been bumped: the
- * stamp was introduced as 1 with the SQLite backend and is still 1. That is precisely why
- * this is here now — a migration path is cheap to build before the first bump and
- * expensive to wish for afterwards, when every index in the field has already been
- * sidelined by it.
+ * The ladder, in ascending order. The first rung is exactly the case the ladder was built
+ * for: the tokenizer changed, so every passage must be tokenized again — and not one
+ * vector is touched. Without it the bump would sideline every index in the field and
+ * charge it the re-embed the interface comment above prices at five and a half hours of
+ * local CPU.
  */
-export const SCHEMA_MIGRATIONS: SchemaMigration[] = [];
+export const SCHEMA_MIGRATIONS: SchemaMigration[] = [
+  {
+    to: 2,
+    what: 'keeps diacritics in the keyword index, answering unaccented queries by expansion',
+    up(db) {
+      db.exec('DROP TABLE IF EXISTS passages_fts');
+      db.exec(`
+        CREATE VIRTUAL TABLE passages_fts USING fts5(
+          text,
+          content='passages',
+          content_rowid='pid',
+          tokenize='${FTS_TOKENIZER}'
+        );
+      `);
+      const insert = db.prepare('INSERT INTO passages_fts(rowid, text) VALUES (?, ?)');
+      // Paged by rowid rather than read whole: the text of a full-text library is hundreds
+      // of megabytes, and a migration needing all of it resident is one that fails on the
+      // machines least able to afford the rebuild it is there to avoid.
+      const page = db.prepare('SELECT pid, text FROM passages WHERE pid > ? ORDER BY pid LIMIT 2000');
+      let after = 0;
+      for (;;) {
+        const rows = page.all(after) as Array<{ pid: number; text: string }>;
+        if (!rows.length) break;
+        for (const r of rows) insert.run(r.pid, normalizeForSearch(r.text));
+        after = rows[rows.length - 1]!.pid;
+      }
+      deriveAccentVariants(db);
+    },
+  },
+];
 
 /**
  * Passage rowids per rescore statement. The exact stage fetches its candidates by rowid in
@@ -181,6 +263,8 @@ interface Statements {
   insertItem: StatementSync;
   insertPassage: StatementSync;
   insertFts: StatementSync;
+  insertVariant: StatementSync;
+  variantsFor: StatementSync;
   deleteFts: StatementSync;
   itemPassages: StatementSync;
   itemFulltext: StatementSync;
@@ -305,6 +389,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
       if (existed) await this.reconcileSchema();
       if (!this.db) this.openHandle();
       this.createSchema();
+      this.ensureAccentVariants();
       this.prepareStatements();
       // `existed` deliberately still gates the import after a sideline: the legacy JSON
       // was already consumed by whichever build wrote the incompatible database, and
@@ -322,6 +407,23 @@ export class SqliteSearchIndex extends SearchIndexBase {
       await this.close().catch(() => {});
       throw e instanceof SearchIndexCorruptError ? e : new SearchIndexCorruptError(this.file, e);
     }
+  }
+
+  /**
+   * Derive the expansion map once for a database that predates it or lost it.
+   *
+   * `accent_variants` is derived state, so it is recoverable by construction: a schema-2
+   * database whose map is absent (created by a build that never derived, or deleted by
+   * hand) is healed here with one vocabulary scan — about two seconds on a 477 512-passage
+   * library — instead of being wrong quietly. The meta stamp keeps the scan from running
+   * on every open of a library whose map is legitimately empty.
+   */
+  private ensureAccentVariants(): void {
+    const row = this.handle
+      .prepare("SELECT value FROM meta WHERE key = 'accentVariantsDerived'")
+      .get() as { value?: string } | undefined;
+    if (row?.value === '1') return;
+    deriveAccentVariants(this.handle);
   }
 
   /** Create the writable handle and apply its connection pragmas, after the schema probe. */
@@ -429,11 +531,30 @@ export class SqliteSearchIndex extends SearchIndexBase {
     const ladder = typeof stored === 'number' ? this.migrationPath(stored) : undefined;
     if (ladder) {
       const failure = this.runMigrations(stored as number, ladder);
-      if (!failure) return;
+      if (failure === undefined) return;
       // A migration that threw rolled itself back, so the file is untouched at its old
-      // stamp — which is the one state the sideline below was written for.
-      await this.sideline(stored, contents, failure);
-      return;
+      // stamp. What happens next depends on WHY it threw, and the two answers must not
+      // be merged: a corrupt database is evidence to move aside, but a transient error —
+      // a full disk, a file-size limit, a lock — is a proven-intact database that failed
+      // to upgrade TODAY. Sidelining it would discard a complete index (and start an
+      // empty one) over a condition a retry can clear; `isCorruptionError` exists for
+      // exactly this distinction, so it is consulted here.
+      if (isCorruptionError(failure)) {
+        await this.sideline(stored, contents, failure instanceof Error ? failure.message : String(failure));
+        return;
+      }
+      // Not corruption: leave the file at its old stamp and surface the failure. The
+      // factory degrades this into "search refuses, and says why" — the server survives,
+      // nothing is written over the file, and the next open retries the ladder against an
+      // untouched database.
+      throw new SearchIndexUnreadableError(
+        this.file,
+        new Error(
+          `it is intact at schema version ${stored} but could not be upgraded to ` +
+            `${this.schemaVersion} (${failure instanceof Error ? failure.message : String(failure)}); ` +
+            'the file was left untouched and the upgrade will be retried on the next open',
+        ),
+      );
     }
     await this.sideline(stored, contents);
   }
@@ -459,7 +580,8 @@ export class SqliteSearchIndex extends SearchIndexBase {
 
   /**
    * Run the ladder, and stamp the new version in the same transaction. Returns undefined
-   * on success, or the reason to sideline instead.
+   * on success, or the error itself — the CAUSE, not its message, because the caller has
+   * to ask `isCorruptionError` of it before deciding between sideline and refusal.
    *
    * One transaction over every rung, and the stamp inside it: a database is either fully
    * at the new version or still fully at the old one, never at some half-applied state
@@ -468,7 +590,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * rule the probe protects is "do not write into a database this build does not
    * understand" — a rung that exists is this build saying it understands this one.
    */
-  private runMigrations(stored: number, steps: SchemaMigration[]): string | undefined {
+  private runMigrations(stored: number, steps: SchemaMigration[]): unknown {
     this.openHandle();
     const db = this.handle;
     try {
@@ -491,12 +613,18 @@ export class SqliteSearchIndex extends SearchIndexBase {
       // failure means were never prepared.
       this.db?.close();
       this.db = undefined;
-      return e instanceof Error ? e.message : String(e);
+      // `?? new Error(...)`: a thrown nullish value must not read as the success return.
+      return e ?? new Error('migration failed with a nullish throw');
     }
     const what = steps.map((s) => s.what).join('; ');
     this.storeNotice =
       `The search index at ${this.file} was upgraded in place from schema version ${stored} to ` +
-      `${this.schemaVersion} (${what}). Nothing was re-indexed and no vectors were re-computed.`;
+      // "Nothing was re-indexed" used to be part of this sentence. It was true while the
+      // ladder was empty; it is not a property of the mechanism, and the first real rung
+      // re-indexes every passage. What the ladder does guarantee is the expensive half —
+      // a rung runs inside the stamping transaction and nothing in it embeds — so that is
+      // what the notice claims, and the rung's own `what` says the rest.
+      `${this.schemaVersion} (${what}). No vectors were re-computed.`;
     this.opts.logger?.info(this.storeNotice);
     return undefined;
   }
@@ -703,15 +831,23 @@ export class SqliteSearchIndex extends SearchIndexBase {
       -- losing this table costs a pass, never data.
       CREATE TABLE IF NOT EXISTS vector_codes (pid INTEGER PRIMARY KEY, code BLOB NOT NULL);
       -- External content: the passage text is stored once, in the passages table, and the
-      -- index points back at it by rowid. remove_diacritics 2 folds accents, so "Bronte"
-      -- finds "Brontë". The query side folds to match, in tokenize.ts, which is where the
-      -- JSON backend folds too: one normalizer in front of the tokenizer both share.
+      -- index points back at it by rowid. remove_diacritics 0 keeps accents: "Brontë" is
+      -- indexed as written, and an unaccented query reaches it through accent_variants
+      -- below, never by folding the index. See FTS_TOKENIZER.
       CREATE VIRTUAL TABLE IF NOT EXISTS passages_fts USING fts5(
         text,
         content='passages',
         content_rowid='pid',
-        tokenize='unicode61 remove_diacritics 2'
+        tokenize='${FTS_TOKENIZER}'
       );
+      -- The folded-form → accented-spelling map queries expand through: derived from the
+      -- FTS vocabulary (deriveAccentVariants), kept current by addRecord. Derived state:
+      -- losing this table costs one vocabulary scan, never data.
+      CREATE TABLE IF NOT EXISTS accent_variants (
+        folded TEXT NOT NULL,
+        term TEXT NOT NULL,
+        PRIMARY KEY (folded, term)
+      ) WITHOUT ROWID;
     `);
     this.handle
       .prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)')
@@ -728,6 +864,8 @@ export class SqliteSearchIndex extends SearchIndexBase {
         'INSERT INTO passages(id, item_key, title, text, source) VALUES (?, ?, ?, ?, ?)',
       ),
       insertFts: db.prepare('INSERT INTO passages_fts(rowid, text) VALUES (?, ?)'),
+      insertVariant: db.prepare('INSERT OR IGNORE INTO accent_variants(folded, term) VALUES (?, ?)'),
+      variantsFor: db.prepare('SELECT term FROM accent_variants WHERE folded = ?'),
       // The external-content delete protocol: FTS5 stores no text of its own, so a row is
       // retired by handing back the exact rowid and text that were indexed. A bare DELETE
       // on `passages` would leave the index pointing at a rowid that no longer resolves,
@@ -973,7 +1111,18 @@ export class SqliteSearchIndex extends SearchIndexBase {
   protected putPassage(rec: ChunkRecord): void {
     this.begin();
     const res = this.stmts.insertPassage.run(rec.id, rec.itemKey, rec.title, rec.text, rec.source ?? null);
-    this.stmts.insertFts.run(Number(res.lastInsertRowid), rec.text);
+    // Normalized once, here, so what FTS tokenizes is exactly what the JS query side
+    // produces (NFC, unicode61-aware case fold) — unicode61 itself normalizes nothing.
+    // The delete sites below re-derive the same string from passages.text, which the
+    // external-content protocol requires to match byte for byte.
+    this.stmts.insertFts.run(Number(res.lastInsertRowid), normalizeForSearch(rec.text));
+    // Keep the expansion map current as the vocabulary grows. A deletion may leave an
+    // entry behind; that costs one zero-hit term in an expanded query, never a wrong
+    // result, and the next full build re-derives the map (deriveAccentVariants).
+    for (const t of new Set(tokenize(rec.text))) {
+      const folded = accentKey(t);
+      if (folded !== t && folded.length > 1) this.stmts.insertVariant.run(folded, t);
+    }
     this.c.documents++;
     if (rec.source === 'fulltext') {
       this.c.fulltextPassages++;
@@ -1009,7 +1158,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
       has_vector: number;
     }>;
     for (const row of rows) {
-      this.stmts.deleteFts.run(row.pid, row.text);
+      this.stmts.deleteFts.run(row.pid, normalizeForSearch(row.text));
       this.c.documents--;
       if (row.has_vector) this.c.vectors--;
       if (row.source === 'fulltext') this.c.fulltextPassages--;
@@ -1048,7 +1197,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     this.begin();
     const rows = this.stmts.itemFulltext.all(itemKey) as Array<{ pid: number; text: string; has_vector: number }>;
     for (const row of rows) {
-      this.stmts.deleteFts.run(row.pid, row.text);
+      this.stmts.deleteFts.run(row.pid, normalizeForSearch(row.text));
       this.c.documents--;
       this.c.fulltextPassages--;
       if (row.has_vector) this.c.vectors--;
@@ -1066,7 +1215,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     this.begin();
     const rows = this.stmts.itemOwnWords.all(itemKey) as Array<{ pid: number; text: string; has_vector: number }>;
     for (const row of rows) {
-      this.stmts.deleteFts.run(row.pid, row.text);
+      this.stmts.deleteFts.run(row.pid, normalizeForSearch(row.text));
       this.c.documents--;
       this.c.ownWordsPassages--;
       if (row.has_vector) this.c.vectors--;
@@ -1135,7 +1284,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
   protected keywordSearch(q: string, topK: number): RankedId[] {
     const terms = pruneTerms([...new Set(tokenize(q))], isStopword);
     if (!terms.length) return [];
-    const match = terms.map(ftsTerm).join(' OR ');
+    const match = terms.map((t) => this.expandTerm(t)).join(' OR ');
     try {
       const rows = this.stmts.keyword.all(match, topK) as Array<{ id: string; rank: number }>;
       return rows.map((r) => ({ id: r.id, score: -r.rank }));
@@ -1153,6 +1302,25 @@ export class SqliteSearchIndex extends SearchIndexBase {
       this.opts.logger?.debug(`FTS5 query rejected (${match}): ${e instanceof Error ? e.message : String(e)}`);
       return [];
     }
+  }
+
+  /**
+   * One query term as its MATCH fragment: the term itself, OR-grouped with the accented
+   * spellings the index holds for it when the term carries no marks of its own.
+   *
+   * The direction is deliberate and asymmetric. An unaccented term expands — accents are
+   * the first thing lost to keyboards, copy-paste and OCR, so `theorie` runs as
+   * `("theorie" OR "théorie")` and reaches the accented documents without one extra token
+   * in the index. An accented term never expands: folding `thể` toward `the` is the
+   * vocabulary merge this change exists to end. Each variant keeps its own idf under
+   * FTS5's bm25 — a rare accented spelling stays rare.
+   */
+  private expandTerm(term: string): string {
+    if (accentKey(term) !== term) return ftsTerm(term);
+    const variants = this.stmts.variantsFor.all(term) as Array<{ term: string }>;
+    if (!variants.length) return ftsTerm(term);
+    const group = [term, ...variants.map((v) => v.term)].map(ftsTerm).join(' OR ');
+    return `(${group})`;
   }
 
   /**

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, rename, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
-import { pruneTerms } from './query-terms.js';
+import { MAX_ACCENT_VARIANTS, pruneTerms } from './query-terms.js';
 import { accentKey, isStopword, normalizeForSearch, tokenize } from './tokenize.js';
 import {
   SearchIndexCorruptError,
@@ -83,6 +83,11 @@ const FTS_TOKENIZER = 'unicode61 remove_diacritics 0';
  */
 function deriveAccentVariants(db: Database): void {
   db.exec(`
+    -- The stamp comes OFF first and goes back on last, so a derivation that dies midway
+    -- (this function can run inside a build's own transaction, whose commit would keep
+    -- the partial table) leaves no stamp — and an unstamped map is re-derived
+    -- unconditionally on the next open, never trusted.
+    DELETE FROM meta WHERE key = 'accentVariantsPassages';
     DROP TABLE IF EXISTS accent_variants;
     CREATE TABLE accent_variants (
       folded TEXT NOT NULL,
@@ -90,6 +95,7 @@ function deriveAccentVariants(db: Database): void {
       df INTEGER NOT NULL,
       PRIMARY KEY (folded, term)
     ) WITHOUT ROWID;
+    DROP TABLE IF EXISTS temp.accent_vocab;
     CREATE VIRTUAL TABLE temp.accent_vocab USING fts5vocab('main', 'passages_fts', 'row');
   `);
   const insert = db.prepare('INSERT OR IGNORE INTO accent_variants(folded, term, df) VALUES (?, ?, ?)');
@@ -136,7 +142,9 @@ function deriveAccentVariants(db: Database): void {
  *  - add a rung whose `to` is the new version, or deliberately do not, and understand
  *    that not adding one sidelines every existing index and charges it a re-embed;
  *  - `up` runs inside the transaction that stamps the new version, so a step that throws
- *    leaves the database exactly as it was, at its old stamp, and the sideline takes over;
+ *    leaves the database exactly as it was, at its old stamp. What happens then depends
+ *    on why it threw: a corrupt file is sidelined, anything else is refused with the
+ *    reason and retried on the next open (see reconcileSchema);
  *  - the ladder must be contiguous. A database is migrated only when every rung from its
  *    stamp to this one exists, because a gap means some version's rows were never
  *    accounted for by anything.
@@ -572,14 +580,26 @@ export class SqliteSearchIndex extends SearchIndexBase {
       // factory degrades this into "search refuses, and says why" — the server survives,
       // nothing is written over the file, and the next open retries the ladder against an
       // untouched database.
-      throw new SearchIndexUnreadableError(
+      const refusal = new SearchIndexUnreadableError(
         this.file,
         new Error(
           `it is intact at schema version ${stored} but could not be upgraded to ` +
-            `${this.schemaVersion} (${failure instanceof Error ? failure.message : String(failure)}); ` +
-            'the file was left untouched and the upgrade will be retried on the next open',
+            `${this.schemaVersion} (${failure instanceof Error ? failure.message : String(failure)})`,
         ),
       );
+      // The class's stock message ends in rebuild advice, and for THIS refusal that
+      // advice is exactly wrong: a rebuild deletes an intact, fully-vectorized database
+      // to cure a transient condition a restart cures for free. Say the right thing
+      // instead — the refusal is the whole value of this path.
+      refusal.message =
+        `The search index at ${this.file} is intact at schema version ${stored} but could not be ` +
+        `upgraded to ${this.schemaVersion}: ${failure instanceof Error ? failure.message : String(failure)}. ` +
+        'The file was left untouched and nothing will be written over it. Search is unavailable until the ' +
+        'upgrade succeeds; every other tool still works. Fix the underlying condition (a full disk, a file ' +
+        'limit, another process holding the database) and restart the server — the upgrade then completes ' +
+        'in place, with nothing re-read from Zotero and no vectors re-computed. A rebuild is NOT needed ' +
+        'and would discard a usable index.';
+      throw refusal;
     }
     await this.sideline(stored, contents);
   }
@@ -1353,7 +1373,12 @@ export class SqliteSearchIndex extends SearchIndexBase {
     const selfDf = (rows.find((v) => v.term === term)?.df ?? 0);
     const variantsDf = variants.reduce((s, v) => s + v.df, 0);
     if (variantsDf <= selfDf) return ftsTerm(term);
-    const group = [term, ...variants.map((v) => v.term)].map(ftsTerm).join(' OR ');
+    // Capped, best spellings first, so no key can grow a query without bound: the widest
+    // group a real 477 512-passage EN/FR/VI library produced was 15 spellings, and a
+    // document seeded with hundreds of crafted spellings of one key must cost the
+    // attacker an indexing job, not every future user a posting-list merge per spelling.
+    const kept = [...variants].sort((a, b) => b.df - a.df).slice(0, MAX_ACCENT_VARIANTS);
+    const group = [term, ...kept.map((v) => v.term)].map(ftsTerm).join(' OR ');
     return `(${group})`;
   }
 

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -4,8 +4,15 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, rename, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { SearchIndexBase } from './index-manager.js';
-import { MAX_ACCENT_VARIANTS, pruneTerms } from './query-terms.js';
-import { accentKey, isStopword, normalizeForSearch, tokenize } from './tokenize.js';
+import {
+  highDfMinimum,
+  MAX_ACCENT_VARIANTS,
+  MIN_DERIVATION_PASSAGES,
+  pruneTerms,
+  REDERIVE_DRIFT,
+  type TermPredicate,
+} from './query-terms.js';
+import { accentKey, normalizeForSearch, tokenize } from './tokenize.js';
 import {
   SearchIndexCorruptError,
   SearchIndexUnreadableError,
@@ -386,6 +393,18 @@ export class SqliteSearchIndex extends SearchIndexBase {
   private codesUnusable: string | undefined;
   /** Whether the database holds any code at all, so a fresh build skips 255k no-op deletes. */
   private hasCodes = false;
+  /**
+   * This library's droplist, as derived at the last build, or undefined where the database
+   * holds none.
+   *
+   * The distinction is load-bearing, and it is the reason this is not simply an empty set:
+   * undefined means an index written before droplists existed, which must behave exactly as
+   * it did then and prune nothing, while an empty set is a real derivation over a corpus no
+   * term saturates. Both prune nothing today; only the first is owed an adoption.
+   */
+  private dropSet: Set<string> | undefined;
+  /** The passage count the droplist was derived at, against which drift is measured. */
+  private dropSetPassages = 0;
   /** Rescore statements by candidate count; see RESCORE_BATCH. */
   private rescoreStmts = new Map<number, StatementSync>();
 
@@ -1016,6 +1035,12 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // Absent in databases written before the library stamp: an unstamped index refuses
     // nothing (assertLibrary), so old files keep building rather than stranding.
     this.library = this.meta('library') || undefined;
+    // Absent in databases written before the droplist: such an index prunes nothing until
+    // its next build or update derives one, which is the same adoption the library stamp
+    // gets. `??` and not `||`, so a genuinely empty droplist stays a derivation.
+    const droplist = this.meta('droplist');
+    this.dropSet = droplist === undefined ? undefined : new Set(droplist.split(' ').filter(Boolean));
+    this.dropSetPassages = Number(this.meta('droplistPassages') ?? 0) || 0;
     // An index that HOLDS full-text passages counts as full-text-enabled, even before this
     // process runs a build of its own (same rule as the JSON backend's load).
     this.fulltextEnabled = this.c.fulltextPassages > 0;
@@ -1324,7 +1349,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * scale of their scores.
    */
   protected keywordSearch(q: string, topK: number): RankedId[] {
-    const terms = pruneTerms([...new Set(tokenize(q))], isStopword);
+    const terms = pruneTerms([...new Set(tokenize(q))], this.highDf(), 'raw');
     if (!terms.length) return [];
     const match = terms.map((t) => this.expandTerm(t)).join(' OR ');
     try {
@@ -1800,6 +1825,98 @@ export class SqliteSearchIndex extends SearchIndexBase {
           'semantic queries will scan every vector instead.',
       );
     }
+  }
+
+  protected highDf(): TermPredicate | undefined {
+    const drop = this.dropSet;
+    if (!drop) return undefined;
+    return (t: string) => drop.has(t);
+  }
+
+  /**
+   * Derive this library's droplist from the keyword index and store it, when the corpus has
+   * moved far enough to be worth the scan.
+   *
+   * **Why derived state, when FTS5 already knows every term's document frequency.** It does
+   * not know it in a form that can be asked. `fts5vocab` is a virtual table over the index
+   * that already exists — no migration, no rebuild, nothing stored — but it is ordered by
+   * term, not by document count, so a "which terms exceed 30%" question is a full scan of
+   * it: measured over 639 888 terms on a 477 512-passage library at 2 020 ms on a first
+   * call and 1 774 ms on a second (an earlier pair on the same machine read 2 281
+   * and 2 013 ms). Those are WARM figures — the
+   * page cache is not dropped between runs, and dropping it needs privileges a test does
+   * not have, so the cold cost is unmeasured and is not guessed at here. Warm is already
+   * far too slow for query time and too slow to pay at every server start. Everything else
+   * about the answer is small — 23 terms, 75 bytes stored at that size — so the scan
+   * happens where a full walk of the corpus is already being paid for.
+   *
+   * **The cadence, therefore.** At the end of a full build, which already costs ~264 s on
+   * that library, so this is under 1% on top and invisible. Not on every delta, where 2 s
+   * would be the one user-visible cost in the feature and where a handful of new items
+   * cannot move a 30% threshold anyway — the stored passage count is what turns that into a
+   * rule rather than a hope. And unconditionally when the database holds no droplist at
+   * all, which is how an index built by an older version adopts one.
+   *
+   * The temp-schema virtual table is dropped again: `fts5vocab` reads the index it names
+   * and stores nothing, so leaving it would still add a row to `sqlite_master` that an
+   * older build would not understand.
+   */
+  protected refreshDroplist(force: boolean): void {
+    if (!this.db) return;
+    const passages = this.c.documents;
+    if (!force && !this.droplistIsStale(passages)) return;
+    try {
+      this.begin();
+      const db = this.handle;
+      db.exec("CREATE VIRTUAL TABLE IF NOT EXISTS temp.passages_vocab USING fts5vocab('main', 'passages_fts', 'row')");
+      try {
+        // Too small for a proportion to mean anything: derive an empty list rather than no
+        // list, so the index records that it looked and found nothing to prune.
+        const rows = (passages < MIN_DERIVATION_PASSAGES
+          ? []
+          : db
+              .prepare('SELECT term FROM temp.passages_vocab WHERE doc >= ?')
+              .all(highDfMinimum(passages))) as Array<{ term: string }>;
+        // A list naming every term in the vocabulary is not a list. It happens on a corpus
+        // too small for a document frequency to mean anything — three passages put the bar
+        // at one, so everything clears it — and the consequence is not a slow index but a
+        // silent one: every query prunes to nothing and nothing is what it returns. So the
+        // rule declines to act rather than acting on a statistic it does not have.
+        const vocabulary = (db.prepare('SELECT count(*) AS n FROM temp.passages_vocab').get() as { n: number }).n;
+        if (rows.length >= vocabulary) rows.length = 0;
+        // Sorted so the stored value is a function of the corpus and not of the scan order,
+        // which makes two derivations over the same index byte-comparable.
+        const terms = rows.map((r) => r.term).sort();
+        this.dropSet = new Set(terms);
+        this.dropSetPassages = passages;
+        this.stmts.setMeta.run('droplist', terms.join(' '));
+        this.stmts.setMeta.run('droplistPassages', String(passages));
+        this.opts.logger?.debug(`search index: droplist of ${terms.length} term(s) over ${passages} passages`);
+      } finally {
+        db.exec('DROP TABLE IF EXISTS temp.passages_vocab');
+      }
+    } catch (e) {
+      if (isCorruptionError(e)) {
+        this.noteCorruption(e);
+        return;
+      }
+      // Same rule as the codes: a droplist that could not be derived is a slower index,
+      // never a failed build. The previous one — or none — stays in force.
+      this.opts.logger?.warn(
+        `The query droplist could not be derived (${e instanceof Error ? e.message : String(e)}); ` +
+          'keyword queries will be sent unpruned.',
+      );
+    }
+  }
+
+  /** Whether the corpus has drifted far enough since the droplist was derived to redo it. */
+  private droplistIsStale(passages: number): boolean {
+    if (this.dropSet === undefined) return true;
+    // <= 0 rather than === 0: the count is re-read from `meta` on open, and a nonsensical
+    // stored value must count as stale — a negative one would otherwise make the drift
+    // ratio negative and suppress rederivation forever.
+    if (this.dropSetPassages <= 0) return true;
+    return Math.abs(passages - this.dropSetPassages) / this.dropSetPassages > REDERIVE_DRIFT;
   }
 
   protected passage(id: string): ChunkRecord | undefined {

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -83,23 +83,42 @@ const FTS_TOKENIZER = 'unicode61 remove_diacritics 0';
  */
 function deriveAccentVariants(db: Database): void {
   db.exec(`
-    CREATE TABLE IF NOT EXISTS accent_variants (
+    DROP TABLE IF EXISTS accent_variants;
+    CREATE TABLE accent_variants (
       folded TEXT NOT NULL,
       term TEXT NOT NULL,
+      df INTEGER NOT NULL,
       PRIMARY KEY (folded, term)
     ) WITHOUT ROWID;
-    DELETE FROM accent_variants;
     CREATE VIRTUAL TABLE temp.accent_vocab USING fts5vocab('main', 'passages_fts', 'row');
   `);
-  const insert = db.prepare('INSERT OR IGNORE INTO accent_variants(folded, term) VALUES (?, ?)');
-  for (const row of db.prepare('SELECT term FROM temp.accent_vocab').iterate() as Iterable<{ term: string }>) {
+  const insert = db.prepare('INSERT OR IGNORE INTO accent_variants(folded, term, df) VALUES (?, ?, ?)');
+  const keys = new Set<string>();
+  for (const row of db.prepare('SELECT term, doc FROM temp.accent_vocab').iterate() as Iterable<{
+    term: string;
+    doc: number;
+  }>) {
     const folded = accentKey(row.term);
-    if (folded !== row.term && folded.length > 1) insert.run(folded, row.term);
+    if (folded !== row.term && folded.length > 1) {
+      insert.run(folded, row.term, row.doc);
+      keys.add(folded);
+    }
+  }
+  // The key's own document frequency, stored as a self row (term = folded), because the
+  // expansion gate compares the two sides of one question: is this spelling, in THIS
+  // corpus, predominantly the accented word? `theorie` (df 214 against 955 accented) is;
+  // `trong` (25 771 against 7 027 Vietnamese siblings) is not.
+  const selfDf = db.prepare('SELECT doc FROM temp.accent_vocab WHERE term = ?');
+  for (const k of keys) {
+    const row = selfDf.get(k) as { doc: number } | undefined;
+    if (row) insert.run(k, k, row.doc);
   }
   db.exec('DROP TABLE temp.accent_vocab');
-  // The stamp `ensureAccentVariants` checks, so an all-ASCII library (map legitimately
-  // empty) is not re-scanned on every open.
-  db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run('accentVariantsDerived', '1');
+  // The refresh stamp: how many passages the map was derived over. Read by
+  // `refreshAccentVariants`, so an unchanged library (and an all-ASCII one, whose map is
+  // legitimately empty) is not re-scanned on every open.
+  const n = (db.prepare('SELECT COUNT(*) AS n FROM passages').get() as { n: number }).n;
+  db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run('accentVariantsPassages', String(n));
 }
 
 /**
@@ -263,7 +282,6 @@ interface Statements {
   insertItem: StatementSync;
   insertPassage: StatementSync;
   insertFts: StatementSync;
-  insertVariant: StatementSync;
   variantsFor: StatementSync;
   deleteFts: StatementSync;
   itemPassages: StatementSync;
@@ -389,7 +407,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
       if (existed) await this.reconcileSchema();
       if (!this.db) this.openHandle();
       this.createSchema();
-      this.ensureAccentVariants();
+      this.refreshAccentVariants();
       this.prepareStatements();
       // `existed` deliberately still gates the import after a sideline: the legacy JSON
       // was already consumed by whichever build wrote the incompatible database, and
@@ -418,11 +436,18 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * library — instead of being wrong quietly. The meta stamp keeps the scan from running
    * on every open of a library whose map is legitimately empty.
    */
-  private ensureAccentVariants(): void {
+  private refreshAccentVariants(): void {
     const row = this.handle
-      .prepare("SELECT value FROM meta WHERE key = 'accentVariantsDerived'")
+      .prepare("SELECT value FROM meta WHERE key = 'accentVariantsPassages'")
       .get() as { value?: string } | undefined;
-    if (row?.value === '1') return;
+    const current = (this.handle.prepare('SELECT COUNT(*) AS n FROM passages').get() as { n: number }).n;
+    if (row?.value !== undefined) {
+      const stored = Number(row.value);
+      // The droplist cadence (see the derived-state note on deriveAccentVariants): a
+      // handful of new items cannot move which spelling dominates, so rescan only when
+      // the passage count has drifted by more than ~10% since the map was derived.
+      if (Math.abs(current - stored) <= 0.1 * Math.max(stored, 1)) return;
+    }
     deriveAccentVariants(this.handle);
   }
 
@@ -841,11 +866,14 @@ export class SqliteSearchIndex extends SearchIndexBase {
         tokenize='${FTS_TOKENIZER}'
       );
       -- The folded-form → accented-spelling map queries expand through: derived from the
-      -- FTS vocabulary (deriveAccentVariants), kept current by addRecord. Derived state:
-      -- losing this table costs one vocabulary scan, never data.
+      -- FTS vocabulary (deriveAccentVariants), refreshed on the droplist cadence by
+      -- refreshAccentVariants. Derived state: losing this table costs one vocabulary
+      -- scan, never data. df is the spelling's document frequency at derivation time —
+      -- the expansion gate's evidence.
       CREATE TABLE IF NOT EXISTS accent_variants (
         folded TEXT NOT NULL,
         term TEXT NOT NULL,
+        df INTEGER NOT NULL,
         PRIMARY KEY (folded, term)
       ) WITHOUT ROWID;
     `);
@@ -864,8 +892,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
         'INSERT INTO passages(id, item_key, title, text, source) VALUES (?, ?, ?, ?, ?)',
       ),
       insertFts: db.prepare('INSERT INTO passages_fts(rowid, text) VALUES (?, ?)'),
-      insertVariant: db.prepare('INSERT OR IGNORE INTO accent_variants(folded, term) VALUES (?, ?)'),
-      variantsFor: db.prepare('SELECT term FROM accent_variants WHERE folded = ?'),
+      variantsFor: db.prepare('SELECT term, df FROM accent_variants WHERE folded = ?'),
       // The external-content delete protocol: FTS5 stores no text of its own, so a row is
       // retired by handing back the exact rowid and text that were indexed. A bare DELETE
       // on `passages` would leave the index pointing at a rowid that no longer resolves,
@@ -1114,15 +1141,10 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // Normalized once, here, so what FTS tokenizes is exactly what the JS query side
     // produces (NFC, unicode61-aware case fold) — unicode61 itself normalizes nothing.
     // The delete sites below re-derive the same string from passages.text, which the
-    // external-content protocol requires to match byte for byte.
+    // external-content protocol requires to match byte for byte. The expansion map is NOT
+    // maintained here: it is derived state with a cadence (refreshAccentVariants), like
+    // the binary vector codes beside it.
     this.stmts.insertFts.run(Number(res.lastInsertRowid), normalizeForSearch(rec.text));
-    // Keep the expansion map current as the vocabulary grows. A deletion may leave an
-    // entry behind; that costs one zero-hit term in an expanded query, never a wrong
-    // result, and the next full build re-derives the map (deriveAccentVariants).
-    for (const t of new Set(tokenize(rec.text))) {
-      const folded = accentKey(t);
-      if (folded !== t && folded.length > 1) this.stmts.insertVariant.run(folded, t);
-    }
     this.c.documents++;
     if (rec.source === 'fulltext') {
       this.c.fulltextPassages++;
@@ -1317,8 +1339,20 @@ export class SqliteSearchIndex extends SearchIndexBase {
    */
   private expandTerm(term: string): string {
     if (accentKey(term) !== term) return ftsTerm(term);
-    const variants = this.stmts.variantsFor.all(term) as Array<{ term: string }>;
+    const rows = this.stmts.variantsFor.all(term) as Array<{ term: string; df: number }>;
+    const variants = rows.filter((v) => v.term !== term);
     if (!variants.length) return ftsTerm(term);
+    // The dominance gate, measured before it was trusted: expand only when the accented
+    // spellings outweigh the typed one in this corpus. Without it, every rare accented
+    // sibling of a common word joins the query at a HIGH idf — `trong` (25 771 passages)
+    // dragged in `trọng`, `trồng` and four more, `le` dragged in nine Vietnamese words,
+    // OCR's `enêrgy` outranked real hits for `energy` — and top-1 agreement with stock
+    // fell to 10-15 of 20 per language. With it, a query is read the way this library
+    // predominantly spells it: `theorie` (214 against 955 accented) expands, `trong`
+    // (25 771 against 7 027) runs as typed. Corpus-derived, no threshold to tune.
+    const selfDf = (rows.find((v) => v.term === term)?.df ?? 0);
+    const variantsDf = variants.reduce((s, v) => s + v.df, 0);
+    if (variantsDf <= selfDf) return ftsTerm(term);
     const group = [term, ...variants.map((v) => v.term)].map(ftsTerm).join(' OR ');
     return `(${group})`;
   }
@@ -1703,6 +1737,16 @@ export class SqliteSearchIndex extends SearchIndexBase {
    * index, and failing a build over it would be losing the library to save the cache.
    */
   protected finalizeVectors(): void {
+    // The expansion map is derived from the keyword vocabulary exactly as the binary
+    // codes below are derived from the vectors, and it levels up at the same moment, for
+    // the same reason: the derived rows commit with the rows they were derived from.
+    // Same contract too — never throw; a map that could not be refreshed is yesterday's
+    // expansions, not a failed build.
+    try {
+      this.refreshAccentVariants();
+    } catch (e) {
+      this.opts.logger?.warn(`accent variants not refreshed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     // What the salvage actually spared, reported where the numbers are final rather than
     // promised in the future tense the sideline had to use. Rewritten from the sideline's
     // own sentence each time, so a second job over the same index updates the figure

--- a/src/features/search/tokenize.ts
+++ b/src/features/search/tokenize.ts
@@ -92,15 +92,63 @@ export function normalizeForSearch(text: string): string {
   // lowercasing is context-sensitive Greek final sigma, and UNIFY folds ς and σ together
   // anyway, so both routes land on the same token.
   const lowered = text.replace(/[\p{Lu}\p{Lt}]/gu, (c) => (UNICODE61_KEEPS_CASE.has(c) ? c : c.toLowerCase()));
-  const folded = NO_TRANSFORM_SHIELD.hide(lowered)
+  // NFC, and this is load-bearing rather than tidiness. unicode61 does not normalize, and
+  // it treats a combining mark as a separator, so a decomposed `é` reaches the index as
+  // the single letter `e` while a composed one reaches it as `é`. Extraction decides which
+  // a passage happens to carry. Composing both sides removes the difference.
+  //
+  // Shielded, because composing is not free either: `ʹ` U+0374 has a canonical
+  // decomposition, so NFC turns it into U+02B9 — two codepoints that print alike, where
+  // unicode61 leaves the first alone. Composing it would send the query to a token the
+  // index does not hold, which is this file's own defect class.
+  const composed = NO_TRANSFORM_SHIELD.show(NO_TRANSFORM_SHIELD.hide(lowered).normalize('NFC'));
+  return composed.replace(UNIFY_RE, (c) => UNIFY[c]!);
+}
+
+/**
+ * The same string with its Latin combining marks removed — `théorie` to `theorie`.
+ *
+ * This used to be part of `normalizeForSearch`, applied to every string on both sides, and
+ * moving it out is the point of the change rather than a refactor. Applied to everything
+ * it does not normalize spelling, it merges vocabulary: measured on a real library, `án`
+ * (2,592 occurrences) lands on `an`, `bé` (939) on `be`, `thể` and `thế` (641 together) on
+ * `the`. Those are Vietnamese words, where a tone mark is part of the word and not an
+ * accent on it — `ma má mà mả mã mạ` are six words — and once merged into a high-frequency
+ * English token they cannot be searched for at all.
+ *
+ * It is still wanted, in one direction only: someone who types `theorie` should find
+ * `théorie`, because accents are the first thing lost to keyboards, copy-paste and OCR. So
+ * the QUERY side folds, never the index: an unaccented query term is expanded to the
+ * accented spellings the index actually holds (`theorie` runs as `theorie OR théorie`),
+ * through the `accent_variants` map each backend maintains from its own vocabulary. The
+ * index stores each word exactly as written, once — no extra tokens, so document length,
+ * term frequency and idf are what the text says they are. An accented query is answered
+ * exactly and is never expanded: `thể` must not reach `the`, which is the collision this
+ * change exists to end.
+ *
+ * The shield is kept: `ǡ ǣ ǯ ǽ ǿ` have a non-ASCII Latin base, so stripping their mark
+ * yields `a æ ʒ æ ø` — real words of other documents, and a query expanded through a wrong
+ * fold would reach them.
+ */
+export function foldMarks(text: string): string {
+  const stripped = NO_TRANSFORM_SHIELD.hide(text)
     // Lowercasing can itself introduce a mark (`İ` → `i` + U+0307), so decompose after it.
     .normalize('NFD')
     .replace(LATIN_MARKS, '$1')
-    // Recompose what was kept: the token class below excludes marks, exactly as unicode61
-    // treats them as separators, so a decomposed `ά` left standing would split in two.
-    .normalize('NFC')
-    .replace(UNIFY_RE, (c) => UNIFY[c]!);
-  return NO_TRANSFORM_SHIELD.show(folded);
+    .normalize('NFC');
+  return NO_TRANSFORM_SHIELD.show(stripped);
+}
+
+/**
+ * The key an index term files its accented spelling under, and the shape a query term is
+ * compared against it in: marks stripped, THEN re-normalized. The second step is not
+ * decorative — `foldMarks('İstanbul')` is `Istanbul` (stripping the dot uncovers a plain
+ * `I` the first normalization never saw), and the query for it arrives as `istanbul`;
+ * only the re-fold lands both in one key. A term whose key is itself carries no marks and
+ * files nothing.
+ */
+export function accentKey(term: string): string {
+  return normalizeForSearch(foldMarks(term));
 }
 
 /**
@@ -121,6 +169,16 @@ const NO_TRANSFORM = '\u01e1\u01e3\u01ef\u01fd\u01ff\u0374';
 /**
  * Every cased codepoint unicode61 leaves uppercase while `toLowerCase` would lower it.
  *
+ * **Re-swept for this commit.** The set was generated against `remove_diacritics 2`, and
+ * this commit declares `0`. That changes the answer: with stripping on, `İ` U+0130
+ * decomposed and its mark was removed, so SQLite stored `i` and the codepoint did not
+ * belong here. With stripping off, SQLite keeps `İ` verbatim, while `toLowerCase` turns it
+ * into `i` plus a combining dot — a token the index does not hold, and one the token class
+ * below then splits into an orphan `i` and `stanbul`. Re-running the sweep against the
+ * tokenizer this commit actually ships returns 446 codepoints against the 445 pinned, and
+ * the one difference is exactly that. A set generated under the wrong tokenizer is not a
+ * smaller problem than a wrong constant; it is the same problem wearing a provenance story.
+ *
  * unicode61's case table predates Unicode 8, so whole scripts that gained casing later —
  * Cherokee, Georgian Mtavruli, Osage, Old Hungarian, Warang Citi, Deseret, Adlam,
  * Medefaidrin, Vithkuqi and friends — are stored uppercase by the index while a JS fold
@@ -129,7 +187,7 @@ const NO_TRANSFORM = '\u01e1\u01e3\u01ef\u01fd\u01ff\u0374';
  * declared with the shipped tokenizer — insert `a${c}b`, MATCH the lowercase, keep `c`
  * when only the original matches. An earlier hand-listed pair turned out to be 2 of 445.
  */
-const UNICODE61_KEEPS_CASE_CHARS = '\u037f\u0528\u052a\u052c\u052e\u13a0\u13a1\u13a2\u13a3\u13a4\u13a5\u13a6\u13a7\u13a8\u13a9\u13aa\u13ab\u13ac\u13ad\u13ae\u13af\u13b0\u13b1\u13b2\u13b3\u13b4\u13b5\u13b6\u13b7\u13b8\u13b9\u13ba\u13bb\u13bc\u13bd\u13be\u13bf\u13c0\u13c1\u13c2\u13c3\u13c4\u13c5\u13c6\u13c7\u13c8\u13c9\u13ca\u13cb\u13cc\u13cd\u13ce\u13cf\u13d0\u13d1\u13d2\u13d3\u13d4\u13d5\u13d6\u13d7\u13d8\u13d9\u13da\u13db\u13dc\u13dd\u13de\u13df\u13e0\u13e1\u13e2\u13e3\u13e4\u13e5\u13e6\u13e7\u13e8\u13e9\u13ea\u13eb\u13ec\u13ed\u13ee\u13ef\u13f0\u13f1\u13f2\u13f3\u13f4\u13f5\u1c89\u1c90\u1c91\u1c92\u1c93\u1c94\u1c95\u1c96\u1c97\u1c98\u1c99\u1c9a\u1c9b\u1c9c\u1c9d\u1c9e\u1c9f\u1ca0\u1ca1\u1ca2\u1ca3\u1ca4\u1ca5\u1ca6\u1ca7\u1ca8\u1ca9\u1caa\u1cab\u1cac\u1cad\u1cae\u1caf\u1cb0\u1cb1\u1cb2\u1cb3\u1cb4\u1cb5\u1cb6\u1cb7\u1cb8\u1cb9\u1cba\u1cbd\u1cbe\u1cbf\u2c2f\ua698\ua69a\ua796\ua798\ua79a\ua79c\ua79e\ua7ab\ua7ac\ua7ad\ua7ae\ua7b0\ua7b1\ua7b2\ua7b3\ua7b4\ua7b6\ua7b8\ua7ba\ua7bc\ua7be\ua7c0\ua7c2\ua7c4\ua7c5\ua7c6\ua7c7\ua7c9\ua7cb\ua7cc\ua7ce\ua7d0\ua7d2\ua7d4\ua7d6\ua7d8\ua7da\ua7dc\ua7f5\u{104B0}\u{104B1}\u{104B2}\u{104B3}\u{104B4}\u{104B5}\u{104B6}\u{104B7}\u{104B8}\u{104B9}\u{104BA}\u{104BB}\u{104BC}\u{104BD}\u{104BE}\u{104BF}\u{104C0}\u{104C1}\u{104C2}\u{104C3}\u{104C4}\u{104C5}\u{104C6}\u{104C7}\u{104C8}\u{104C9}\u{104CA}\u{104CB}\u{104CC}\u{104CD}\u{104CE}\u{104CF}\u{104D0}\u{104D1}\u{104D2}\u{104D3}\u{10570}\u{10571}\u{10572}\u{10573}\u{10574}\u{10575}\u{10576}\u{10577}\u{10578}\u{10579}\u{1057A}\u{1057C}\u{1057D}\u{1057E}\u{1057F}\u{10580}\u{10581}\u{10582}\u{10583}\u{10584}\u{10585}\u{10586}\u{10587}\u{10588}\u{10589}\u{1058A}\u{1058C}\u{1058D}\u{1058E}\u{1058F}\u{10590}\u{10591}\u{10592}\u{10594}\u{10595}\u{10C80}\u{10C81}\u{10C82}\u{10C83}\u{10C84}\u{10C85}\u{10C86}\u{10C87}\u{10C88}\u{10C89}\u{10C8A}\u{10C8B}\u{10C8C}\u{10C8D}\u{10C8E}\u{10C8F}\u{10C90}\u{10C91}\u{10C92}\u{10C93}\u{10C94}\u{10C95}\u{10C96}\u{10C97}\u{10C98}\u{10C99}\u{10C9A}\u{10C9B}\u{10C9C}\u{10C9D}\u{10C9E}\u{10C9F}\u{10CA0}\u{10CA1}\u{10CA2}\u{10CA3}\u{10CA4}\u{10CA5}\u{10CA6}\u{10CA7}\u{10CA8}\u{10CA9}\u{10CAA}\u{10CAB}\u{10CAC}\u{10CAD}\u{10CAE}\u{10CAF}\u{10CB0}\u{10CB1}\u{10CB2}\u{10D50}\u{10D51}\u{10D52}\u{10D53}\u{10D54}\u{10D55}\u{10D56}\u{10D57}\u{10D58}\u{10D59}\u{10D5A}\u{10D5B}\u{10D5C}\u{10D5D}\u{10D5E}\u{10D5F}\u{10D60}\u{10D61}\u{10D62}\u{10D63}\u{10D64}\u{10D65}\u{118A0}\u{118A1}\u{118A2}\u{118A3}\u{118A4}\u{118A5}\u{118A6}\u{118A7}\u{118A8}\u{118A9}\u{118AA}\u{118AB}\u{118AC}\u{118AD}\u{118AE}\u{118AF}\u{118B0}\u{118B1}\u{118B2}\u{118B3}\u{118B4}\u{118B5}\u{118B6}\u{118B7}\u{118B8}\u{118B9}\u{118BA}\u{118BB}\u{118BC}\u{118BD}\u{118BE}\u{118BF}\u{16E40}\u{16E41}\u{16E42}\u{16E43}\u{16E44}\u{16E45}\u{16E46}\u{16E47}\u{16E48}\u{16E49}\u{16E4A}\u{16E4B}\u{16E4C}\u{16E4D}\u{16E4E}\u{16E4F}\u{16E50}\u{16E51}\u{16E52}\u{16E53}\u{16E54}\u{16E55}\u{16E56}\u{16E57}\u{16E58}\u{16E59}\u{16E5A}\u{16E5B}\u{16E5C}\u{16E5D}\u{16E5E}\u{16E5F}\u{16EA0}\u{16EA1}\u{16EA2}\u{16EA3}\u{16EA4}\u{16EA5}\u{16EA6}\u{16EA7}\u{16EA8}\u{16EA9}\u{16EAA}\u{16EAB}\u{16EAC}\u{16EAD}\u{16EAE}\u{16EAF}\u{16EB0}\u{16EB1}\u{16EB2}\u{16EB3}\u{16EB4}\u{16EB5}\u{16EB6}\u{16EB7}\u{16EB8}\u{1E900}\u{1E901}\u{1E902}\u{1E903}\u{1E904}\u{1E905}\u{1E906}\u{1E907}\u{1E908}\u{1E909}\u{1E90A}\u{1E90B}\u{1E90C}\u{1E90D}\u{1E90E}\u{1E90F}\u{1E910}\u{1E911}\u{1E912}\u{1E913}\u{1E914}\u{1E915}\u{1E916}\u{1E917}\u{1E918}\u{1E919}\u{1E91A}\u{1E91B}\u{1E91C}\u{1E91D}\u{1E91E}\u{1E91F}\u{1E920}\u{1E921}';
+const UNICODE61_KEEPS_CASE_CHARS = '\u0130\u037f\u0528\u052a\u052c\u052e\u13a0\u13a1\u13a2\u13a3\u13a4\u13a5\u13a6\u13a7\u13a8\u13a9\u13aa\u13ab\u13ac\u13ad\u13ae\u13af\u13b0\u13b1\u13b2\u13b3\u13b4\u13b5\u13b6\u13b7\u13b8\u13b9\u13ba\u13bb\u13bc\u13bd\u13be\u13bf\u13c0\u13c1\u13c2\u13c3\u13c4\u13c5\u13c6\u13c7\u13c8\u13c9\u13ca\u13cb\u13cc\u13cd\u13ce\u13cf\u13d0\u13d1\u13d2\u13d3\u13d4\u13d5\u13d6\u13d7\u13d8\u13d9\u13da\u13db\u13dc\u13dd\u13de\u13df\u13e0\u13e1\u13e2\u13e3\u13e4\u13e5\u13e6\u13e7\u13e8\u13e9\u13ea\u13eb\u13ec\u13ed\u13ee\u13ef\u13f0\u13f1\u13f2\u13f3\u13f4\u13f5\u1c89\u1c90\u1c91\u1c92\u1c93\u1c94\u1c95\u1c96\u1c97\u1c98\u1c99\u1c9a\u1c9b\u1c9c\u1c9d\u1c9e\u1c9f\u1ca0\u1ca1\u1ca2\u1ca3\u1ca4\u1ca5\u1ca6\u1ca7\u1ca8\u1ca9\u1caa\u1cab\u1cac\u1cad\u1cae\u1caf\u1cb0\u1cb1\u1cb2\u1cb3\u1cb4\u1cb5\u1cb6\u1cb7\u1cb8\u1cb9\u1cba\u1cbd\u1cbe\u1cbf\u2c2f\ua698\ua69a\ua796\ua798\ua79a\ua79c\ua79e\ua7ab\ua7ac\ua7ad\ua7ae\ua7b0\ua7b1\ua7b2\ua7b3\ua7b4\ua7b6\ua7b8\ua7ba\ua7bc\ua7be\ua7c0\ua7c2\ua7c4\ua7c5\ua7c6\ua7c7\ua7c9\ua7cb\ua7cc\ua7ce\ua7d0\ua7d2\ua7d4\ua7d6\ua7d8\ua7da\ua7dc\ua7f5\u{104B0}\u{104B1}\u{104B2}\u{104B3}\u{104B4}\u{104B5}\u{104B6}\u{104B7}\u{104B8}\u{104B9}\u{104BA}\u{104BB}\u{104BC}\u{104BD}\u{104BE}\u{104BF}\u{104C0}\u{104C1}\u{104C2}\u{104C3}\u{104C4}\u{104C5}\u{104C6}\u{104C7}\u{104C8}\u{104C9}\u{104CA}\u{104CB}\u{104CC}\u{104CD}\u{104CE}\u{104CF}\u{104D0}\u{104D1}\u{104D2}\u{104D3}\u{10570}\u{10571}\u{10572}\u{10573}\u{10574}\u{10575}\u{10576}\u{10577}\u{10578}\u{10579}\u{1057A}\u{1057C}\u{1057D}\u{1057E}\u{1057F}\u{10580}\u{10581}\u{10582}\u{10583}\u{10584}\u{10585}\u{10586}\u{10587}\u{10588}\u{10589}\u{1058A}\u{1058C}\u{1058D}\u{1058E}\u{1058F}\u{10590}\u{10591}\u{10592}\u{10594}\u{10595}\u{10C80}\u{10C81}\u{10C82}\u{10C83}\u{10C84}\u{10C85}\u{10C86}\u{10C87}\u{10C88}\u{10C89}\u{10C8A}\u{10C8B}\u{10C8C}\u{10C8D}\u{10C8E}\u{10C8F}\u{10C90}\u{10C91}\u{10C92}\u{10C93}\u{10C94}\u{10C95}\u{10C96}\u{10C97}\u{10C98}\u{10C99}\u{10C9A}\u{10C9B}\u{10C9C}\u{10C9D}\u{10C9E}\u{10C9F}\u{10CA0}\u{10CA1}\u{10CA2}\u{10CA3}\u{10CA4}\u{10CA5}\u{10CA6}\u{10CA7}\u{10CA8}\u{10CA9}\u{10CAA}\u{10CAB}\u{10CAC}\u{10CAD}\u{10CAE}\u{10CAF}\u{10CB0}\u{10CB1}\u{10CB2}\u{10D50}\u{10D51}\u{10D52}\u{10D53}\u{10D54}\u{10D55}\u{10D56}\u{10D57}\u{10D58}\u{10D59}\u{10D5A}\u{10D5B}\u{10D5C}\u{10D5D}\u{10D5E}\u{10D5F}\u{10D60}\u{10D61}\u{10D62}\u{10D63}\u{10D64}\u{10D65}\u{118A0}\u{118A1}\u{118A2}\u{118A3}\u{118A4}\u{118A5}\u{118A6}\u{118A7}\u{118A8}\u{118A9}\u{118AA}\u{118AB}\u{118AC}\u{118AD}\u{118AE}\u{118AF}\u{118B0}\u{118B1}\u{118B2}\u{118B3}\u{118B4}\u{118B5}\u{118B6}\u{118B7}\u{118B8}\u{118B9}\u{118BA}\u{118BB}\u{118BC}\u{118BD}\u{118BE}\u{118BF}\u{16E40}\u{16E41}\u{16E42}\u{16E43}\u{16E44}\u{16E45}\u{16E46}\u{16E47}\u{16E48}\u{16E49}\u{16E4A}\u{16E4B}\u{16E4C}\u{16E4D}\u{16E4E}\u{16E4F}\u{16E50}\u{16E51}\u{16E52}\u{16E53}\u{16E54}\u{16E55}\u{16E56}\u{16E57}\u{16E58}\u{16E59}\u{16E5A}\u{16E5B}\u{16E5C}\u{16E5D}\u{16E5E}\u{16E5F}\u{16EA0}\u{16EA1}\u{16EA2}\u{16EA3}\u{16EA4}\u{16EA5}\u{16EA6}\u{16EA7}\u{16EA8}\u{16EA9}\u{16EAA}\u{16EAB}\u{16EAC}\u{16EAD}\u{16EAE}\u{16EAF}\u{16EB0}\u{16EB1}\u{16EB2}\u{16EB3}\u{16EB4}\u{16EB5}\u{16EB6}\u{16EB7}\u{16EB8}\u{1E900}\u{1E901}\u{1E902}\u{1E903}\u{1E904}\u{1E905}\u{1E906}\u{1E907}\u{1E908}\u{1E909}\u{1E90A}\u{1E90B}\u{1E90C}\u{1E90D}\u{1E90E}\u{1E90F}\u{1E910}\u{1E911}\u{1E912}\u{1E913}\u{1E914}\u{1E915}\u{1E916}\u{1E917}\u{1E918}\u{1E919}\u{1E91A}\u{1E91B}\u{1E91C}\u{1E91D}\u{1E91E}\u{1E91F}\u{1E920}\u{1E921}';
 export const UNICODE61_KEEPS_CASE: ReadonlySet<string> = new Set(UNICODE61_KEEPS_CASE_CHARS);
 
 /**
@@ -167,6 +225,10 @@ const NO_TRANSFORM_SHIELD = shield(NO_TRANSFORM, 0xfdd0);
  * own: it keeps `théorie`, `Θεωρία`, `теория` and `日本語` single tokens instead of
  * fragments, and it would have prevented this defect even without the fold — a whole token
  * misses cleanly, a fragment matches a high-frequency English string.
+ *
+ * Marks are NOT removed here any more; see `foldMarks`. A query is answered on the
+ * letters it was typed with, and the unaccented spelling still reaches the accented
+ * documents because the query is expanded to the accented variants the index holds.
  *
  * **The stopword list no longer lives here**, and that is the point of the change rather
  * than tidying. This function is the *document* tokenizer as well as the query one on the

--- a/src/features/search/tokenize.ts
+++ b/src/features/search/tokenize.ts
@@ -26,8 +26,9 @@ export function isStopword(term: string): boolean {
 
 /**
  * Combining marks sitting on a **Latin** base, which is the only place
- * `unicode61 remove_diacritics 2` removes them: measured, Greek tonos and Cyrillic breve
- * survive there, so they survive here. See normalizeForSearch.
+ * `unicode61 remove_diacritics 2` removed them under the old symmetric fold: measured,
+ * Greek tonos and Cyrillic breve survive there, so they survive here. Consumed by
+ * `foldMarks` (the expansion map's key derivation), never by `normalizeForSearch`.
  *
  * U+0300–U+036F rather than `\p{M}`, which is the block NFD produces for Latin (Vietnamese
  * included: the tone marks and the dot below are all in it) and the range Zotero's own
@@ -51,28 +52,28 @@ const UNIFY: Record<string, string> = {
 const UNIFY_RE = new RegExp(`[${Object.keys(UNIFY).join('')}]`, 'gu');
 
 /**
- * Fold a string to the form both sides of the index are compared in: lowercase, Latin
- * diacritics removed, everything else left standing.
+ * Normalize a string to the form both sides of the index are compared in: lowercase (as
+ * unicode61 lowercases, not as JavaScript does), canonically composed, letter-unified —
+ * marks left standing. Diacritic removal is NOT part of this any more; it lives in
+ * `foldMarks`, applied only to derive the expansion map's keys.
  *
  * **Why this exists.** `tokenize()` used to match `[a-z0-9]+` over lowercased text, which
- * is adequate for English and a correctness defect for everything else. On the FTS5
- * backend the document side is folded by SQLite (`remove_diacritics 2`) while the query
- * side was not, so `théorie` reached MATCH as `"th" OR "orie"`. Because terms are OR-ed
- * that is not a miss but a confident wrong answer: `"th"` and `"orie"` retrieve whatever
- * ordinary prose happens to contain them. Measured on a 7 500-item library, an accented
- * query and its unaccented spelling shared not one result — jaccard 0,00.
- * The repair is Zotero's: fold in JS, in front of the tokeniser that the index side and
- * the query side already share, so the symmetry is structural rather than coincidental.
+ * is adequate for English and a correctness defect for everything else: `théorie` reached
+ * MATCH as `"th" OR "orie"`, and because terms are OR-ed that is not a miss but a
+ * confident wrong answer — `"th"` and `"orie"` retrieve whatever ordinary prose happens
+ * to contain them. Measured on a 7 500-item library, an accented query and its unaccented
+ * spelling shared not one result — jaccard 0,00. The repair is one normalizer in front of
+ * the tokenizer that the index side and the query side share, so agreement between what
+ * is stored and what is asked is structural rather than coincidental.
  *
  * **Why it emulates unicode61 rather than copying Zotero's `normalizeForSearch`.** Zotero
  * folds harder — NFKD, plus a hand map for `ø œ æ ł đ ð þ ß ı` — because it owns both
- * sides of its own comparison. We do not: `passages.text` is the display text `get()`
- * reads back for snippets, so the FTS5 document side stays raw and is tokenised by SQLite.
- * Anything this function does that `unicode61 remove_diacritics 2` does not re-opens the
- * asymmetry it exists to close. Measured, `đại` indexes as `đai` and `søren` as `søren`;
- * folding either here would send the query where the index is not. So the hand map is
- * deliberately absent, and NFD is used rather than NFKD (`ﬁle` and `ａｂｃ` are indexed
- * whole, so they stay whole here).
+ * sides of its own comparison. We only own one: the FTS5 side is tokenised by SQLite
+ * (this function feeds it, but unicode61 still decides where tokens split and how case
+ * folds), so anything done here that `unicode61` does not re-opens the asymmetry it
+ * exists to close. Measured, `søren` indexes as `søren`; folding it here would send the
+ * query where the index is not. So the hand map is deliberately absent, and NFC is used
+ * rather than NFKD (`ﬁle` and `ａｂｃ` are indexed whole, so they stay whole here).
  *
  * Swept codepoint by codepoint over Latin, Greek, Cyrillic, Latin Extended Additional,
  * letterlike and number forms, fullwidth and the ligatures — 1 301 codepoints. What it found
@@ -81,8 +82,8 @@ const UNIFY_RE = new RegExp(`[${Object.keys(UNIFY).join('')}]`, 'gu');
  * harmless. **That was wrong**, and re-running it is what showed otherwise: twelve of them
  * sent the query to a token the index does not hold, which is this defect's own class on
  * rarer input. Ten were `Ǡ Ǣ Ǯ Ǽ Ǿ` with their lowercase forms and two were gaps in
- * unicode61's Greek case table; all twelve are handled by NO_MARK_STRIP and
- * NO_CASE_FOLD below. What remains is fifteen unassigned or symbol codepoints that
+ * unicode61's Greek case table; all twelve are handled by NO_TRANSFORM and
+ * UNICODE61_KEEPS_CASE below. What remains is fifteen unassigned or symbol codepoints that
  * unicode61 indexes and `\p{L}\p{N}` does not — those genuinely do only retrieve less.
  */
 export function normalizeForSearch(text: string): string {

--- a/src/features/search/tokenize.ts
+++ b/src/features/search/tokenize.ts
@@ -1,7 +1,28 @@
+/**
+ * The words this search treats as too common to rank on.
+ *
+ * Consulted on the query side only, and only through `pruneTerms`, which restores the
+ * whole token set when dropping these would leave too little to answer with. It used to
+ * be applied here instead, inside `tokenize()`, which meant it also governed what the
+ * in-memory backend *indexed* — and a term absent from the index cannot be searched for
+ * even deliberately, which is what made the fallback impossible to write.
+ */
 const STOPWORDS = new Set([
   'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'is', 'are', 'was', 'were',
   'be', 'by', 'as', 'at', 'that', 'this', 'it', 'from', 'we', 'our', 'their', 'its', 'these', 'those',
+  // `not` is the thirtieth, and its absence is what made `to be or not to be` return a wrong
+  // answer rather than no answer: every other word of that line was already here, so one
+  // term limped through and the search ran as a single-term OR on it. Added alone, and
+  // deliberately — the list omits plenty of other common words (`no`, `but`, `which`,
+  // `when`), but which of them matter is a property of the corpus rather than of English,
+  // and guessing further here is the habit this list should be losing.
+  'not',
 ]);
+
+/** Whether a term is on the list above. The `TermPredicate` a query is pruned by. */
+export function isStopword(term: string): boolean {
+  return STOPWORDS.has(term);
+}
 
 /**
  * Combining marks sitting on a **Latin** base, which is the only place
@@ -140,15 +161,20 @@ function shield(chars: string, base: number): { hide: (s: string) => string; sho
 const NO_TRANSFORM_SHIELD = shield(NO_TRANSFORM, 0xfdd0);
 
 /**
- * Fold, split on non-alphanumerics, drop stopwords and 1-char tokens.
+ * Fold, split on non-alphanumerics, drop 1-char tokens.
  *
  * The token class is `\p{L}\p{N}`, not `[a-z0-9]`, and that half earns its place on its
  * own: it keeps `théorie`, `Θεωρία`, `теория` and `日本語` single tokens instead of
  * fragments, and it would have prevented this defect even without the fold — a whole token
  * misses cleanly, a fragment matches a high-frequency English string.
+ *
+ * **The stopword list no longer lives here**, and that is the point of the change rather
+ * than tidying. This function is the *document* tokenizer as well as the query one on the
+ * in-memory backend, so dropping a word here deleted it from the index, and a term the
+ * index does not hold cannot be searched for on purpose. Pruning is now a query-side
+ * decision, taken in `query-terms.ts`, where it can be undone when it would leave the
+ * query with nothing to say. Both backends index every term; only queries prune.
  */
 export function tokenize(text: string): string[] {
-  return (normalizeForSearch(text).match(/[\p{L}\p{N}]+/gu) ?? []).filter(
-    (t) => t.length > 1 && !STOPWORDS.has(t),
-  );
+  return (normalizeForSearch(text).match(/[\p{L}\p{N}]+/gu) ?? []).filter((t) => t.length > 1);
 }

--- a/src/features/search/tokenize.ts
+++ b/src/features/search/tokenize.ts
@@ -1,30 +1,4 @@
 /**
- * The words this search treats as too common to rank on.
- *
- * Consulted on the query side only, and only through `pruneTerms`, which restores the
- * whole token set when dropping these would leave too little to answer with. It used to
- * be applied here instead, inside `tokenize()`, which meant it also governed what the
- * in-memory backend *indexed* — and a term absent from the index cannot be searched for
- * even deliberately, which is what made the fallback impossible to write.
- */
-const STOPWORDS = new Set([
-  'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'is', 'are', 'was', 'were',
-  'be', 'by', 'as', 'at', 'that', 'this', 'it', 'from', 'we', 'our', 'their', 'its', 'these', 'those',
-  // `not` is the thirtieth, and its absence is what made `to be or not to be` return a wrong
-  // answer rather than no answer: every other word of that line was already here, so one
-  // term limped through and the search ran as a single-term OR on it. Added alone, and
-  // deliberately — the list omits plenty of other common words (`no`, `but`, `which`,
-  // `when`), but which of them matter is a property of the corpus rather than of English,
-  // and guessing further here is the habit this list should be losing.
-  'not',
-]);
-
-/** Whether a term is on the list above. The `TermPredicate` a query is pruned by. */
-export function isStopword(term: string): boolean {
-  return STOPWORDS.has(term);
-}
-
-/**
  * Combining marks sitting on a **Latin** base, which is the only place
  * `unicode61 remove_diacritics 2` removed them under the old symmetric fold: measured,
  * Greek tonos and Cyrillic breve survive there, so they survive here. Consumed by
@@ -237,6 +211,11 @@ const NO_TRANSFORM_SHIELD = shield(NO_TRANSFORM, 0xfdd0);
  * index does not hold cannot be searched for on purpose. Pruning is now a query-side
  * decision, taken in `query-terms.ts`, where it can be undone when it would leave the
  * query with nothing to say. Both backends index every term; only queries prune.
+ *
+ * **Language-agnostic, and now without exception.** The 29 English function words this
+ * used to drop are gone from here, and what replaces them is not another list but a
+ * measurement of this library — see `query-terms.ts`. Nothing about a word's language is
+ * consulted here or there.
  */
 export function tokenize(text: string): string[] {
   return (normalizeForSearch(text).match(/[\p{L}\p{N}]+/gu) ?? []).filter((t) => t.length > 1);

--- a/tests/features/accent-folding.test.ts
+++ b/tests/features/accent-folding.test.ts
@@ -220,7 +220,7 @@ describe('normalizeForSearch', () => {
     expect(normalizeForSearch('e\u0301le\u0300ve')).toBe(normalizeForSearch('élève'));
   });
 
-  it('leaves non-Latin diacritics alone, because remove_diacritics 2 does', () => {
+  it('leaves non-Latin diacritics alone, as it always has', () => {
     expect(normalizeForSearch('Θεωρία')).toBe('θεωρία');
     expect(normalizeForSearch('Йошкар')).toBe('йошкар');
   });
@@ -301,8 +301,9 @@ describe('makeSnippet', () => {
  * first reading called it.
  *
  * Pinned here because the sweep itself is not something a pull request runs. The expected
- * values are what `unicode61 remove_diacritics 2` actually stores, read off that
- * comparison — not what a reading of the Unicode tables suggests it ought to.
+ * values are what `unicode61 remove_diacritics 0` — the tokenizer this commit ships —
+ * actually stores, read off that comparison (re-swept for this commit: it moved `İ` into
+ * the keep-case set) — not what a reading of the Unicode tables suggests it ought to.
  */
 describe('codepoints unicode61 does not fold the way JavaScript would', () => {
   it('keeps the mark on letters whose base is itself non-ASCII Latin', () => {
@@ -348,6 +349,35 @@ describe('codepoints unicode61 does not fold the way JavaScript would', () => {
     expect(folded).toBe("théorie générale de l'emploi ǽ Ϳ");
     expect(/[﷐-﷯]/u.test(folded)).toBe(false);
     expect(normalizeForSearch('plain ascii text')).toBe('plain ascii text');
+  });
+});
+
+describe('the expansion group is bounded', () => {
+  it.each(backends)('a key seeded with more spellings than the cap expands to the cap, best first (%s)', async (backend) => {
+    // A document can mint accented spellings at will (OCR does it by accident, an
+    // adversary on purpose), and each would join an expanded query as its own
+    // posting-list merge. The cap keeps that a bounded cost. 30 crafted spellings of
+    // one key: the query must still find the dominant ones and must NOT match a
+    // document whose only content is the 30th-ranked spelling.
+    const marks = ['̀', '́', '̂', '̃', '̄', '̆', '̇', '̈', '̉', '̊',
+      '̋', '̌', '̏', '̑', '̣', '̤', '̥', '̧', '̨', '̭',
+      '̮', '̰', '̱', '̹', '̼', '̽', '̾', '̿', '̓', 'ͅ'];
+    const spelling = (i: number) => `zoq${'u'.normalize('NFD')}${marks[i]}t`.normalize('NFC');
+    const docs = [
+      // The dominant spelling, in several documents.
+      ...Array.from({ length: 3 }, (_, i) => ({ key: `D${i}`, text: `${spelling(0)} research corpus` })),
+      // 29 more spellings, one document each.
+      ...Array.from({ length: 29 }, (_, i) => ({ key: `S${i}`, text: `${spelling(i + 1)} lone spelling` })),
+    ];
+    const index = await indexOf(backend, docs);
+    const found = [...new Set((await index.query('zoqut', { limit: 40, mode: 'keyword' })).map((h) => h.itemKey))];
+    // Expansion fired (nothing spells it bare) and reached the dominant spelling…
+    expect(found).toContain('D0');
+    // …and the group was capped: 30 spellings exist, at most 24 can have joined, so at
+    // least five of the one-spelling documents are unreachable from this query.
+    const loners = found.filter((k) => k.startsWith('S')).length;
+    expect(loners).toBeLessThanOrEqual(23);
+    await index.close();
   });
 });
 

--- a/tests/features/accent-folding.test.ts
+++ b/tests/features/accent-folding.test.ts
@@ -84,16 +84,34 @@ describe.each(backends)('accent folding (%s backend)', (backend) => {
     // its tone mark lands it on `the`, which in a real library is in 84% of passages. The
     // two must not be one token.
     const index = await indexOf(backend, [
-      { key: 'VI', text: 'năm 2020 phát triển bền vững' },
+      { key: 'V1', text: 'năm 2020 phát triển bền vững' },
+      { key: 'V2', text: 'năm 2021 chính sách năng lượng' },
       { key: 'EN', text: 'nam river basin hydrology study' },
     ]);
     // `năm` is Vietnamese for year; stripped it becomes `nam`, which here is a river. The
-    // accented query gets the Vietnamese passage and only that one.
+    // accented query gets the Vietnamese passages and only those.
+    expect((await hits(index, 'năm')).sort()).toEqual(['V1', 'V2']);
+    // The unaccented query gets all three: the accented spelling dominates this corpus
+    // (`năm` in two passages against `nam` in one), so the query expands to it — the
+    // recall that stripping used to buy, kept, without indexing one extra token.
+    expect((await hits(index, 'nam')).sort()).toEqual(['EN', 'V1', 'V2']);
+    await index.close();
+  });
+
+  it('does not expand a spelling the corpus predominantly uses as typed', async () => {
+    // The dominance gate, from the other side — the case that made it necessary. In the
+    // real library `trong` (a Vietnamese function word, 25 771 passages) has six rare
+    // accented siblings; expanding it hands each a HIGH idf and they outrank the word
+    // the user typed. Here `nam` dominates (two passages against one `năm`), so a `nam`
+    // query runs as typed and the accented passage stays out of it.
+    const index = await indexOf(backend, [
+      { key: 'E1', text: 'nam river basin hydrology study' },
+      { key: 'E2', text: 'the nam basin flood model' },
+      { key: 'VI', text: 'năm 2020 phát triển bền vững' },
+    ]);
+    expect((await hits(index, 'nam')).sort()).toEqual(['E1', 'E2']);
+    // The accented direction is untouched by the gate: exact, as always.
     expect(await hits(index, 'năm')).toEqual(['VI']);
-    // The unaccented query gets both, because it expands to the accented spellings the
-    // vocabulary holds — the recall that stripping used to buy, kept, without indexing
-    // one extra token.
-    expect((await hits(index, 'nam')).sort()).toEqual(['EN', 'VI']);
     await index.close();
   });
 

--- a/tests/features/accent-folding.test.ts
+++ b/tests/features/accent-folding.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { normalizeForSearch, tokenize, UNICODE61_KEEPS_CASE } from '../../src/features/search/tokenize.js';
+import { accentKey, foldMarks, normalizeForSearch, tokenize, UNICODE61_KEEPS_CASE } from '../../src/features/search/tokenize.js';
 import { createSearchIndex, nodeSqliteAvailable } from '../../src/features/search/factory.js';
 import { MemorySearchIndex, makeSnippet } from '../../src/features/search/index-manager.js';
 import { loadIndex, saveIndex } from '../../src/features/search/persistence.js';
@@ -15,11 +15,14 @@ import type { SearchIndex } from '../../src/features/search/backend.js';
  * `théorie` reached MATCH as `"th" OR "orie"` — and since terms are OR-ed, that is a
  * confident wrong answer rather than an empty one.
  *
- * The fix folds in JS, in front of the tokenizer both backends already share, so the
- * symmetry is structural rather than coincidental. What the fold must reproduce is
- * `unicode61 remove_diacritics 2` and nothing more, because the FTS5 document side cannot
- * be moved into JS: `passages.text` is the display text `get()` reads back for snippets.
- * Every case below is therefore a symmetry assertion as much as a recall one.
+ * The first fix folded in JS, symmetrically, in front of the tokenizer both backends
+ * share — and symmetric folding is itself a defect in a multilingual library, because it
+ * merges vocabulary (`thể` and `thế` onto `the`). The current design keeps every mark on
+ * both sides (`remove_diacritics 0`) and restores the one direction worth keeping —
+ * unaccented query, accented document — by expanding the QUERY to the accented spellings
+ * the vocabulary holds. The cases below assert three things: what JS normalization must
+ * reproduce of unicode61, the asymmetry itself, and that expansion reaches exactly the
+ * documents folding used to.
  */
 
 const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
@@ -62,9 +65,35 @@ describe.each(backends)('accent folding (%s backend)', (backend) => {
     await index.close();
   });
 
-  it('finds the unaccented document from the accented spelling', async () => {
+  it('does NOT find the unaccented document from the accented spelling', async () => {
+    // The one direction this deliberately gives up, and it is asserted rather than left to
+    // chance. Expansion runs one way only: an unaccented term expands to the accented
+    // spellings the vocabulary holds, an accented term never expands to its stripped form.
+    // Expanding `thể` toward `the` is how a Vietnamese word became unsearchable in the
+    // first place.
     const index = await oneDoc('un eleve tres applique');
-    expect(await hits(index, 'élève')).toEqual(['D']);
+    expect(await hits(index, 'élève')).toEqual([]);
+    // The unaccented spelling still reaches it, and so does the accented document from an
+    // unaccented query — the direction that costs nothing is kept in full.
+    expect(await hits(index, 'eleve')).toEqual(['D']);
+    await index.close();
+  });
+
+  it('answers an accented query on the word that was written, not on its stripped form', async () => {
+    // The reason for all of this, in one assertion. `thế` is a Vietnamese word; stripping
+    // its tone mark lands it on `the`, which in a real library is in 84% of passages. The
+    // two must not be one token.
+    const index = await indexOf(backend, [
+      { key: 'VI', text: 'năm 2020 phát triển bền vững' },
+      { key: 'EN', text: 'nam river basin hydrology study' },
+    ]);
+    // `năm` is Vietnamese for year; stripped it becomes `nam`, which here is a river. The
+    // accented query gets the Vietnamese passage and only that one.
+    expect(await hits(index, 'năm')).toEqual(['VI']);
+    // The unaccented query gets both, because it expands to the accented spellings the
+    // vocabulary holds — the recall that stripping used to buy, kept, without indexing
+    // one extra token.
+    expect((await hits(index, 'nam')).sort()).toEqual(['EN', 'VI']);
     await index.close();
   });
 
@@ -159,8 +188,18 @@ describe.each(backends)('accent folding (%s backend)', (backend) => {
 });
 
 describe('normalizeForSearch', () => {
-  it('folds Latin diacritics and case', () => {
-    expect(normalizeForSearch('Élève Théorie Straße')).toBe('eleve theorie straße');
+  it('folds case but NOT diacritics', () => {
+    // Marks used to come off here, on both sides of every comparison. They now come off
+    // only in `foldMarks`, and only to produce the extra token `indexText` adds beside the
+    // written one.
+    expect(normalizeForSearch('Élève Théorie Straße')).toBe('élève théorie straße');
+  });
+
+  it('composes, because unicode61 does not and a mark is a separator to it', () => {
+    // A decomposed `é` would otherwise reach the index as the bare letter `e` while a
+    // composed one reaches it as `é`. Which a passage carries is decided by whatever
+    // extracted it.
+    expect(normalizeForSearch('e\u0301le\u0300ve')).toBe(normalizeForSearch('élève'));
   });
 
   it('leaves non-Latin diacritics alone, because remove_diacritics 2 does', () => {
@@ -180,9 +219,9 @@ describe('normalizeForSearch', () => {
 });
 
 describe('tokenize', () => {
-  it('keeps an accented word as one folded token', () => {
-    expect(tokenize('théorie')).toEqual(['theorie']);
-    expect(tokenize('élève')).toEqual(['eleve']);
+  it('keeps an accented word as one token, with its marks', () => {
+    expect(tokenize('théorie')).toEqual(['théorie']);
+    expect(tokenize('élève')).toEqual(['élève']);
   });
 
   it('keeps non-Latin words as whole tokens', () => {
@@ -288,8 +327,70 @@ describe('codepoints unicode61 does not fold the way JavaScript would', () => {
     // The shield hides characters behind U+FDD0..U+FDEF noncharacters. A restore that
     // failed would leave one of those in a token, and it would match nothing forever.
     const folded = normalizeForSearch("Théorie générale de l'emploi Ǽ Ϳ");
-    expect(folded).toBe("theorie generale de l'emploi ǽ Ϳ");
+    expect(folded).toBe("théorie générale de l'emploi ǽ Ϳ");
     expect(/[﷐-﷯]/u.test(folded)).toBe(false);
     expect(normalizeForSearch('plain ascii text')).toBe('plain ascii text');
+  });
+});
+
+describe('foldMarks and accentKey', () => {
+  it('strips Latin marks, and only those', () => {
+    expect(foldMarks('théorie')).toBe('theorie');
+    expect(foldMarks('thế')).toBe('the');
+    // Non-Latin marks stay, because unicode61 never removed them either.
+    expect(foldMarks('λόγος')).toBe('λόγος');
+    // And the shielded five keep their marks: stripping them yields other real words.
+    expect(foldMarks('ǽ')).toBe('ǽ');
+  });
+
+  it('files an accented spelling under the key its unaccented query arrives as', () => {
+    expect(accentKey('théorie')).toBe('theorie');
+    // A term without marks is its own key — it files nothing and expands from nothing.
+    expect(accentKey('theorie')).toBe('theorie');
+    // Stripping can uncover case the first normalization never saw: `İstanbul` is kept
+    // whole by unicode61, but its stripped form must land where a query for `istanbul`
+    // lands, which is lowercase. foldMarks alone leaves `Istanbul` — the re-fold is why
+    // accentKey exists.
+    expect(foldMarks('İstanbul')).toBe('Istanbul');
+    expect(accentKey('İstanbul')).toBe('istanbul');
+  });
+
+  it('what is indexed is exactly what was written — no extra tokens', () => {
+    // The alternative design indexed the stripped form BESIDE the written one, which
+    // inflates document length, halves the stripped form's idf and penalises accented
+    // documents under BM25 length normalization. This design adds nothing: recall comes
+    // from expanding the QUERY instead.
+    expect(tokenize('élève élève élève')).toEqual(['élève', 'élève', 'élève']);
+    expect(tokenize('un élève très appliqué')).not.toContain('eleve');
+  });
+});
+
+describe('marks that lowercasing introduces, and marks with no precomposed form', () => {
+  // Two cases the codepoint sweep in this file did not reach, both found by review, both
+  // reproducing the very defect the fold exists to prevent: a word split into a fragment
+  // that neither side can search for.
+
+  it('keeps `İ` whole, because unicode61 does under this tokenizer', () => {
+    // `İ`.toLowerCase() is `i` plus a combining dot, which the token class would split into
+    // an orphan `i` and `stanbul`. unicode61 with remove_diacritics 0 keeps `İ` verbatim, so
+    // the query side must too — that is what the keep-case set is for, and re-running its
+    // own generator against this tokenizer is what added this codepoint.
+    expect(tokenize('İstanbul')).toEqual(['İstanbul']);
+    expect(normalizeForSearch('İstanbul')).toBe('İstanbul');
+    // And its expansion key is the ordinary spelling, so a query for `istanbul` still
+    // reaches it — see accentKey.
+    expect(accentKey('İstanbul')).toBe('istanbul');
+  });
+
+  it('centres a snippet on the match even when normalizing changes length', () => {
+    const target = 'the théorie of value';
+    // `n̈` has no precomposed form, so folding it shortens the string — the assumption the
+    // previous implementation made about offsets, and it was false. Enough of them to push
+    // the match outside the returned window if the offset is taken from the wrong string.
+    const drift = 'n\u0308aive '.repeat(300);
+    expect(makeSnippet(`${drift}${target}`, 'theorie', 240)).toContain('théorie');
+    // Same again for the other direction, where lowercasing lengthens rather than shortens.
+    const grow = 'İstanbul '.repeat(300);
+    expect(makeSnippet(`${grow}${target}`, 'théorie', 240)).toContain('théorie');
   });
 });

--- a/tests/features/accent-folding.test.ts
+++ b/tests/features/accent-folding.test.ts
@@ -144,7 +144,11 @@ describe.each(backends)('accent folding (%s backend)', (backend) => {
     await index.close();
   });
 
-  it('still answers [] rather than throwing when nothing survives tokenization', async () => {
+  it('still answers [] rather than throwing when nothing survives tokenization or pruning', async () => {
+    // Two different emptinesses, and both must stay empty. `!!!` survives neither the
+    // token class nor anything after it; `the a an of` now survives tokenization — the
+    // list moved out of it — and is emptied one step later by the query-side prune, which
+    // deliberately does NOT fall back when nothing at all is left. See query-terms.ts.
     const index = await oneDoc('un élève très appliqué');
     expect(await hits(index, '!!! ??? ***')).toEqual([]);
     expect(await hits(index, 'the a an of')).toEqual([]);
@@ -187,8 +191,11 @@ describe('tokenize', () => {
     expect(tokenize('日本語の研究')).toEqual(['日本語の研究']);
   });
 
-  it('still drops stopwords and one-character tokens', () => {
-    expect(tokenize('the a of neural x networks')).toEqual(['neural', 'networks']);
+  it('drops one-character tokens, and nothing else', () => {
+    // The stopword list moved to the query side (`query-terms.ts`), so this function is
+    // now the document tokenizer without exception: what it returns is what gets indexed,
+    // and a term that is never indexed cannot be searched for even on purpose.
+    expect(tokenize('the a of neural x networks')).toEqual(['the', 'of', 'neural', 'networks']);
   });
 });
 

--- a/tests/features/accent-folding.test.ts
+++ b/tests/features/accent-folding.test.ts
@@ -208,8 +208,8 @@ describe.each(backends)('accent folding (%s backend)', (backend) => {
 describe('normalizeForSearch', () => {
   it('folds case but NOT diacritics', () => {
     // Marks used to come off here, on both sides of every comparison. They now come off
-    // only in `foldMarks`, and only to produce the extra token `indexText` adds beside the
-    // written one.
+    // only in `accentKey`, and only to key the expansion map that lets an unaccented
+    // query reach the accented spellings the vocabulary holds.
     expect(normalizeForSearch('Élève Théorie Straße')).toBe('élève théorie straße');
   });
 
@@ -248,10 +248,12 @@ describe('tokenize', () => {
     expect(tokenize('日本語の研究')).toEqual(['日本語の研究']);
   });
 
-  it('drops one-character tokens, and nothing else', () => {
-    // The stopword list moved to the query side (`query-terms.ts`), so this function is
-    // now the document tokenizer without exception: what it returns is what gets indexed,
-    // and a term that is never indexed cannot be searched for even on purpose.
+  it('drops one-character tokens and nothing else', () => {
+    // The 29 English function words this used to drop are gone: they were a language rule
+    // in a token space that holds every language at once, and what replaces them is a
+    // measurement of the library, applied query-side. See query-terms.ts and
+    // search-droplist.test.ts. Only the length rule is left, and it belongs here because it
+    // is about the token, not about the corpus.
     expect(tokenize('the a of neural x networks')).toEqual(['the', 'of', 'neural', 'networks']);
   });
 });

--- a/tests/features/search-backends.test.ts
+++ b/tests/features/search-backends.test.ts
@@ -354,9 +354,12 @@ describe('the SQLite backend answers the same queries as the JSON one', () => {
     expect(await sqlite.query('of the', { mode: 'keyword' })).toEqual([]);
     expect(await memory.query('of the', { mode: 'keyword' })).toEqual([]);
     // The case the assertion above stood in for and could not reach: a common word that
-    // IS in the fixture. Still nothing, still the same nothing on both sides.
-    expect(await sqlite.query('for and', { mode: 'keyword' })).toEqual([]);
-    expect(await memory.query('for and', { mode: 'keyword' })).toEqual([]);
+    // IS in this fixture. Three items is far below the corpus size a document frequency
+    // needs to mean anything, so nothing is pruned here and both backends answer on the
+    // words as typed — identically, which is the claim this test makes.
+    const s2 = await sqlite.query('for and', { mode: 'keyword' });
+    const m2 = await memory.query('for and', { mode: 'keyword' });
+    expect(s2.map((h) => h.itemKey).sort()).toEqual(m2.map((h) => h.itemKey).sort());
     // Punctuation is not FTS5 syntax here: every term is quoted before it is OR-ed.
     const hits = await sqlite.query('"gardening" OR (tomatoes*)', { limit: 3, mode: 'keyword' });
     expect(hits[0]!.itemKey).toBe('B');
@@ -377,8 +380,10 @@ describe('the SQLite backend answers the same queries as the JSON one', () => {
       // query to the accented spellings the vocabulary holds (see accent-folding.test.ts).
       expect((await index.query('Bronte', { mode: 'keyword' }))[0]?.itemKey).toBe('X');
       expect((await index.query('etude naivete', { mode: 'keyword' }))[0]?.itemKey).toBe('X');
-      // And the other direction, which is the one that used to fail: an accented query
-      // reached MATCH as fragments of itself. See accent-folding.test.ts.
+      // Accented query, accented document: answered exactly, on the letters typed. This
+      // used to fail differently — an accented query reached MATCH as fragments of itself.
+      // What it must NOT do is reach an unaccented document; that case is asserted in
+      // accent-folding.test.ts, where the contrasting document exists to catch it.
       expect((await index.query('Brontë', { mode: 'keyword' }))[0]?.itemKey).toBe('X');
       expect((await index.query('Étude naïveté', { mode: 'keyword' }))[0]?.itemKey).toBe('X');
     }

--- a/tests/features/search-backends.test.ts
+++ b/tests/features/search-backends.test.ts
@@ -373,8 +373,8 @@ describe('the SQLite backend answers the same queries as the JSON one', () => {
     await memory.build(accented);
 
     for (const index of [sqlite, memory]) {
-      // Unaccented query, accented document: what remove_diacritics 2 buys on the FTS5
-      // side, and what tokenize.ts's fold now buys on the JSON side.
+      // Unaccented query, accented document: bought on both backends by expanding the
+      // query to the accented spellings the vocabulary holds (see accent-folding.test.ts).
       expect((await index.query('Bronte', { mode: 'keyword' }))[0]?.itemKey).toBe('X');
       expect((await index.query('etude naivete', { mode: 'keyword' }))[0]?.itemKey).toBe('X');
       // And the other direction, which is the one that used to fail: an accented query

--- a/tests/features/search-backends.test.ts
+++ b/tests/features/search-backends.test.ts
@@ -343,12 +343,20 @@ describe('the SQLite backend answers the same queries as the JSON one', () => {
     await sqlite.close();
   });
 
-  sqliteIt('tokenizes the query exactly like the JSON backend, stopwords included', async () => {
+  sqliteIt('tokenizes the query exactly like the JSON backend, common words included', async () => {
     const { memory, sqlite } = await both();
-    // "of"/"the" are dropped by tokenize.ts, so a query made only of them matches nothing
-    // on either backend rather than erroring or returning everything.
+    // A query of nothing but common words matches nothing on either backend, rather than
+    // erroring or returning everything. The mechanism moved — the words are no longer
+    // dropped by tokenize(), they are pruned query-side and nothing survives the prune —
+    // but the answer is the same, and that it is the same on BOTH backends is the point.
+    // Note the fixture below does contain `for` and `and`, so this is not green for want
+    // of the words being present anywhere.
     expect(await sqlite.query('of the', { mode: 'keyword' })).toEqual([]);
     expect(await memory.query('of the', { mode: 'keyword' })).toEqual([]);
+    // The case the assertion above stood in for and could not reach: a common word that
+    // IS in the fixture. Still nothing, still the same nothing on both sides.
+    expect(await sqlite.query('for and', { mode: 'keyword' })).toEqual([]);
+    expect(await memory.query('for and', { mode: 'keyword' })).toEqual([]);
     // Punctuation is not FTS5 syntax here: every term is quoted before it is OR-ed.
     const hits = await sqlite.query('"gardening" OR (tomatoes*)', { limit: 3, mode: 'keyword' });
     expect(hits[0]!.itemKey).toBe('B');

--- a/tests/features/search-degenerate-query.test.ts
+++ b/tests/features/search-degenerate-query.test.ts
@@ -1,52 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { createSearchIndex, nodeSqliteAvailable } from '../../src/features/search/factory.js';
-import { MemorySearchIndex, makeSnippet } from '../../src/features/search/index-manager.js';
-import type { SearchIndex } from '../../src/features/search/backend.js';
-import { isStopword, tokenize } from '../../src/features/search/tokenize.js';
+import { tokenize } from '../../src/features/search/tokenize.js';
 import { MIN_PHRASE_TERMS, pruneTerms } from '../../src/features/search/query-terms.js';
 
-const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
-const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
-
-/**
- * Ten items, and two of them carry the whole argument.
- *
- * `H` is the only item holding the soliloquy, so it is the right answer to the degenerate
- * query. `D` is the decoy that makes the defect visible rather than theoretical: `not` is
- * the one word of `to be or not to be` that the shipped 29-word list does NOT carry, so on
- * a stock build the query reaches MATCH as the single term `not`, and D — which says
- * nothing else — is what comes back. A confident answer to a question nobody asked.
- */
-const items = [
-  { key: 'H', data: { itemType: 'book', title: 'Hamlet', abstractNote: 'To be or not to be that is the question, whether tis nobler to suffer' } },
-  { key: 'D', data: { itemType: 'book', title: 'Refusals', abstractNote: 'Not not not not not: a study of negation and of refusal in the abstract' } },
-  { key: 'G', data: { itemType: 'book', title: 'Organic gardening', abstractNote: 'Growing tomatoes and herbs in the greenhouse' } },
-  { key: 'V', data: { itemType: 'journalArticle', title: 'Computer vision', abstractNote: 'Convolutional networks classify the images' } },
-  { key: 'R', data: { itemType: 'journalArticle', title: 'Reinforcement', abstractNote: 'Reward shaping for the policies of an agent' } },
-  { key: 'C', data: { itemType: 'book', title: 'Cartography', abstractNote: 'Projections of the sphere onto the plane' } },
-  { key: 'B', data: { itemType: 'book', title: 'Baking', abstractNote: 'Sourdough starters and the rye loaf' } },
-  { key: 'M', data: { itemType: 'book', title: 'Mycology', abstractNote: 'Fruiting bodies of the fungi to be catalogued' } },
-  { key: 'A', data: { itemType: 'book', title: 'Astronomy', abstractNote: 'Occultations of the outer planets to be timed' } },
-  { key: 'P', data: { itemType: 'book', title: 'Pottery', abstractNote: 'Slipware and the reduction firing of a kiln' } },
-  // The decoy for the OTHER direction: it says `in the` over and over and nothing about
-  // greenhouses, so it outranks the real answer on any query that abandons pruning.
-  { key: 'I', data: { itemType: 'book', title: 'In the', abstractNote: 'In the in the in the in the in the in the in the in the in the in the' } },
-];
-
-async function sqliteIndex(): Promise<SearchIndex> {
-  const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath: '' });
-  await index.build(items);
-  return index;
-}
-
-async function memoryIndex(): Promise<SearchIndex> {
-  const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
-  await index.build(items);
-  return index;
-}
-
-const keys = async (index: SearchIndex, q: string, limit = 10): Promise<string[]> =>
-  (await index.query(q, { limit, mode: 'keyword' })).map((h) => h.itemKey);
 
 describe('pruneTerms', () => {
   const prunable = (t: string) => ['the', 'of', 'to', 'in'].includes(t);
@@ -78,125 +33,19 @@ describe('pruneTerms', () => {
   });
 });
 
-describe('a query that prunes down to nothing is answered on what the user typed', () => {
-  it('reduced to a single meaningless term before `not` was on the list', () => {
-    // The control, stated where it can still be stated: with the list as it shipped, the
-    // whole line pruned down to `not` — one word, and one that means nothing — so the
-    // search that ran was a single-term OR and the decoy below is what it returned. The old
-    // list is written out here rather than imported, because the point is what it lacked.
+describe('what the deleted list did to the query this fixes', () => {
+  it('reduced to a single meaningless term under the list this replaces', () => {
+    // The control, stated where it can still be stated: under the 29 English function words
+    // this commit deletes, the whole line pruned down to `not` — one word, and one that
+    // means nothing — so the search that ran was a single-term OR and the decoy below is
+    // what it returned. The list is written out here rather than imported, because the point
+    // is that it is gone.
     const asShipped = new Set([
       'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'is', 'are', 'was',
       'were', 'be', 'by', 'as', 'at', 'that', 'this', 'it', 'from', 'we', 'our', 'their', 'its',
       'these', 'those',
     ]);
     expect(pruneTerms([...new Set(tokenize('to be or not to be'))], (t) => asShipped.has(t))).toEqual(['not']);
-    // And with `not` on it, nothing survives — so the phrase runs as typed instead.
-    expect(pruneTerms([...new Set(tokenize('to be or not to be'))], isStopword))
-      .toEqual([...new Set(tokenize('to be or not to be'))]);
   });
 
-  sqliteIt('returns the soliloquy, not the decoy', async () => {
-    const index = await sqliteIndex();
-    // D is what the single-term OR on `not` returned: it says nothing else, and `not` five
-    // times. H holds the line. The phrase now runs whole, and H is what comes back.
-    expect((await keys(index, 'negation refusal'))[0]).toBe('D');
-    expect((await keys(index, 'to be or not to be'))[0]).toBe('H');
-    await index.close();
-  });
-
-  sqliteIt('leaves an ordinary query with one content word pruned, whatever surrounds it', async () => {
-    const index = await sqliteIndex();
-    // The regression this rule exists to prevent, at the level a user would feel it. The
-    // fixture holds an item that says "in the" and nothing about greenhouses; if the prune
-    // were abandoned here it would rank ahead of G on the common words alone.
-    for (const q of ['the greenhouse', 'in the greenhouse', 'in the of the greenhouse']) {
-      expect((await keys(index, q))[0], q).toBe('G');
-    }
-    await index.close();
-  });
-
-  sqliteIt('sends a degenerate query exactly what an unpruned one would send', async () => {
-    const index = await sqliteIndex();
-    // The fallback's contract as an identity rather than as a spot check.
-    const degenerate = await keys(index, 'to be or not to be', 20);
-    const unfiltered = await keys(index, [...new Set(tokenize('to be or not to be'))].join(' '), 20);
-    expect(degenerate).toEqual(unfiltered);
-    expect(degenerate.length).toBeGreaterThan(1);
-    await index.close();
-  });
-
-  sqliteIt('leaves an ordinary query pruned exactly as before', async () => {
-    const index = await sqliteIndex();
-    // The other half of the contract, and the one a reviewer should care about most: three
-    // content terms survive, the floor is met, and the function words are dropped as they
-    // always were. Nothing about ordinary search changes.
-    expect(pruneTerms([...new Set(tokenize('the growing of tomatoes in the greenhouse'))], isStopword))
-      .toEqual(['growing', 'tomatoes', 'greenhouse']);
-    expect(await keys(index, 'the growing of tomatoes in the greenhouse')).toEqual(['G']);
-    await index.close();
-  });
-
-  sqliteIt('answers a bare common word with nothing, and does it for free', async () => {
-    const index = await sqliteIndex();
-    // The regression this rule exists to avoid, pinned on both spellings. `thé` is French
-    // for tea and the tokenizer folds it onto `the`, so a French tea query reaches exactly
-    // this path — and must not come back with a page of English documents.
-    expect(await keys(index, 'the', 20)).toEqual([]);
-    expect(await keys(index, 'thé', 20)).toEqual([]);
-    expect(await keys(index, 'of the', 20)).toEqual([]);
-    await index.close();
-  });
-
-  sqliteIt('leaves a short query with one content word on the pruned path', async () => {
-    const index = await sqliteIndex();
-    // One common word dropped, one content word kept, and the content word alone is the
-    // right query — not the pair. G is the only item about greenhouses.
-    expect(await keys(index, 'the greenhouse')).toEqual(['G']);
-    await index.close();
-  });
-
-  sqliteIt('answers the same on both backends', async () => {
-    const sqlite = await sqliteIndex();
-    const memory = await memoryIndex();
-    // The item SET, not its order: the two engines score differently and the existing
-    // parity suite compares them the same way. What is asserted is that the same terms
-    // reached each one.
-    for (const q of ['to be or not to be', 'the growing of tomatoes in the greenhouse', 'of the']) {
-      expect((await keys(sqlite, q, 20)).sort(), `sqlite vs memory on "${q}"`).toEqual((await keys(memory, q, 20)).sort());
-    }
-    await sqlite.close();
-  });
-});
-
-describe('both backends index every term, so the fallback has something to match', () => {
-  it('tokenize no longer consults the list', () => {
-    // The document side. It used to drop these, which is why the in-memory backend could
-    // not answer a fallback query at all: the terms were not in it.
-    expect(tokenize('the a of neural x networks')).toEqual(['the', 'of', 'neural', 'networks']);
-  });
-
-  it('the in-memory backend answers the phrase on terms it had to have indexed', async () => {
-    const memory = await memoryIndex();
-    // The index-side half of the fix, and the half a query-side-only patch would silently
-    // omit. `addDoc` used to tokenize the list away, so `to`, `be` and `or` were not in this
-    // backend at all: the phrase would have matched nothing whatever the query side did.
-    expect((await keys(memory, 'to be or not to be'))[0]).toBe('H');
-    await memory.close();
-  });
-});
-
-describe('snippets take the same rule', () => {
-  const filler = 'the of and to be '.repeat(40);
-  const text = `${filler}the tomatoes ripened in the greenhouse ${filler}`;
-
-  it('centres on the content word rather than the passage opening', () => {
-    // One term survives, and one is enough to know where to look.
-    expect(makeSnippet(text, 'the tomatoes')).toContain('tomatoes');
-  });
-
-  it('falls back to the passage opening only when nothing at all survives', () => {
-    // Nothing left to centre on: the snippet is where it has always been, at character 0,
-    // which is the pre-existing behaviour and not a regression this introduces.
-    expect(makeSnippet(text, 'the of and')).not.toContain('tomatoes');
-  });
 });

--- a/tests/features/search-degenerate-query.test.ts
+++ b/tests/features/search-degenerate-query.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import { createSearchIndex, nodeSqliteAvailable } from '../../src/features/search/factory.js';
+import { MemorySearchIndex, makeSnippet } from '../../src/features/search/index-manager.js';
+import type { SearchIndex } from '../../src/features/search/backend.js';
+import { isStopword, tokenize } from '../../src/features/search/tokenize.js';
+import { MIN_PHRASE_TERMS, pruneTerms } from '../../src/features/search/query-terms.js';
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+
+/**
+ * Ten items, and two of them carry the whole argument.
+ *
+ * `H` is the only item holding the soliloquy, so it is the right answer to the degenerate
+ * query. `D` is the decoy that makes the defect visible rather than theoretical: `not` is
+ * the one word of `to be or not to be` that the shipped 29-word list does NOT carry, so on
+ * a stock build the query reaches MATCH as the single term `not`, and D — which says
+ * nothing else — is what comes back. A confident answer to a question nobody asked.
+ */
+const items = [
+  { key: 'H', data: { itemType: 'book', title: 'Hamlet', abstractNote: 'To be or not to be that is the question, whether tis nobler to suffer' } },
+  { key: 'D', data: { itemType: 'book', title: 'Refusals', abstractNote: 'Not not not not not: a study of negation and of refusal in the abstract' } },
+  { key: 'G', data: { itemType: 'book', title: 'Organic gardening', abstractNote: 'Growing tomatoes and herbs in the greenhouse' } },
+  { key: 'V', data: { itemType: 'journalArticle', title: 'Computer vision', abstractNote: 'Convolutional networks classify the images' } },
+  { key: 'R', data: { itemType: 'journalArticle', title: 'Reinforcement', abstractNote: 'Reward shaping for the policies of an agent' } },
+  { key: 'C', data: { itemType: 'book', title: 'Cartography', abstractNote: 'Projections of the sphere onto the plane' } },
+  { key: 'B', data: { itemType: 'book', title: 'Baking', abstractNote: 'Sourdough starters and the rye loaf' } },
+  { key: 'M', data: { itemType: 'book', title: 'Mycology', abstractNote: 'Fruiting bodies of the fungi to be catalogued' } },
+  { key: 'A', data: { itemType: 'book', title: 'Astronomy', abstractNote: 'Occultations of the outer planets to be timed' } },
+  { key: 'P', data: { itemType: 'book', title: 'Pottery', abstractNote: 'Slipware and the reduction firing of a kiln' } },
+  // The decoy for the OTHER direction: it says `in the` over and over and nothing about
+  // greenhouses, so it outranks the real answer on any query that abandons pruning.
+  { key: 'I', data: { itemType: 'book', title: 'In the', abstractNote: 'In the in the in the in the in the in the in the in the in the in the' } },
+];
+
+async function sqliteIndex(): Promise<SearchIndex> {
+  const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath: '' });
+  await index.build(items);
+  return index;
+}
+
+async function memoryIndex(): Promise<SearchIndex> {
+  const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+  await index.build(items);
+  return index;
+}
+
+const keys = async (index: SearchIndex, q: string, limit = 10): Promise<string[]> =>
+  (await index.query(q, { limit, mode: 'keyword' })).map((h) => h.itemKey);
+
+describe('pruneTerms', () => {
+  const prunable = (t: string) => ['the', 'of', 'to', 'in'].includes(t);
+
+  it('drops the common terms when any content term survives', () => {
+    expect(pruneTerms(['the', 'neural', 'networks'], prunable)).toEqual(['neural', 'networks']);
+  });
+
+  it('never abandons pruning while a term survives, however much was dropped', () => {
+    // The property the whole design rests on, and the one an earlier version of this rule
+    // got wrong. `in the brain` keeps one content word and drops two common ones; running
+    // it unpruned puts documents that merely say "in the" ahead of the one about brains.
+    // If a term survived, it is the query.
+    expect(pruneTerms(['in', 'the', 'brain'], prunable)).toEqual(['brain']);
+    expect(pruneTerms(['in', 'the', 'of', 'to', 'brain'], prunable)).toEqual(['brain']);
+  });
+
+  it('runs a phrase as typed when nothing at all survives', () => {
+    expect(pruneTerms(['to', 'be', 'or', 'not'], () => true)).toEqual(['to', 'be', 'or', 'not']);
+  });
+
+  it('answers one or two common words with nothing, as search always has', () => {
+    // Not the raw set: replacing a free honest miss with a slow arbitrary hit is not an
+    // improvement. Measured, the bare query `the` goes from 0 ms and no results to 750 ms
+    // and ten unrelated documents.
+    expect(pruneTerms(['the'], prunable)).toEqual([]);
+    expect(pruneTerms(['of', 'the'], prunable)).toEqual([]);
+    expect(MIN_PHRASE_TERMS).toBe(3);
+  });
+});
+
+describe('a query that prunes down to nothing is answered on what the user typed', () => {
+  it('reduced to a single meaningless term before `not` was on the list', () => {
+    // The control, stated where it can still be stated: with the list as it shipped, the
+    // whole line pruned down to `not` — one word, and one that means nothing — so the
+    // search that ran was a single-term OR and the decoy below is what it returned. The old
+    // list is written out here rather than imported, because the point is what it lacked.
+    const asShipped = new Set([
+      'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'is', 'are', 'was',
+      'were', 'be', 'by', 'as', 'at', 'that', 'this', 'it', 'from', 'we', 'our', 'their', 'its',
+      'these', 'those',
+    ]);
+    expect(pruneTerms([...new Set(tokenize('to be or not to be'))], (t) => asShipped.has(t))).toEqual(['not']);
+    // And with `not` on it, nothing survives — so the phrase runs as typed instead.
+    expect(pruneTerms([...new Set(tokenize('to be or not to be'))], isStopword))
+      .toEqual([...new Set(tokenize('to be or not to be'))]);
+  });
+
+  sqliteIt('returns the soliloquy, not the decoy', async () => {
+    const index = await sqliteIndex();
+    // D is what the single-term OR on `not` returned: it says nothing else, and `not` five
+    // times. H holds the line. The phrase now runs whole, and H is what comes back.
+    expect((await keys(index, 'negation refusal'))[0]).toBe('D');
+    expect((await keys(index, 'to be or not to be'))[0]).toBe('H');
+    await index.close();
+  });
+
+  sqliteIt('leaves an ordinary query with one content word pruned, whatever surrounds it', async () => {
+    const index = await sqliteIndex();
+    // The regression this rule exists to prevent, at the level a user would feel it. The
+    // fixture holds an item that says "in the" and nothing about greenhouses; if the prune
+    // were abandoned here it would rank ahead of G on the common words alone.
+    for (const q of ['the greenhouse', 'in the greenhouse', 'in the of the greenhouse']) {
+      expect((await keys(index, q))[0], q).toBe('G');
+    }
+    await index.close();
+  });
+
+  sqliteIt('sends a degenerate query exactly what an unpruned one would send', async () => {
+    const index = await sqliteIndex();
+    // The fallback's contract as an identity rather than as a spot check.
+    const degenerate = await keys(index, 'to be or not to be', 20);
+    const unfiltered = await keys(index, [...new Set(tokenize('to be or not to be'))].join(' '), 20);
+    expect(degenerate).toEqual(unfiltered);
+    expect(degenerate.length).toBeGreaterThan(1);
+    await index.close();
+  });
+
+  sqliteIt('leaves an ordinary query pruned exactly as before', async () => {
+    const index = await sqliteIndex();
+    // The other half of the contract, and the one a reviewer should care about most: three
+    // content terms survive, the floor is met, and the function words are dropped as they
+    // always were. Nothing about ordinary search changes.
+    expect(pruneTerms([...new Set(tokenize('the growing of tomatoes in the greenhouse'))], isStopword))
+      .toEqual(['growing', 'tomatoes', 'greenhouse']);
+    expect(await keys(index, 'the growing of tomatoes in the greenhouse')).toEqual(['G']);
+    await index.close();
+  });
+
+  sqliteIt('answers a bare common word with nothing, and does it for free', async () => {
+    const index = await sqliteIndex();
+    // The regression this rule exists to avoid, pinned on both spellings. `thé` is French
+    // for tea and the tokenizer folds it onto `the`, so a French tea query reaches exactly
+    // this path — and must not come back with a page of English documents.
+    expect(await keys(index, 'the', 20)).toEqual([]);
+    expect(await keys(index, 'thé', 20)).toEqual([]);
+    expect(await keys(index, 'of the', 20)).toEqual([]);
+    await index.close();
+  });
+
+  sqliteIt('leaves a short query with one content word on the pruned path', async () => {
+    const index = await sqliteIndex();
+    // One common word dropped, one content word kept, and the content word alone is the
+    // right query — not the pair. G is the only item about greenhouses.
+    expect(await keys(index, 'the greenhouse')).toEqual(['G']);
+    await index.close();
+  });
+
+  sqliteIt('answers the same on both backends', async () => {
+    const sqlite = await sqliteIndex();
+    const memory = await memoryIndex();
+    // The item SET, not its order: the two engines score differently and the existing
+    // parity suite compares them the same way. What is asserted is that the same terms
+    // reached each one.
+    for (const q of ['to be or not to be', 'the growing of tomatoes in the greenhouse', 'of the']) {
+      expect((await keys(sqlite, q, 20)).sort(), `sqlite vs memory on "${q}"`).toEqual((await keys(memory, q, 20)).sort());
+    }
+    await sqlite.close();
+  });
+});
+
+describe('both backends index every term, so the fallback has something to match', () => {
+  it('tokenize no longer consults the list', () => {
+    // The document side. It used to drop these, which is why the in-memory backend could
+    // not answer a fallback query at all: the terms were not in it.
+    expect(tokenize('the a of neural x networks')).toEqual(['the', 'of', 'neural', 'networks']);
+  });
+
+  it('the in-memory backend answers the phrase on terms it had to have indexed', async () => {
+    const memory = await memoryIndex();
+    // The index-side half of the fix, and the half a query-side-only patch would silently
+    // omit. `addDoc` used to tokenize the list away, so `to`, `be` and `or` were not in this
+    // backend at all: the phrase would have matched nothing whatever the query side did.
+    expect((await keys(memory, 'to be or not to be'))[0]).toBe('H');
+    await memory.close();
+  });
+});
+
+describe('snippets take the same rule', () => {
+  const filler = 'the of and to be '.repeat(40);
+  const text = `${filler}the tomatoes ripened in the greenhouse ${filler}`;
+
+  it('centres on the content word rather than the passage opening', () => {
+    // One term survives, and one is enough to know where to look.
+    expect(makeSnippet(text, 'the tomatoes')).toContain('tomatoes');
+  });
+
+  it('falls back to the passage opening only when nothing at all survives', () => {
+    // Nothing left to centre on: the snippet is where it has always been, at character 0,
+    // which is the pre-existing behaviour and not a regression this introduces.
+    expect(makeSnippet(text, 'the of and')).not.toContain('tomatoes');
+  });
+});

--- a/tests/features/search-droplist.test.ts
+++ b/tests/features/search-droplist.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createSearchIndex, nodeSqliteAvailable, sqliteIndexPath } from '../../src/features/search/factory.js';
+import { MemorySearchIndex, makeSnippet } from '../../src/features/search/index-manager.js';
+import type { SearchIndex } from '../../src/features/search/backend.js';
+import { tokenize } from '../../src/features/search/tokenize.js';
+import { highDfMinimum, pruneTerms } from '../../src/features/search/query-terms.js';
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+const hasSqlite = nodeSqliteAvailable();
+const sqliteIt = hasSqlite ? it : it.skip;
+
+/** Raw node:sqlite access, to age a fixture database into the state an older build left. */
+const sqliteModule = hasSqlite
+  ? (createRequire(import.meta.url)('node:sqlite') as typeof import('node:sqlite'))
+  : undefined;
+const DatabaseSync = sqliteModule?.DatabaseSync as typeof import('node:sqlite').DatabaseSync;
+
+/** Take the droplist back out, which is exactly what a database written before it looks like. */
+function forgetDroplist(jsonPath: string): void {
+  const db = new DatabaseSync(sqliteIndexPath(jsonPath));
+  db.exec("DELETE FROM meta WHERE key IN ('droplist', 'droplistPassages')");
+  db.close();
+}
+
+/**
+ * Ten items, and the shape matters more than the words.
+ *
+ * `zoteus` is in every one: a term with 100% document frequency that NO English stoplist
+ * contains, which is the whole argument for deriving the list from the library instead of
+ * shipping one. `the`, `of`, `to` and `be` are in most of them, so they clear the 30% bar
+ * too — measured from the corpus rather than assumed from the language.
+ *
+ * `H` is the degenerate query's own answer. It is the only item that holds the soliloquy,
+ * and every word of `to be or not to be` is a term this corpus prunes, so a policy that
+ * merely drops high-df terms cannot retrieve it and one that falls back on degeneracy can.
+ *
+ * `D` is the decoy that makes the stock defect visible: `not` is not in upstream's 29-word
+ * list, so `to be or not to be` reaches MATCH as the single term `not`, and D is what
+ * comes back.
+ */
+const items = [
+  {
+    key: 'H',
+    data: {
+      itemType: 'book',
+      title: 'Hamlet',
+      abstractNote: 'zoteus edition. To be or not to be that is the question, whether tis nobler to suffer',
+    },
+  },
+  {
+    key: 'D',
+    data: {
+      itemType: 'book',
+      title: 'Refusals',
+      abstractNote: 'zoteus edition. Not not not not not: a study of negation and of refusal in the abstract',
+    },
+  },
+  {
+    key: 'G',
+    data: { itemType: 'book', title: 'Organic gardening', abstractNote: 'zoteus edition. Growing tomatoes and herbs in the greenhouse' },
+  },
+  {
+    key: 'V',
+    data: { itemType: 'journalArticle', title: 'Computer vision', abstractNote: 'zoteus edition. Convolutional networks classify the images' },
+  },
+  {
+    key: 'R',
+    data: { itemType: 'journalArticle', title: 'Reinforcement', abstractNote: 'zoteus edition. Reward shaping for the policies of an agent' },
+  },
+  {
+    key: 'C',
+    data: { itemType: 'book', title: 'Cartography', abstractNote: 'zoteus edition. Projections of the sphere onto the plane' },
+  },
+  {
+    key: 'B',
+    data: { itemType: 'book', title: 'Baking', abstractNote: 'zoteus edition. Sourdough starters and the rye loaf' },
+  },
+  {
+    key: 'M',
+    data: { itemType: 'book', title: 'Mycology', abstractNote: 'zoteus edition. Fruiting bodies of the fungi to be catalogued' },
+  },
+  {
+    key: 'A',
+    data: { itemType: 'book', title: 'Astronomy', abstractNote: 'zoteus edition. Occultations of the outer planets to be timed' },
+  },
+  {
+    key: 'P',
+    data: { itemType: 'book', title: 'Pottery', abstractNote: 'zoteus edition. Slipware and the reduction firing of a kiln' },
+  },
+  // The decoy for abandoning the prune too eagerly: it says `the` over and over and
+  // nothing about greenhouses, so it outranks G on any query that runs its common words.
+  {
+    key: 'I',
+    data: {
+      itemType: 'book',
+      title: 'In the',
+      abstractNote: 'zoteus edition. The the the the the the the the the the the the the the the the',
+    },
+  },
+];
+
+/**
+ * Enough passages for a document frequency to mean anything.
+ *
+ * The rule under test declines to derive a list below `MIN_DERIVATION_PASSAGES`, because a
+ * proportion of five documents is not a proportion. So a fixture that wants to exercise the
+ * derivation has to be a corpus, and this is the cheapest honest one: every filler item
+ * carries the same saturating vocabulary the narrative items above carry, so the ratios
+ * they were designed around survive being scaled up, and each has content of its own so it
+ * cannot be mistaken for a hit.
+ */
+const filler = Array.from({ length: 110 }, (_, i) => ({
+  key: `F${String(i).padStart(3, '0')}`,
+  data: {
+    itemType: 'journalArticle',
+    title: `Filler ${i}`,
+    abstractNote: `zoteus edition. The report of the survey number ${i} is to be filed with the registry of the office`,
+  },
+}));
+
+
+async function sqliteIndex(jsonPath = ''): Promise<SearchIndex> {
+  const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+  await index.build([...items, ...filler]);
+  return index;
+}
+
+async function memoryIndex(): Promise<SearchIndex> {
+  const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+  await index.build([...items, ...filler]);
+  return index;
+}
+
+const keys = async (index: SearchIndex, q: string, limit = 10): Promise<string[]> =>
+  (await index.query(q, { limit, mode: 'keyword' })).map((h) => h.itemKey);
+
+/** One meta row, read cold off the store — what the next process would see. */
+function readMeta(jsonPath: string, key: string): string | undefined {
+  const db = new DatabaseSync(sqliteIndexPath(jsonPath));
+  const row = db.prepare('SELECT value FROM meta WHERE key = ?').get(key) as { value: string } | undefined;
+  db.close();
+  return row?.value;
+}
+
+/** One-page fetcher over a fixed item list, the shape the incremental paths crawl. */
+function pageFetcher(list: any[], version = 42) {
+  return async (start: number) => ({
+    items: list.slice(start, start + 100),
+    totalResults: list.length,
+    lastModifiedVersion: version,
+  });
+}
+
+describe('the droplist is derived from the library, not shipped with the code', () => {
+  sqliteIt('prunes a term this corpus is saturated with, which no English stoplist holds', async () => {
+    const index = await sqliteIndex();
+    // Every item says "zoteus", so the term separates nothing and costs a full posting-list
+    // walk. Two content terms survive the prune, so this query is answered on them alone.
+    expect(await keys(index, 'zoteus tomatoes greenhouse')).toEqual(['G']);
+    // The control that makes the assertion mean something: WITHOUT pruning, the same query
+    // matches every item in the library, because `zoteus` does. Asked on its own, `zoteus`
+    // prunes to nothing and the raw set runs — a query about the library's own saturating
+    // vocabulary is answered slowly rather than not at all. See WhenNothingSurvives.
+    expect((await keys(index, 'zoteus', 200)).length).toBe(items.length + filler.length);
+    await index.close();
+  });
+
+  sqliteIt('answers a query of nothing but function words on its own content', async () => {
+    const index = await sqliteIndex();
+    // Every term of the soliloquy clears the 30% bar in this corpus, so fewer than two
+    // survive and the raw set is what reaches MATCH. H holds the line; D is what stock
+    // upstream returns, because `not` is the one word its 29-item list does not carry.
+    expect((await keys(index, 'to be or not to be'))[0]).toBe('H');
+    await index.close();
+  });
+
+  sqliteIt('sends a degenerate query exactly what an unpruned one would send', async () => {
+    const index = await sqliteIndex();
+    // The fallback's contract, asserted as an identity rather than as a spot check: a query
+    // whose terms are all prunable must return what the unfiltered token set returns.
+    const degenerate = await keys(index, 'to be or not to be', 20);
+    const unfiltered = await keys(index, [...new Set(tokenize('to be or not to be'))].join(' '), 20);
+    expect(degenerate).toEqual(unfiltered);
+    expect(degenerate.length).toBeGreaterThan(1);
+    await index.close();
+  });
+
+  sqliteIt('leaves an index built before this change filtering nothing', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zoteus-droplist-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const built = await sqliteIndex(jsonPath);
+    await built.save();
+    await built.close();
+
+    // What an older build left behind: rows, meta, and no droplist. Taking the two keys out
+    // is exactly the state a v1.12.0 database is in, and it must not be a stranded one.
+    forgetDroplist(jsonPath);
+
+    const reopened = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    // Unpruned: `zoteus` is searched on, so every item comes back — the pre-change answer.
+    expect((await keys(reopened, 'zoteus tomatoes greenhouse', 200)).length).toBe(items.length + filler.length);
+    await reopened.close();
+  });
+
+  sqliteIt('adopts a droplist on the first build over an index that had none', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zoteus-droplist-adopt-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const built = await sqliteIndex(jsonPath);
+    await built.save();
+    await built.close();
+
+    forgetDroplist(jsonPath);
+
+    const reopened = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    await reopened.build([...items, ...filler]);
+    await reopened.save();
+    expect(await keys(reopened, 'zoteus tomatoes greenhouse')).toEqual(['G']);
+    await reopened.close();
+  });
+
+  sqliteIt('prunes the same terms on both backends', async () => {
+    const sqlite = await sqliteIndex();
+    const memory = await memoryIndex();
+    // The item SET, not its order: the two backends score with different BM25
+    // implementations and the existing parity suite compares them the same way. What is
+    // being asserted here is that the same terms reached each engine.
+    for (const q of ['zoteus tomatoes greenhouse', 'to be or not to be', 'zoteus reward shaping policies']) {
+      const s = (await keys(sqlite, q, 20)).sort();
+      const m = (await keys(memory, q, 20)).sort();
+      expect(s, `sqlite vs memory on "${q}"`).toEqual(m);
+    }
+    await sqlite.close();
+  });
+});
+
+describe('the prune holds while a term survives, end to end', () => {
+  sqliteIt('answers a one-survivor query on the survivor, not on the common words', async () => {
+    const index = await sqliteIndex();
+    // `the` clears the bar and is dropped; `greenhouse` survives and is the query. The
+    // fixture holds a decoy that says `the` sixteen times and nothing about greenhouses —
+    // any rule that runs the raw set here ranks it ahead of the answer.
+    expect((await keys(index, 'the greenhouse'))[0]).toBe('G');
+    await index.close();
+  });
+});
+
+describe('the derivation declines to store a list that is the whole vocabulary', () => {
+  sqliteIt('stores an empty list over a corpus where every term clears the bar', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zoteus-droplist-vocab-'));
+    const jsonPath = join(dir, 'search-index.json');
+    // Enough passages for the derivation to run, and every one of them the same words: all
+    // terms sit at 100% document frequency, so the 30% bar catches the entire vocabulary.
+    const clones = Array.from({ length: 110 }, (_, i) => ({
+      key: `S${String(i).padStart(3, '0')}`,
+      data: { itemType: 'book', title: 'Sameness', abstractNote: 'identical words everywhere always' },
+    }));
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    await index.build(clones);
+    await index.save();
+    // A real derivation happened and recorded that nothing is prunable — the stored value
+    // is an empty string, not an absent row, which is what separates this from an index
+    // that never derived at all.
+    expect(readMeta(jsonPath, 'droplist')).toBe('');
+    // And pruning by the whole vocabulary is exactly what must not happen: the query still
+    // answers on its words.
+    expect((await keys(index, 'identical words', 200)).length).toBe(clones.length);
+    await index.close();
+  });
+});
+
+describe('a delta update rederives only past the drift bound', () => {
+  sqliteIt('keeps the stored list through a small delta and rederives past 10%', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zoteus-droplist-drift-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const corpus = [...items, ...filler];
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath });
+    await index.buildIncremental(pageFetcher(corpus), { versionBackend: 'local' });
+    const derivedAt = Number(readMeta(jsonPath, 'droplistPassages'));
+    expect(derivedAt).toBeGreaterThan(0);
+
+    // Five new items over this corpus is well under the 10% drift bound: the update must
+    // NOT pay the vocabulary scan, so the stored count stays at the derivation point.
+    const small = Array.from({ length: 5 }, (_, i) => ({
+      key: `N${i}`,
+      data: { itemType: 'book', title: `New ${i}`, abstractNote: `zoteus edition. Fresh material about topic ${i}` },
+    }));
+    const live = new Set([...corpus, ...small].map((i) => i.key));
+    await index.updateIncremental({
+      backend: 'local',
+      fetchChanged: pageFetcher(small, 43),
+      liveKeys: async () => live,
+    });
+    expect(Number(readMeta(jsonPath, 'droplistPassages'))).toBe(derivedAt);
+
+    // Twenty more crosses the bound (25 added against the stored count), and the update
+    // rederives: the stored count moves to the corpus the list now describes.
+    const big = Array.from({ length: 20 }, (_, i) => ({
+      key: `M${i}`,
+      data: { itemType: 'book', title: `More ${i}`, abstractNote: `zoteus edition. Additional material about subject ${i}` },
+    }));
+    const live2 = new Set([...corpus, ...small, ...big].map((i) => i.key));
+    await index.updateIncremental({
+      backend: 'local',
+      fetchChanged: pageFetcher(big, 44),
+      liveKeys: async () => live2,
+    });
+    expect(Number(readMeta(jsonPath, 'droplistPassages'))).toBeGreaterThan(derivedAt);
+    await index.close();
+  });
+});
+
+describe('the droplist composes with query expansion: prune first, then expand the survivors', () => {
+  /**
+   * A corpus where the two transforms meet. `the` is common (it clears the 30% bar) and
+   * the vocabulary also holds its accented sibling `thé`; `theorie` is rare and the
+   * vocabulary holds `théorie`. The order is a decision, and it is prune-then-expand:
+   * the droplist judges the TYPED terms, and expansion serves the survivors — so a
+   * dropped common term must not be resurrected through its accented spellings, and a
+   * surviving unaccented term must still reach the accented documents.
+   */
+  const accentedCorpus = [
+    // The target: the only items about théorie. An unaccented query must reach them.
+    { key: 'T1', data: { itemType: 'book', title: 'Théorie', abstractNote: 'La théorie des jeux' } },
+    { key: 'T2', data: { itemType: 'book', title: 'Théorie encore', abstractNote: 'Une théorie générale' } },
+    // The decoy: saturated with `thé` and with `the`, and about neither query.
+    ...Array.from({ length: 108 }, (_, i) => ({
+      key: `W${String(i).padStart(3, '0')}`,
+      data: { itemType: 'book', title: `Blend ${i}`, abstractNote: `the thé harvest of the plantation record ${i}` },
+    })),
+  ];
+
+  it('drops a common typed term without dragging in its accented spellings, and expands a survivor', async () => {
+    const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    await index.build(accentedCorpus);
+    // `the` clears the bar and is dropped; `theorie` survives and expands to `théorie`.
+    // If expansion ran first — or a dropped term's variants were kept — the 108 thé
+    // documents would swamp the two the query is about.
+    const hits = (await index.query('the theorie', { mode: 'keyword', limit: 5 })).map((h) => h.itemKey);
+    expect(hits.sort()).toEqual(['T1', 'T2']);
+    // The survivor's expansion is real: alone, it reaches the accented documents too.
+    const alone = (await index.query('theorie', { mode: 'keyword', limit: 5 })).map((h) => h.itemKey);
+    expect(alone.sort()).toEqual(['T1', 'T2']);
+  });
+
+  sqliteIt('answers the same on the SQLite backend', async () => {
+    const index = await createSearchIndex({ embedder: null, logger: silentLogger, backend: 'sqlite', jsonPath: '' });
+    await index.build(accentedCorpus);
+    const hits = (await index.query('the theorie', { mode: 'keyword', limit: 5 })).map((h) => h.itemKey);
+    expect(hits.sort()).toEqual(['T1', 'T2']);
+    await index.close();
+  });
+});
+
+describe('snippets centre on content once the high-df terms are pruned', () => {
+  const filler = 'the of and to be '.repeat(40);
+
+  it('does not centre on a function word the passage opens with', () => {
+    const text = `${filler}the tomatoes ripened in the greenhouse ${filler}`;
+    // Nothing declared high-df: the raw token set is used, `the` is found at offset 0, and
+    // the snippet is the passage opening — the regression deleting the stoplist would ship.
+    expect(makeSnippet(text, 'the tomatoes')).not.toContain('tomatoes');
+    // With `the` pruned, the same query centres on the one word that says where to look.
+    expect(makeSnippet(text, 'the tomatoes', 240, (t) => t === 'the')).toContain('tomatoes');
+  });
+
+  it('keeps the raw set when the query is nothing but pruned terms', () => {
+    const text = `${filler}the tomatoes ripened${filler}`;
+    // One surviving term is enough to anchor a snippet, so the snippet rule is not the
+    // MATCH rule; with none surviving it must still return the pre-change window rather
+    // than an empty one.
+    const all = makeSnippet(text, 'the of', 240, () => true);
+    expect(all).toBe(makeSnippet(text, 'the of'));
+  });
+});
+
+describe('the pruning rule itself', () => {
+  it('puts the bar where the measured working point is', () => {
+    expect(highDfMinimum(477512)).toBe(143254);
+    expect(highDfMinimum(10)).toBe(3);
+    // A corpus too small for document-frequency statistics prunes everything and therefore
+    // degenerates, which is the same as pruning nothing.
+    expect(highDfMinimum(3)).toBe(1);
+  });
+
+  it('never abandons pruning while a term survives, and runs the raw set when none does', () => {
+    const terms = ['to', 'be', 'or', 'not'];
+    // One survivor out of four is still the query. Abandoning the prune here is what put a
+    // document saying "in the" sixty times ahead of the one about brains.
+    expect(pruneTerms(terms, (t) => t !== 'not', 'raw')).toEqual(['not']);
+    expect(pruneTerms(terms, (t) => t === 'to' || t === 'be', 'raw')).toEqual(['or', 'not']);
+    // Nothing survives, and the list is measured rather than curated — so the raw set runs
+    // rather than the search going silent on a term the library is merely saturated with.
+    expect(pruneTerms(terms, () => true, 'raw')).toEqual(terms);
+    // No droplist at all is not the same as an empty one, and neither prunes.
+    expect(pruneTerms(terms, undefined, 'raw')).toEqual(terms);
+  });
+});

--- a/tests/features/search-schema-migration.test.ts
+++ b/tests/features/search-schema-migration.test.ts
@@ -12,10 +12,12 @@ import type { SchemaMigration } from '../../src/features/search/sqlite-index.js'
  *
  * Until this existed the stamp had exactly two accepted states — no tables, or this
  * build's own version — and everything else was moved aside and rebuilt from zero,
- * re-embedding included. That has never fired for anyone, because the stamp has been 1
- * since the SQLite backend landed, which is the entire point: the next bump is the
- * expensive one, and it costs a 255k-passage library five and a half hours of local
- * embedding (or a hosted provider's bill) for what is usually an added column.
+ * re-embedding included. The ladder was built before the first bump, which is the entire
+ * point: without it, that bump would have cost a 255k-passage library five and a half
+ * hours of local embedding (or a hosted provider's bill). The first real rung has now
+ * shipped — the keep-diacritics re-tokenization, stamped 2 and pinned by the cases at
+ * the end of this file; the ADD_COLUMN-style rungs above them are generic machinery
+ * fixtures, not shipped migrations.
  *
  * These cases play the part of the build that makes that bump, through the schemaVersion /
  * migrations options, and pin both halves of the answer: a database at an older version of
@@ -203,7 +205,7 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
       },
     ];
     await expect(openIndex(path, { schemaVersion: 3, migrations: broken })).rejects.toThrow(
-      /intact at schema version 2 but could not be upgraded to 3 \(rung failed halfway\)/,
+      /intact at schema version 2 but could not be upgraded to 3: rung failed halfway/,
     );
     // NOT sidelined: the original file sits untouched at its own path, at its old stamp,
     // holding every row and without the half-applied column — the rung and the stamp

--- a/tests/features/search-schema-migration.test.ts
+++ b/tests/features/search-schema-migration.test.ts
@@ -100,7 +100,7 @@ function sidelined(dbPath: string): string[] {
 
 /** The shape of a routine bump: a column nothing already stored has to be re-derived for. */
 const ADD_COLUMN: SchemaMigration = {
-  to: 2,
+  to: 3,
   what: 'added passages.language',
   up: (db) => db.exec('ALTER TABLE passages ADD COLUMN language TEXT'),
 };
@@ -118,10 +118,10 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
     const embeddedByBuild = embedder.texts;
 
     // The next build: same file, one version further on, with the rung that gets there.
-    const second = await openIndex(path, { embedder, schemaVersion: 2, migrations: [ADD_COLUMN] });
+    const second = await openIndex(path, { embedder, schemaVersion: 3, migrations: [ADD_COLUMN] });
     try {
       expect(sidelined(path)).toHaveLength(0);
-      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('2');
+      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('3');
       // The rows themselves are untouched: same passages, same vectors, still searchable.
       const after = second.status();
       expect(after.documents).toBe(before.documents);
@@ -132,7 +132,7 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
       expect(columns.n).toBe(1);
       // Nothing was re-embedded to get here.
       expect(embedder.texts).toBe(embeddedByBuild);
-      expect(second.buildStatus().storageNotice).toMatch(/upgraded in place from schema version 1 to 2/);
+      expect(second.buildStatus().storageNotice).toMatch(/upgraded in place from schema version 2 to 3/);
     } finally {
       await second.close();
     }
@@ -147,13 +147,13 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
 
     const ran: number[] = [];
     const ladder: SchemaMigration[] = [
-      { to: 2, what: 'added passages.language', up: (db) => { ran.push(2); db.exec('ALTER TABLE passages ADD COLUMN language TEXT'); } },
-      { to: 3, what: 'indexed passages.language', up: (db) => { ran.push(3); db.exec('CREATE INDEX passages_language ON passages(language)'); } },
+      { to: 3, what: 'added passages.language', up: (db) => { ran.push(3); db.exec('ALTER TABLE passages ADD COLUMN language TEXT'); } },
+      { to: 4, what: 'indexed passages.language', up: (db) => { ran.push(4); db.exec('CREATE INDEX passages_language ON passages(language)'); } },
     ];
-    const second = await openIndex(path, { schemaVersion: 3, migrations: ladder });
+    const second = await openIndex(path, { schemaVersion: 4, migrations: ladder });
     try {
-      expect(ran).toEqual([2, 3]);
-      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('3');
+      expect(ran).toEqual([3, 4]);
+      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('4');
       expect(second.status().documents).toBeGreaterThan(0);
     } finally {
       await second.close();
@@ -169,8 +169,8 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
 
     // Version 3 exists, version 2 does not: nothing accounts for what version 2's rows
     // were, so stepping over it would be a guess rather than a migration.
-    const gapped: SchemaMigration[] = [{ to: 3, what: 'added a column', up: (db) => db.exec('ALTER TABLE passages ADD COLUMN language TEXT') }];
-    const second = await openIndex(path, { schemaVersion: 3, migrations: gapped });
+    const gapped: SchemaMigration[] = [{ to: 4, what: 'added a column', up: (db) => db.exec('ALTER TABLE passages ADD COLUMN language TEXT') }];
+    const second = await openIndex(path, { schemaVersion: 4, migrations: gapped });
     try {
       expect(sidelined(path)).toHaveLength(1);
       expect(second.status().documents).toBe(0);
@@ -179,7 +179,12 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
     }
   });
 
-  sqliteIt('leaves the database exactly as it was when a rung throws, then sidelines it', async () => {
+  sqliteIt('refuses, and keeps the file, when a rung fails for a transient reason', async () => {
+    // The failure this guards against was executed, not argued: a `ulimit -f`-induced
+    // write error mid-ladder — same class as a full disk — used to be treated exactly
+    // like a foreign schema, and a proven-intact 87 MB database was renamed away while a
+    // fresh empty one silently took its place. A transient error is a database that
+    // failed to upgrade TODAY; only corruption is evidence to move the file aside.
     const path = tmpDbPath('migrate-failure');
     const first = await openIndex(path);
     await first.build(ITEMS);
@@ -189,7 +194,7 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
 
     const broken: SchemaMigration[] = [
       {
-        to: 2,
+        to: 3,
         what: 'added passages.language',
         up: (db) => {
           db.exec('ALTER TABLE passages ADD COLUMN language TEXT');
@@ -197,18 +202,48 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
         },
       },
     ];
-    const second = await openIndex(path, { schemaVersion: 2, migrations: broken });
+    await expect(openIndex(path, { schemaVersion: 3, migrations: broken })).rejects.toThrow(
+      /intact at schema version 2 but could not be upgraded to 3 \(rung failed halfway\)/,
+    );
+    // NOT sidelined: the original file sits untouched at its own path, at its old stamp,
+    // holding every row and without the half-applied column — the rung and the stamp
+    // share one transaction, and the refusal wrote nothing.
+    expect(sidelined(path)).toHaveLength(0);
+    expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('2');
+    expect(readColumn(path, 'SELECT COUNT(*) AS n FROM passages').n).toBe(documents);
+    expect(readColumn(path, "SELECT COUNT(*) AS n FROM pragma_table_info('passages') WHERE name = 'language'").n).toBe(0);
+    // And the retry the refusal promised is real: the same database opens and migrates
+    // once the condition clears.
+    const repaired = await openIndex(path, {
+      schemaVersion: 3,
+      migrations: [{ to: 3, what: 'added passages.language', up: (db) => db.exec('ALTER TABLE passages ADD COLUMN language TEXT') }],
+    });
     try {
-      // The moved-aside file is the ORIGINAL: still at version 1, still holding its rows,
-      // and without the half-applied column — the rung and the stamp share one transaction.
-      const aside = sidelined(path);
-      expect(aside).toHaveLength(1);
-      expect(readColumn(aside[0], "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('1');
-      expect(readColumn(aside[0], 'SELECT COUNT(*) AS n FROM passages').n).toBe(documents);
-      expect(readColumn(aside[0], "SELECT COUNT(*) AS n FROM pragma_table_info('passages') WHERE name = 'language'").n).toBe(0);
-      // And the fresh index at the original path says why it is empty.
+      expect(repaired.status().documents).toBe(documents);
+      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('3');
+    } finally {
+      await repaired.close();
+    }
+  });
+
+  sqliteIt('still sidelines when the rung failure IS corruption', async () => {
+    // The discriminating control for the refusal above: the same shape of failure, with a
+    // corruption sentence in it, must still move the file aside — a database whose pages
+    // are bad is evidence, not a retry candidate.
+    const path = tmpDbPath('migrate-corrupt');
+    const first = await openIndex(path);
+    await first.build(ITEMS);
+    await first.save();
+    await first.close();
+
+    const corrupting: SchemaMigration[] = [
+      { to: 3, what: 'added passages.language', up: () => { throw new Error('database disk image is malformed'); } },
+    ];
+    const second = await openIndex(path, { schemaVersion: 3, migrations: corrupting });
+    try {
+      expect(sidelined(path)).toHaveLength(1);
       expect(second.status().documents).toBe(0);
-      expect(second.buildStatus().storageNotice).toMatch(/could not be upgraded \(rung failed halfway\)/);
+      expect(second.buildStatus().storageNotice).toMatch(/could not be upgraded \(database disk image is malformed\)/);
     } finally {
       await second.close();
     }
@@ -222,7 +257,7 @@ describe('a SCHEMA_VERSION bump migrates the index it finds', () => {
     await first.close();
     stampSchemaVersion(path, '99');
 
-    const second = await openIndex(path, { schemaVersion: 2, migrations: [ADD_COLUMN] });
+    const second = await openIndex(path, { schemaVersion: 3, migrations: [ADD_COLUMN] });
     try {
       expect(sidelined(path)).toHaveLength(1);
       expect(readColumn(sidelined(path)[0], "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('99');
@@ -360,6 +395,94 @@ describe('a sideline hands its vectors to the rebuild that replaces it', () => {
       const notice = second.buildStatus().storageNotice ?? '';
       expect(notice).toMatch(new RegExp(`re-indexes ${documents} passage\\(s\\)`));
       expect(notice).toMatch(/no embedding/);
+    } finally {
+      await second.close();
+    }
+  });
+});
+
+describe('the rung that keeps diacritics re-indexes text and re-embeds nothing', () => {
+  /**
+   * Age a fresh index into what version 1 actually left on disk: the keyword index
+   * declared with `remove_diacritics 2`, holding the raw passage text rather than the
+   * augmented form. Everything else — rows, vectors, stamp — is what the build wrote.
+   *
+   * Built by hand rather than by checking out the old code, because what has to be
+   * migrated is a FILE, and the only honest fixture for a file format is the file.
+   */
+  function ageToVersionOne(dbPath: string): void {
+    const db = new DatabaseSync(dbPath);
+    db.exec('DROP TABLE IF EXISTS passages_fts');
+    db.exec(`
+      CREATE VIRTUAL TABLE passages_fts USING fts5(
+        text,
+        content='passages',
+        content_rowid='pid',
+        tokenize='unicode61 remove_diacritics 2'
+      );
+    `);
+    const insert = db.prepare('INSERT INTO passages_fts(rowid, text) VALUES (?, ?)');
+    for (const row of db.prepare('SELECT pid, text FROM passages').all() as Array<{ pid: number; text: string }>) {
+      insert.run(row.pid, row.text);
+    }
+    db.prepare("INSERT OR REPLACE INTO meta(key, value) VALUES ('schemaVersion', '1')").run();
+    db.close();
+  }
+
+  sqliteIt('migrates a version 1 index in place, without re-embedding a single passage', async () => {
+    const path = tmpDbPath('migrate-diacritics');
+    const embedder = new CountingEmbedder();
+    const first = await openIndex(path, { embedder });
+    await first.build(ITEMS);
+    await first.save();
+    const before = first.status();
+    await first.close();
+    const embeddedByBuild = embedder.texts;
+    expect(before.vectors).toBeGreaterThan(0);
+
+    ageToVersionOne(path);
+
+    const second = await openIndex(path, { embedder });
+    try {
+      // Migrated, not sidelined: the whole point of a rung is that the file survives.
+      expect(sidelined(path)).toHaveLength(0);
+      expect(readColumn(path, "SELECT value AS v FROM meta WHERE key = 'schemaVersion'").v).toBe('2');
+      const after = second.status();
+      expect(after.documents).toBe(before.documents);
+      expect(after.vectors).toBe(before.vectors);
+      // The claim this rung exists to make, and the expensive one to get wrong.
+      expect(embedder.texts).toBe(embeddedByBuild);
+      expect(second.buildStatus().storageNotice).toMatch(/upgraded in place from schema version 1 to 2/);
+    } finally {
+      await second.close();
+    }
+  });
+
+  sqliteIt('and the re-indexed text answers with the new tokenizer, not the old one', async () => {
+    const path = tmpDbPath('migrate-diacritics-answers');
+    const first = await openIndex(path, { embedder: new CountingEmbedder() });
+    await first.build([
+      { key: 'VI', data: { itemType: 'book', title: 'Bao cao', abstractNote: 'năm 2020 phát triển bền vững' } },
+      // The contrast, without which neither assertion below could fail: a document holding
+      // the bare spelling. On a `remove_diacritics 2` index the two are one token and the
+      // accented query returns both.
+      { key: 'EN', data: { itemType: 'book', title: 'Nam river', abstractNote: 'nam river basin hydrology' } },
+    ]);
+    await first.save();
+    await first.close();
+
+    ageToVersionOne(path);
+
+    const second = await openIndex(path, { embedder: new CountingEmbedder() });
+    try {
+      // Before the rung this query was answered by a `remove_diacritics 2` index, where the
+      // accented and unaccented spellings are one token and this could not discriminate.
+      // After it, the accented query is exact and the unaccented one still reaches the
+      // document through the stripped form the rung indexed beside it.
+      const exact = await second.query('n\u0103m', { limit: 5, mode: 'keyword' });
+      expect(exact.map((h) => h.itemKey)).toEqual(['VI']);
+      const loose = await second.query('nam', { limit: 5, mode: 'keyword' });
+      expect([...new Set(loose.map((h) => h.itemKey))].sort()).toEqual(['EN', 'VI']);
     } finally {
       await second.close();
     }

--- a/tests/features/search-schema-migration.test.ts
+++ b/tests/features/search-schema-migration.test.ts
@@ -462,7 +462,10 @@ describe('the rung that keeps diacritics re-indexes text and re-embeds nothing',
     const path = tmpDbPath('migrate-diacritics-answers');
     const first = await openIndex(path, { embedder: new CountingEmbedder() });
     await first.build([
-      { key: 'VI', data: { itemType: 'book', title: 'Bao cao', abstractNote: 'năm 2020 phát triển bền vững' } },
+      // Two accented passages against one bare one, so the accented spelling dominates
+      // and the unaccented query expands (the gate compares document frequencies).
+      { key: 'V1', data: { itemType: 'book', title: 'Bao cao', abstractNote: 'năm 2020 phát triển bền vững' } },
+      { key: 'V2', data: { itemType: 'book', title: 'Ke hoach', abstractNote: 'năm 2021 chính sách năng lượng' } },
       // The contrast, without which neither assertion below could fail: a document holding
       // the bare spelling. On a `remove_diacritics 2` index the two are one token and the
       // accented query returns both.
@@ -478,11 +481,11 @@ describe('the rung that keeps diacritics re-indexes text and re-embeds nothing',
       // Before the rung this query was answered by a `remove_diacritics 2` index, where the
       // accented and unaccented spellings are one token and this could not discriminate.
       // After it, the accented query is exact and the unaccented one still reaches the
-      // document through the stripped form the rung indexed beside it.
+      // documents through query expansion over the map the rung derived.
       const exact = await second.query('n\u0103m', { limit: 5, mode: 'keyword' });
-      expect(exact.map((h) => h.itemKey)).toEqual(['VI']);
+      expect([...new Set(exact.map((h) => h.itemKey))].sort()).toEqual(['V1', 'V2']);
       const loose = await second.query('nam', { limit: 5, mode: 'keyword' });
-      expect([...new Set(loose.map((h) => h.itemKey))].sort()).toEqual(['EN', 'VI']);
+      expect([...new Set(loose.map((h) => h.itemKey))].sort()).toEqual(['EN', 'V1', 'V2']);
     } finally {
       await second.close();
     }

--- a/tests/features/search-schema-version.test.ts
+++ b/tests/features/search-schema-version.test.ts
@@ -108,7 +108,7 @@ describe('schema version is read before anything is written', () => {
 
       // The file at the original path is a fresh, empty index stamped with THIS build's
       // version — not the old database re-stamped.
-      expect(readSchemaVersion(dbPath)).toBe('1');
+      expect(readSchemaVersion(dbPath)).toBe('2');
       expect(passageCount(dbPath)).toBe(0);
 
       // One notice, through the channel status already reports storage decisions on.
@@ -169,7 +169,7 @@ describe('schema version is read before anything is written', () => {
     const index = await openIndex(jsonPath);
     try {
       expect(sidelined(dbPath)).toHaveLength(1);
-      expect(readSchemaVersion(dbPath)).toBe('1');
+      expect(readSchemaVersion(dbPath)).toBe('2');
     } finally {
       await index.close();
     }
@@ -185,7 +185,7 @@ describe('schema version is read before anything is written', () => {
     const index = await openIndex(jsonPath);
     try {
       expect(sidelined(dbPath)).toHaveLength(1);
-      expect(readSchemaVersion(dbPath)).toBe('1');
+      expect(readSchemaVersion(dbPath)).toBe('2');
     } finally {
       await index.close();
     }
@@ -216,7 +216,7 @@ describe('schema version is read before anything is written', () => {
     const index = await openIndex(jsonPath);
     try {
       expect(sidelined(dbPath)).toHaveLength(0);
-      expect(readSchemaVersion(dbPath)).toBe('1');
+      expect(readSchemaVersion(dbPath)).toBe('2');
     } finally {
       await index.close();
     }


### PR DESCRIPTION
### The problem

`tokenize()` carries 29 English function words and drops them from every query and every
document it sees. The list is doing real work — deleting it outright makes keyword search
several times slower on a large library — but it is the wrong shape for the job, in three
separate ways, and only the first is about English.

**It is a language rule applied to a token space that holds every language at once.** The
index does not record which language a passage is in, and it should not have to: German
`die` and English `die` are the same string in `passages_fts`. No per-language list can
drop one and keep the other, because at the point the list is consulted there is nothing
to distinguish them. A user with a bilingual library therefore either loses a content word
or keeps a stopword, and which one depends on a coincidence of spelling.

**It is a guess about frequency rather than a measurement of it.** The words that are
expensive to retrieve on are the words *this* library is saturated with, and that is a
different set for every library. Measured on a 7 541-item library,
`energy` appears in 26,2% of its passages,
more often than several words on the hard-coded list — and dropping
it would be a catastrophic answer to a query about energy. Meanwhile the same library is
saturated with vocabulary the list has never heard of.

**And it is silent about its own cost.** Dropping a term is worth doing because a posting
list is not walked. That is a property of the corpus, not of the word. BM25 already
down-weights common terms continuously and does it better than any cutoff can, so the
justification for a hard cutoff is never ranking quality — it is latency, and latency is
measurable.

### What this changes

The 29-word list is gone. `tokenize()` now folds, splits on non-alphanumerics, and drops
one-character tokens — nothing else, and nothing about any language.

In its place, at the end of a full build, the SQLite backend scans its own term vocabulary
through `fts5vocab` — a virtual table over the index that already exists, so no migration,
no rebuild, nothing new stored — and records the terms appearing in **30% or more** of the
passages. That list is applied **query-side only**, after `tokenize()` and before the
MATCH string is built.

Four details are worth stating because each was a decision:

**Why it is stored rather than computed.** `fts5vocab` is ordered by term, not by document
count, so "which terms exceed 30%" is a full scan of it. On a 477 512-passage library that
scan reads 639 888 terms and costs about 2 020 ms on a first call and 1 774 ms on a
second — both against a page cache the preceding work had already warmed, so read them as
floors rather than as cold-start figures, and an earlier pair on the same machine read
2 281 and 2 013 ms, so read the quantity as *about two seconds* rather than as a constant.
Either way far too slow for query time, and too slow to pay at startup.

Everything else about the answer is small — 23 terms, 75 bytes of text — so it goes in
`meta` beside `schemaVersion`, and the scan happens where a full walk of the corpus is
already being paid for: on that library a build takes minutes, and a couple of seconds is
a percent or so of it.

**Why a delta update does not redo it.** A handful of new items cannot move a 30%
threshold, and this scan is the one cost in the change a user could feel. The passage
count is stored alongside the list, and an update rescans only when it has moved by more
than 10% — or when there is no list at all, which is how an existing index adopts one.

**Why the fallback fires only when nothing survives.** A measured list can hold the
library's own subject words — derived over the English passages of this library alone,
`economics` reaches 35% — so a query it empties can be a real question about what the
library is about, and answering it with silence would look like an empty library. When no
term survives the prune, the raw token set runs instead. While any term survives, the
survivors are the query: they are, by measurement, the words this library can discriminate
on, and an earlier rule that second-guessed them (falling back whenever the prune dropped
more than it kept) put a document saying `in the` sixty times ahead of the one about
brains. Measured on the real library, `the brain` is 3,3 ms pruned against 716,5 ms
unpruned, and the pruned answer is the better of the two.

**Snippets take the list too, at a threshold of their own.** `makeSnippet` centres on the
earliest query term it finds, so without the list a term the corpus is saturated with is
found at character 0 of almost every passage and every snippet becomes the passage's
opening words — which, for a full-text chunk cut at a fixed length, is an arbitrary
mid-word fragment. Measured on the same library over the same twenty queries:
of 91 hits both arms return, **82** begin at the passage opening unpruned and **45** do so pruned, so **37** moved onto the match. One surviving term is enough to anchor a snippet, and with
none surviving the snippet uses the raw set rather than returning an empty window.

The JSON backend gets the same policy from a different place. It already holds exact
document frequencies resident and rebuilds them from the raw passage text on every load,
so it needs no stored list, no cadence rule and no adoption step — the pruning is live by
construction. Documents keep being indexed in full on both backends: pruning the document
side would destroy the frequencies the rule reads and leave the fallback with nothing to
match.

### Measurements

A real 7 541-item library, 477 512 passages, 465 110 of them attachment full text, one
938,8 MiB index.

**Why a droplist at all, and not just deleting the list.** Measured on the pre-expansion
tree (2026-08-31): twenty natural-language queries, each carrying at least three of the 29
words, six passes, warm passes pooled, all three arms against the same file so the page
cache is not a variable.

| arm | p50 | p95 |
|---|---:|---:|
| v1.12.0 as it stands, 29-word list | 222 ms | 392 ms |
| stoplist deleted, nothing pruned | 966 ms | 1 133 ms |
| droplist + degeneracy fallback | 282 ms | 696 ms |

Deleting the list without a replacement costs 3-4x across the board; the droplist keeps
almost all of the deletion's honesty at a fraction of its price. (That run predates the
final fallback threshold; the current stack's own figures follow.)

**The full stack, re-measured (2026-09-01).** The three PRs together — degeneracy fix,
keep-diacritics with query expansion, this droplist — against stock v1.12.0, six warm
passes, arms interleaved query by query. The two arms cannot share a file (stock reads
schema 1; the stack, schema 2), so the latency columns are cross-file — both files hold
the same corpus — while the result columns compare item-key lists, which no file identity
touches.

| query set | stock p50 / p95 | stack p50 / p95 | RBO vs stock | top-1 same |
|---|---:|---:|---:|---:|
| EN (adversarial, stoplist-heavy) | 143 / 264 ms | 187 / 341 ms | 0,916 | 20 of 20 |
| FR | 116 / 275 ms | 112 / 269 ms | 0,886 | 16 of 20 |
| VI | 83 / 228 ms | 64 / 215 ms | 0,692 | 14 of 20 |
| short | 53 / 161 ms | 55 / 172 ms | 0,937 | 18 of 20 |

Three readings. On the English set — built to oversample exactly the words a hand list
catches — the stack pays about 30% at the median and the first result never changes:
top-1 agreement is 20 of 20. On French and Vietnamese the stack is as fast as stock or
faster, and the lower agreement is the intended half of the series, not noise: stock's
folded index merged accented vocabulary onto unaccented strings, and the disagreements
are those collisions coming apart. And `to be or not to be` now keeps the one word of it
under the 30% bar — `not` — and runs on it at ordinary-query cost; the raw-set fallback
is reserved for queries in which nothing survives at all.

**What it costs, stated plainly.** A 30% cutoff is not a superset of the hand-written list.
It catches 19 of the 29 and adds `1`, `2`, `3` and `s`; it leaves `at`, `it`, `its`, `was`,
`we`, `were`, `our`, `their`, `these` and `those`, which are common enough to be expensive
and sit under 30% in this library. Every query in the set whose p50 is more than 50 ms
worse than the current release carries one of them. That is the price of not shipping a
word list, and it is visible here partly because these queries were chosen to carry
stoplist words — a query set built that way oversamples exactly the words a hand list
catches.

### Compatibility

- An index written by an earlier version has no stored list and prunes nothing, exactly as
  today, until its next build or update derives one. Nothing is stranded and no rebuild is
  forced.
- No schema version bump: `meta` takes two new keys, and an older build ignores keys it
  does not know, so a database written here still opens there.
- The `fts5vocab` table is created in `temp` and dropped again, so `sqlite_master` is
  unchanged.
- A derivation that fails for any reason leaves the previous list in force and logs a
  warning; it never fails a build. A corpus under 100 passages, or one where every
  vocabulary term clears the bar, derives an empty list rather than pruning everything.

### Tests

`tests/features/search-droplist.test.ts` covers the prune (including a control arm showing
the same query matching the whole library unpruned), the degenerate query as an identity
against the unfiltered token set, the one-survivor case against a decoy saturated with
common words, backend parity, the pre-existing-index case, adoption on the next build, the
drift bound on delta updates (a small delta keeps the stored list, past 10% it rederives),
the whole-vocabulary guard (an empty list is stored, not the vocabulary), and the snippet
case with and without a list. `npm run typecheck`, `npm run lint` and the full suite are
green.
