### PR TITLE
docs: publish an uninstall procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ claude mcp add --transport stdio zoteus -e ZOTERO_API_KEY=xxxxx -- npx -y @oscar
 
 > Get a key at [zotero.org/settings/keys](https://www.zotero.org/settings/keys). For key-free local reads and writes, enable **Settings → Advanced → "Allow other applications on this computer to communicate with Zotero"** in the desktop app.
 
+## Uninstall
+
+Zoteus writes everything it derives — the search index, the on-device model weights, the update-check cache — into one directory: `ZOTEUS_DATA_DIR` if you set it, otherwise your OS's default application-data path. Stop the server, remove it from your MCP client's configuration, then delete that directory; your Zotero library lives elsewhere and nothing here touches it. Full steps, platform paths, and the pre-v1.10.0 case (model weights that used to land outside this directory): [`docs/uninstall.md`](./docs/uninstall.md).
+
 ---
 
 ## Features
@@ -96,7 +100,7 @@ Full table in [`docs/configuration.md`](./docs/configuration.md). To run a share
 
 ## Documentation
 
-**[zoteus.com/docs](https://zoteus.com/docs)** · [Getting started](./docs/getting-started.md) · [Configuration](./docs/configuration.md) · [Import & resolver](./docs/resolver.md) · [Architecture](./docs/architecture.md) · [Safe writes](./docs/writing.md) · [Citations](./docs/citations.md) · [Semantic search](./docs/semantic-search.md) · [Scholarly context](./docs/scholar.md) · [Code execution](./docs/code-execution.md) · [Deployment](./docs/deployment.md)
+**[zoteus.com/docs](https://zoteus.com/docs)** · [Getting started](./docs/getting-started.md) · [Configuration](./docs/configuration.md) · [Uninstall](./docs/uninstall.md) · [Import & resolver](./docs/resolver.md) · [Architecture](./docs/architecture.md) · [Safe writes](./docs/writing.md) · [Citations](./docs/citations.md) · [Semantic search](./docs/semantic-search.md) · [Scholarly context](./docs/scholar.md) · [Code execution](./docs/code-execution.md) · [Deployment](./docs/deployment.md)
 
 ## Privacy
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,102 @@
+# Uninstalling Zoteus
+
+**Zoteus writes everything it derives into one directory.** Removing that
+directory removes the search index, the on-device model weights, and the
+update-check cache — every file the server has ever written for itself. Your
+Zotero library is somewhere else entirely, and nothing below goes near it.
+
+## Where that directory is
+
+`ZOTEUS_DATA_DIR`, if you set it. Otherwise the OS default:
+
+| Platform | Default |
+|---|---|
+| macOS | `~/Library/Application Support/zoteus` |
+| Windows | `%APPDATA%\zoteus` |
+| Linux, BSD, everything else | `${XDG_DATA_HOME:-~/.local/share}/zoteus` |
+
+The table above is the whole rule: no tool reports the resolved path, so if
+you set `ZOTEUS_DATA_DIR` yourself, read it back from wherever you set it.
+
+## The steps
+
+1. **Stop the server.** Quit whatever holds the stdio connection — Claude
+   Desktop, your editor, or the `node` process, if you started it yourself.
+   A running server holds the index's
+   SQLite file open and will rewrite its `-wal` sidecar underneath you.
+
+2. **Remove the registration.** Delete Zoteus's entry from your MCP client's
+   configuration, or uninstall the desktop extension bundle through the
+   client that installed it. Nothing else in this list depends on the order,
+   but doing this second means the client will not relaunch the server while
+   you are deleting its files.
+
+3. **Delete the data directory.** The one from the table above — and only
+   that one. It is not your Zotero library, which lives elsewhere and is not
+   part of this procedure; check the path you are about to remove against the
+   table before you run anything.
+
+   ```sh
+   # Linux/BSD, default location
+   rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/zoteus"
+   # macOS, default location
+   rm -rf ~/Library/Application\ Support/zoteus
+   # Windows, PowerShell, default location
+   Remove-Item -Recurse -Force "$env:APPDATA\zoteus"
+   # any platform, if you set the variable yourself
+   rm -rf "$ZOTEUS_DATA_DIR"
+   ```
+
+   That is the whole removal. The index (`search-index.sqlite` and its
+   `-wal`/`-shm` sidecars, or the older `search-index.json`), the downloaded
+   model weights under `<ZOTEUS_DATA_DIR>/models`, and `update-check.json`
+   all live inside it.
+
+4. **Remove the embedding runtime, if you installed one by hand.** Semantic
+   search needs `@huggingface/transformers`, which Zoteus does not vendor. If
+   you installed it yourself and pointed `ZOTEUS_TRANSFORMERS_PATH` at it,
+   that directory is yours and outlives every step above — delete it if
+   nothing else uses it. An install that never enabled semantic search has
+   nothing to do here.
+
+## What is deliberately left alone
+
+**Your Zotero library.** Zoteus reads the desktop app's data directory
+(`~/Zotero` by default, `ZOTERO_DATA_DIR` if you moved it) to open attachment
+files, and writes no file into it. That is a claim about the directory, not
+about your library: unless you ran with `ZOTEUS_READ_ONLY=true`, Zoteus could
+add and edit items through the API like any other client, and removing it
+leaves those items where they are. Do not delete the directory as part of
+removing Zoteus.
+
+**Your API keys.** They live wherever you put them — a shell profile, your
+MCP client's configuration, a secret manager. Zoteus keeps no copy of its own,
+so nothing in this list reaches them. Revoke them yourself if you want them
+gone.
+
+## If you installed before v1.10.0
+
+**Earlier versions left the model weights outside the data directory**, and
+deleting the data directory alone was an incomplete uninstall for those
+installs. `@huggingface/transformers` caches downloaded weights inside its own
+package directory by default; Zoteus did not override that until the fix that
+pins the cache to `<ZOTEUS_DATA_DIR>/models` before the pipeline is built.
+Under `ZOTEUS_TRANSFORMERS_PATH` pointing at a global `node_modules`, those
+weights outlived even uninstalling the desktop extension — and they are the
+largest artifact of the lot, tens of megabytes for the default model and
+gigabytes for a larger one.
+
+If your install predates that fix and you never removed the package, look for
+a `.cache` or `models` directory inside the `@huggingface/transformers`
+install you pointed at and delete it. A fresh install writes nothing there.
+
+## Checking
+
+Nothing should remain:
+
+```sh
+ls "${ZOTEUS_DATA_DIR:-$HOME/.local/share/zoteus}"    # no such file or directory
+```
+
+Reinstalling later rebuilds the index from your library. Nothing removed here
+is unrecoverable, and nothing removed here was yours.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -69,10 +69,12 @@ add and edit items through the API like any other client, and removing it
 leaves those items where they are. Do not delete the directory as part of
 removing Zoteus.
 
-**Your API keys.** They live wherever you put them — a shell profile, your
-MCP client's configuration, a secret manager. Zoteus keeps no copy of its own,
-so nothing in this list reaches them. Revoke them yourself if you want them
-gone.
+**Your cloud API keys.** They live wherever you put them — a shell profile,
+your MCP client's configuration, a secret manager. Zoteus never writes them to
+disk, so nothing in this list reaches them. The only key Zoteus stores is the
+one Zotero grants it for the local API; it lives at
+`<ZOTEUS_DATA_DIR>/local-api-key.json`, and deleting the data directory in step
+3 removes it. Revoke cloud keys yourself if you want them gone.
 
 ## If you installed before v1.10.0
 
@@ -95,7 +97,7 @@ install you pointed at and delete it. A fresh install writes nothing there.
 Nothing should remain:
 
 ```sh
-ls "${ZOTEUS_DATA_DIR:-$HOME/.local/share/zoteus}"    # no such file or directory
+ls "${ZOTEUS_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/zoteus}"    # no such file or directory
 ```
 
 Reinstalling later rebuilds the index from your library. Nothing removed here


### PR DESCRIPTION
Zoteus has no host uninstall lifecycle to hook (it's an external MCP server), so the removal surface has to be documentation. This adds a short `## Uninstall` section to the README (same short-answer-plus-link shape as the existing "Vector ranking is opt-in" callout), pointing at a full `docs/uninstall.md`.

The procedure:
- names `ZOTEUS_DATA_DIR` and the per-OS default paths, with copy-paste removal commands for Linux/macOS/Windows
- covers the pre-v1.10.0 case, where `@huggingface/transformers` cached model weights outside the data directory before the cache-under-data-dir fix — deleting just the data directory used to be an incomplete uninstall
- states explicitly what it does *not* touch: the Zotero library itself, and any API keys

Happy to adjust placement or wording if you'd rather it live somewhere else.