### PR TITLE
Add a durable pause for index work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **A durable pause for index work.** `zotero_index action:"pause"` stops a running job and
+  persists a hold even when the index is idle; `build`, `refresh`, `update`, and the
+  semantic-search automatic build then refuse until `action:"resume"` explicitly clears
+  it. Queries remain available, and resume clears the hold without starting work by itself.
+
 ## [1.14.0] - 2026-09-04
 
 ### Added

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -58,6 +58,12 @@ can never time out the MCP client, even on very large libraries.
   checkpoint, so the next `action:"build"` carries on from it rather than starting over. A
   stopped **update** keeps what it applied but leaves the version stamp where it was, so the
   next update simply repeats the delta.
+- `action: "pause"` sets a durable hold and cooperatively stops any running job. The hold
+  survives a server restart and makes `build`, `refresh`, `update`, and semantic search's
+  automatic first build refuse without creating background work. Existing indexed content
+  remains searchable.
+- `action: "resume"` clears that hold. It deliberately starts no job by itself: follow it
+  with `build` to continue a checkpoint or `update` to request a delta.
 - `limit` — optional max number of items to index. It lowers the configured cap for one
   build and can never raise it: the build stops at the lower of `limit` and
   `ZOTEUS_INDEX_MAX_ITEMS` (default 5000).

--- a/src/features/search/backend.ts
+++ b/src/features/search/backend.ts
@@ -133,6 +133,8 @@ export interface IndexCounts {
 
 export interface SearchIndexStatus {
   documents: number;
+  /** Whether background index work is durably held until action:"resume" clears it. */
+  paused: boolean;
   vectors: number;
   items: number;
   /** Where the index is kept: the legacy JSON file, or SQLite. */
@@ -562,6 +564,8 @@ export interface IndexSnapshot {
   checkpoint?: BuildCheckpoint;
   /** Canonical identity of the library these rows belong to (absent in older files). */
   library?: string;
+  /** Durable hold on all build/update entry points (absent in older files means false). */
+  paused?: boolean;
 }
 
 export interface QueryOptions {
@@ -620,6 +624,10 @@ export interface SearchIndex {
   status(): SearchIndexStatus;
   /** Full live status: index size + build progress. */
   buildStatus(): IndexBuildStatus;
+  /** Whether build/update work is durably held. */
+  readonly isPaused: boolean;
+  /** Persist or clear the hold, including while no job is running. */
+  setPaused(paused: boolean): Promise<void>;
   /** Cooperatively cancel the running build. Returns false if nothing is building. */
   requestStop(): boolean;
   /** Embed arbitrary texts with the configured provider (empty array if none). */

--- a/src/features/search/build.ts
+++ b/src/features/search/build.ts
@@ -279,6 +279,9 @@ export function localApiNotice(s: IndexBuildStatus): string {
 /** Human summary of a build/status snapshot. */
 export function statusSummary(s: IndexBuildStatus): string {
   const job = s.operation === 'update' ? 'update' : 'build';
+  const pause = s.paused
+    ? ' Index work is paused; queries remain available. Call zotero_index action:"resume" before starting more work.'
+    : '';
   const notice =
     embedderNotice(s) +
     staleVectorsNotice(s) +
@@ -300,13 +303,13 @@ export function statusSummary(s: IndexBuildStatus): string {
         s.phase === 'fulltext'
           ? ' Every item\'s metadata is already indexed and searchable — this pass only adds the body text of attachments.'
           : '';
-      return `Index ${job} in progress: ${progressLine(s)}.${searchable} Poll zotero_index action:"status" again shortly.${notice}`;
+      return `Index ${job} in progress: ${progressLine(s)}.${searchable} Poll zotero_index action:"status" again shortly.${pause}${notice}`;
     }
     case 'error': {
       // A failed build keeps what it got; a failed update keeps nothing of its own, because
       // a half-applied delta is a wrong index rather than a partial one.
       const kept = job === 'update' ? 'Index unchanged' : 'Partial data kept';
-      return `Index ${job} failed: ${s.lastError ?? 'unknown error'}. ${kept}: ${progressLine(s)}.${notice}`;
+      return `Index ${job} failed: ${s.lastError ?? 'unknown error'}. ${kept}: ${progressLine(s)}.${pause}${notice}`;
     }
     case 'done': {
       const ft = s.fulltextEnabled
@@ -317,10 +320,10 @@ export function statusSummary(s: IndexBuildStatus): string {
       const own = s.ownWordsItems
         ? `, and the notes and annotations of ${s.ownWordsItems} of them (${s.ownWordsPassages} passages)`
         : '';
-      return `Index ready — ${s.documents} passages over ${s.items} items${ft}${own} (embedder=${s.embedder}). Run zotero_semantic_search to search by meaning.${notice}`;
+      return `Index ready — ${s.documents} passages over ${s.items} items${ft}${own} (embedder=${s.embedder}). Run zotero_semantic_search to search by meaning.${pause}${notice}`;
     }
     default:
-      return `Index: ${s.documents} passages over ${s.items} items; embedder=${s.embedder}.${notice}`;
+      return `Index: ${s.documents} passages over ${s.items} items; embedder=${s.embedder}.${pause}${notice}`;
   }
 }
 
@@ -387,6 +390,9 @@ export function startIndexBuild(
   maxItems?: number,
   opts: BuildFulltextOptions = {},
 ): IndexBuildStatus {
+  if (ctx.search.isPaused) {
+    throw new Error('Index work is paused. Call zotero_index action:"resume" before build, refresh, or update.');
+  }
   // Synchronously, before the fire-and-forget job below: a refusal thrown inside the job
   // would only reach the logger, and the tool caller would see a build that "started".
   const library = canonicalLibraryToken(lib);
@@ -463,6 +469,9 @@ export function startIndexUpdate(
   maxItems?: number,
   opts: BuildFulltextOptions = {},
 ): IndexBuildStatus {
+  if (ctx.search.isPaused) {
+    throw new Error('Index work is paused. Call zotero_index action:"resume" before build, refresh, or update.');
+  }
   const backend: VersionBackend = ctx.router.servesLocally(lib) ? 'local' : 'cloud';
   // Same synchronous guard as startIndexBuild, and for the same reason: the version stamp
   // this update would diff against belongs to the library the index holds, not to `lib`.

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -2385,9 +2385,9 @@ export class MemorySearchIndex extends SearchIndexBase {
   }
 
   /** Atomically rewrite the JSON artifact. A no-op when this index has no file. */
-  protected async writeSnapshot(): Promise<void> {
+  protected async writeSnapshot(snapshot: IndexSnapshot): Promise<void> {
     if (!this.path) return;
-    await saveIndex(this, this.path);
+    await saveIndex({ toJSON: () => snapshot, loadFromJSON() {} }, this.path);
   }
 
   async save(): Promise<void> {
@@ -2398,7 +2398,11 @@ export class MemorySearchIndex extends SearchIndexBase {
     // reporting on. Faulted means: touch the artifact only to replace it deliberately.
     this.refuseIfFaulted();
     if (!this.path) return;
-    const write = this.saveTail.then(() => this.writeSnapshot());
+    // Capture now, not when the queued write gets its turn. A later setter may roll its
+    // in-memory value back after a failed write; no earlier save may publish that transient
+    // value merely because it observed mutable `this` late.
+    const snapshot = this.toJSON();
+    const write = this.saveTail.then(() => this.writeSnapshot(snapshot));
     // A failed write rejects its own caller but must not poison every later save.
     this.saveTail = write.catch(() => {});
     await write;

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -2441,8 +2441,12 @@ export class MemorySearchIndex extends SearchIndexBase {
     await this.enqueueSnapshot(snapshot);
   }
 
-  /** Nothing to release: the store is this object. */
-  async close(): Promise<void> {}
+  /** No handle to release, but do not report closed while a durable write is outstanding. */
+  async close(): Promise<void> {
+    const pauseTransition = this.pauseTransition;
+    if (pauseTransition) await pauseTransition.catch(() => {});
+    await this.saveTail.catch(() => {});
+  }
 
   toJSON(): IndexSnapshot {
     const snapshot: IndexSnapshot = {

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -268,6 +268,8 @@ export abstract class SearchIndexBase implements SearchIndex {
    * resume redoes to a single persistence interval (#24).
    */
   protected checkpoint: BuildCheckpoint | undefined = undefined;
+  /** Durable operator hold. Unlike requestStop(), this survives restarts and idle periods. */
+  protected paused = false;
   /**
    * Canonical identity of the library whose rows this store holds (canonicalLibraryToken;
    * undefined until a stamped build writes rows, or for indexes persisted before the
@@ -696,6 +698,32 @@ export abstract class SearchIndexBase implements SearchIndex {
     return this.buildState === 'building';
   }
 
+  get isPaused(): boolean {
+    return this.paused;
+  }
+
+  /**
+   * Change the durable hold independently of the running-job cancellation token. Setting
+   * it while idle is the important case: requestStop() deliberately has nothing to save
+   * then, whereas a user must still be able to prevent the next explicit build.
+   */
+  async setPaused(paused: boolean): Promise<void> {
+    this.refuseIfFaulted();
+    const previous = this.paused;
+    this.paused = paused;
+    try {
+      await this.save();
+    } catch (e) {
+      this.paused = previous;
+      throw e;
+    }
+  }
+
+  private refuseIfPaused(): void {
+    if (!this.paused) return;
+    throw new Error('Index work is paused. Call zotero_index action:"resume" before build, refresh, or update.');
+  }
+
   /** Full live status: index size + build progress. Backward compatible with status(). */
   buildStatus(): IndexBuildStatus {
     const base = this.status();
@@ -759,6 +787,7 @@ export abstract class SearchIndexBase implements SearchIndex {
     const c = this.counts();
     const s: SearchIndexStatus = {
       documents: c.documents,
+      paused: this.paused,
       vectors: c.vectors,
       items: c.items,
       storage: this.storage,
@@ -817,6 +846,7 @@ export abstract class SearchIndexBase implements SearchIndex {
 
   async build(libraryItems: any[], opts: BuildOptions = {}): Promise<SearchIndexStatus> {
     this.refuseIfFaulted();
+    this.refuseIfPaused();
     this.reset();
     // A rebuild is the retry: clear a previous runtime failure so a provider that has since
     // been fixed (model downloaded, package installed) reports healthy again.
@@ -916,6 +946,7 @@ export abstract class SearchIndexBase implements SearchIndex {
    */
   async buildIncremental(fetchPage: PageFetcher, opts: IncrementalBuildOptions = {}): Promise<IndexBuildStatus> {
     this.refuseIfFaulted();
+    this.refuseIfPaused();
     // Before anything is cleared: a build for a different library than the rows held must
     // refuse here rather than reach reset() below (startIndexBuild also asserts this
     // synchronously, so tool callers see the refusal rather than a logged rejection).
@@ -1449,6 +1480,7 @@ export abstract class SearchIndexBase implements SearchIndex {
    */
   async updateIncremental(opts: IncrementalUpdateOptions): Promise<IndexBuildStatus> {
     this.refuseIfFaulted();
+    this.refuseIfPaused();
     // Same guard as the full build: a delta for a different library would splice its
     // changes into — and delete "missing" items from — rows that were never its own.
     if (opts.library) this.assertLibrary(opts.library);
@@ -2379,6 +2411,7 @@ export class MemorySearchIndex extends SearchIndexBase {
       // The other sequence's cursor: what an update hands to `/fulltext?since=` to find
       // the text Zotero extracted after this index was built (#26).
       fulltextVersion: this.fulltextVersion,
+      paused: this.paused,
     };
     if (this.libraryBackend) snapshot.libraryBackend = this.libraryBackend;
     // Present only while a build is unfinished, which is exactly when the next one has
@@ -2417,6 +2450,7 @@ export class MemorySearchIndex extends SearchIndexBase {
     // Absent in files written before resume existed, and in any file a finished build
     // wrote: both mean there is nothing to resume, which is what undefined says (#24).
     this.checkpoint = data.checkpoint;
+    this.paused = data.paused ?? false;
     // Absent in files written before the library stamp existed: an unstamped index
     // refuses nothing (assertLibrary), which is the only workable answer for it.
     this.library = data.library;

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -2210,6 +2210,12 @@ export class MemorySearchIndex extends SearchIndexBase {
   private ownWordsItems = new Set<string>();
   private ownWordsPassages = 0;
   private readonly path: string | undefined;
+  /**
+   * JSON writes are atomic individually, but two overlapping writes can still rename out
+   * of order. Keep their invocation order so an older snapshot can never overwrite a
+   * newer durable state (notably a pause asserted while a build save is in flight).
+   */
+  private saveTail: Promise<void> = Promise.resolve();
 
   constructor(opts: MemorySearchIndexOptions) {
     super(opts);
@@ -2379,6 +2385,11 @@ export class MemorySearchIndex extends SearchIndexBase {
   }
 
   /** Atomically rewrite the JSON artifact. A no-op when this index has no file. */
+  protected async writeSnapshot(): Promise<void> {
+    if (!this.path) return;
+    await saveIndex(this, this.path);
+  }
+
   async save(): Promise<void> {
     // Refusing here is not tidiness, it is the difference between a bad read and lost
     // data. `loadFromJSON` resets before it parses, so an artifact that failed to load
@@ -2387,7 +2398,10 @@ export class MemorySearchIndex extends SearchIndexBase {
     // reporting on. Faulted means: touch the artifact only to replace it deliberately.
     this.refuseIfFaulted();
     if (!this.path) return;
-    await saveIndex(this, this.path);
+    const write = this.saveTail.then(() => this.writeSnapshot());
+    // A failed write rejects its own caller but must not poison every later save.
+    this.saveTail = write.catch(() => {});
+    await write;
   }
 
   /** Nothing to release: the store is this object. */

--- a/src/features/search/index-manager.ts
+++ b/src/features/search/index-manager.ts
@@ -270,6 +270,7 @@ export abstract class SearchIndexBase implements SearchIndex {
   protected checkpoint: BuildCheckpoint | undefined = undefined;
   /** Durable operator hold. Unlike requestStop(), this survives restarts and idle periods. */
   protected paused = false;
+  protected pauseTransition: Promise<void> | undefined;
   /**
    * Canonical identity of the library whose rows this store holds (canonicalLibraryToken;
    * undefined until a stamped build writes rows, or for indexes persisted before the
@@ -709,14 +710,33 @@ export abstract class SearchIndexBase implements SearchIndex {
    */
   async setPaused(paused: boolean): Promise<void> {
     this.refuseIfFaulted();
+    if (this.pauseTransition) throw new Error('An index pause/resume transition is already in progress.');
+    if (this.paused === paused) return;
     const previous = this.paused;
-    this.paused = paused;
+    // A hold takes effect before its write so no work can enter during persistence. A
+    // resume does the inverse: keep the live hold until the clear is safely on disk.
+    if (paused) this.paused = true;
+    const transition = (async () => {
+      try {
+        await this.persistPaused(paused);
+        this.paused = paused;
+      } catch (e) {
+        this.paused = previous;
+        throw e;
+      }
+    })();
+    this.pauseTransition = transition;
     try {
-      await this.save();
-    } catch (e) {
-      this.paused = previous;
-      throw e;
+      await transition;
+    } finally {
+      if (this.pauseTransition === transition) this.pauseTransition = undefined;
     }
+  }
+
+  /** Persist a requested pause value without requiring it to be live first. */
+  protected async persistPaused(paused: boolean): Promise<void> {
+    if (paused !== this.paused) throw new Error('This index backend cannot persist a pending resume.');
+    await this.save();
   }
 
   private refuseIfPaused(): void {
@@ -2390,6 +2410,17 @@ export class MemorySearchIndex extends SearchIndexBase {
     await saveIndex({ toJSON: () => snapshot, loadFromJSON() {} }, this.path);
   }
 
+  private async enqueueSnapshot(snapshot: IndexSnapshot): Promise<void> {
+    const write = this.saveTail.then(() => this.writeSnapshot(snapshot));
+    // A failed write rejects its own caller but must not poison every later save.
+    this.saveTail = write.catch(() => {});
+    await write;
+  }
+
+  protected override async persistPaused(paused: boolean): Promise<void> {
+    await this.enqueueSnapshot({ ...this.toJSON(), paused });
+  }
+
   async save(): Promise<void> {
     // Refusing here is not tidiness, it is the difference between a bad read and lost
     // data. `loadFromJSON` resets before it parses, so an artifact that failed to load
@@ -2398,14 +2429,16 @@ export class MemorySearchIndex extends SearchIndexBase {
     // reporting on. Faulted means: touch the artifact only to replace it deliberately.
     this.refuseIfFaulted();
     if (!this.path) return;
+    // A build already winding down may save while resume is being persisted. Let that
+    // transition settle before capturing its snapshot, or it could queue the old held
+    // value after a successful clear (or the transient clear after a failed one).
+    const pauseTransition = this.pauseTransition;
+    if (pauseTransition) await pauseTransition.catch(() => {});
     // Capture now, not when the queued write gets its turn. A later setter may roll its
     // in-memory value back after a failed write; no earlier save may publish that transient
     // value merely because it observed mutable `this` late.
     const snapshot = this.toJSON();
-    const write = this.saveTail.then(() => this.writeSnapshot(snapshot));
-    // A failed write rejects its own caller but must not poison every later save.
-    this.saveTail = write.catch(() => {});
-    await write;
+    await this.enqueueSnapshot(snapshot);
   }
 
   /** Nothing to release: the store is this object. */

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -2031,10 +2031,14 @@ export class SqliteSearchIndex extends SearchIndexBase {
   /** Commit the build's open transaction: this is what makes the last passages durable. */
   async save(): Promise<void> {
     this.refuseIfFaulted();
+    const pauseTransition = this.pauseTransition;
+    if (pauseTransition) await pauseTransition.catch(() => {});
     this.flush();
   }
 
   async close(): Promise<void> {
+    const pauseTransition = this.pauseTransition;
+    if (pauseTransition) await pauseTransition.catch(() => {});
     // Released whether or not this object ever opened a database of its own: the salvage
     // is a second handle on a second file, and a server that keeps it would keep a lock
     // on the very file it told the user they may delete.

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -1107,7 +1107,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     this.reconcileVectorProvenance();
   }
 
-  private writeMeta(): void {
+  private writeMeta(paused = this.paused): void {
     const set = this.stmts.setMeta;
     set.run('builtFromVersion', String(this.builtFromVersion));
     set.run('itemsTotal', String(this.itemsTotal));
@@ -1121,7 +1121,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // place a value can be added without a schema version bump: an older build ignores a
     // key it does not know, so a database written here still opens there.
     set.run('checkpoint', this.checkpoint ? JSON.stringify(this.checkpoint) : '');
-    set.run('paused', String(this.paused));
+    set.run('paused', String(paused));
     set.run('library', this.library ?? '');
   }
 
@@ -2018,6 +2018,13 @@ export class SqliteSearchIndex extends SearchIndexBase {
     if (!this.db) return;
     this.begin();
     this.writeMeta();
+    this.commit();
+  }
+
+  protected override async persistPaused(paused: boolean): Promise<void> {
+    this.refuseIfFaulted();
+    this.begin();
+    this.writeMeta(paused);
     this.commit();
   }
 

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -1090,6 +1090,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // coverage gap is unknown, which the first update closes once (#26).
     this.fulltextVersion = Number(this.meta('fulltextVersion') ?? 0) || 0;
     this.checkpoint = parseCheckpoint(this.meta('checkpoint'));
+    this.paused = this.meta('paused') === 'true';
     // Absent in databases written before the library stamp: an unstamped index refuses
     // nothing (assertLibrary), so old files keep building rather than stranding.
     this.library = this.meta('library') || undefined;
@@ -1120,6 +1121,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // place a value can be added without a schema version bump: an older build ignores a
     // key it does not know, so a database written here still opens there.
     set.run('checkpoint', this.checkpoint ? JSON.stringify(this.checkpoint) : '');
+    set.run('paused', String(this.paused));
     set.run('library', this.library ?? '');
   }
 
@@ -1199,6 +1201,7 @@ export class SqliteSearchIndex extends SearchIndexBase {
     // keeps knowing how far into Zotero's full-text sequence it read.
     this.fulltextVersion = snapshot.fulltextVersion ?? 0;
     this.checkpoint = snapshot.checkpoint;
+    this.paused = snapshot.paused ?? false;
     this.writeMeta();
     this.commit();
     this.storeNotice =

--- a/src/tools/index-tool.ts
+++ b/src/tools/index-tool.ts
@@ -17,9 +17,11 @@ const indexTool: ToolDefinition = {
   name: 'zotero_index',
   title: 'Build the semantic search index',
   description:
+    `\`action:"pause"\` durably holds all index work (and stops a running job); the hold survives restarts. ` +
+    `\`action:"resume"\` clears the hold but starts no work by itself. ` +
     `Manage the local hybrid-search index used by zotero_semantic_search. Every job runs in the background on the server, so this tool returns immediately and never blocks on large libraries. THREE write actions, and picking the right one matters: \`action: "update"\` is the cheap one and should be the default for a library that is already indexed; \`action: "build"\` and \`action: "refresh"\` both rebuild the WHOLE index, which on a large library means many minutes and, with an API embedding provider, real spend (they differ in one thing: build resumes an interrupted build, refresh always starts over). \`action: "build"\`/"refresh" pages the library's top-level items (100-at-a-time, stopping at the server's item cap, ZOTEUS_INDEX_MAX_ITEMS, default ${DEFAULT_INDEX_MAX_ITEMS}, or at a smaller \`limit\` if one is given), indexes their text (title, abstract, creators, tags) for BM25 keyword search and, if an embedding provider is configured, for vector search, persisting partial progress atomically as it goes; use it for the first build, after changing the embedding model, or to widen a previously capped build. It is ALSO the repair: if the index cannot be read at all, only \`action:"build"\` clears it, by deleting the unreadable file and opening a fresh one before rebuilding (nothing repairs it at startup or inside a query). \`action: "update"\` instead fetches only the items changed since the version the index recorded (Zotero's \`?since=\`), re-chunks and re-embeds just those, and removes items the library no longer holds (diffed from a cheap keys-only \`?format=versions\` census, since the deletion log is cloud-only); untouched items are never re-embedded, so adding a handful of items costs seconds instead of a full rebuild. Update falls back to a full rebuild by itself, and says so in \`updateNotice\`, when a delta would be wrong: no version stamp recorded yet, the library is now served by a different Zotero API (the desktop app and the cloud number their versions independently), or the embedding model changed. An update ALSO asks Zotero's full-text index what it has extracted since the build (that is a separate version sequence from item versions, so a PDF Zotero extracted when it was first opened changes no item version and appears in no delta) and indexes the new body text for items nothing else touched; on a library where nothing was extracted, that costs one request. A build or update interrupted by \`action:"stop"\`, a crash or a restart leaves a checkpoint, and \`action: "build"\` RESUMES from it: the items already committed stay searchable and are never re-fetched or re-embedded, and only work since the last save is redone (\`resumedFrom\` on the status reports how many were inherited). \`action: "refresh"\` is the one that always starts over. A build also indexes the reader's OWN words by default: every child note, and every PDF annotation (its highlighted passage and its comment), as extra passages carrying the parent item's key — so \`zotero_annotate\` writes text that search can then find, an item with forty annotations still takes one result slot, and a hit whose snippet came from one is marked source:"note" or source:"annotation". That corpus is one paged crawl of hand-written text, orders of magnitude smaller than attachment bodies; turn it off with \`own_words:false\` or ZOTEUS_INDEX_OWN_WORDS=false. An \`action:"update"\` keeps it current for the cost of one request when nothing was written: notes and annotations are ordinary items carrying ordinary versions, so an edit, an addition and a deletion are all found by comparing the library's note/annotation keys against the ones the index holds — which is also how an index built before this existed fills its gap, once, on its first update. Set \`fulltext:true\` to ALSO index the body text Zotero extracted from each item's attachments, which is what makes semantic search match a claim buried in a PDF rather than only its title and abstract; it is off by default because it multiplies build time and index size (default cap: ${DEFAULT_FULLTEXT_MAX_CHARS} characters per item, tunable with \`fulltext_max_chars\`), and only attachments Zotero has already extracted are available. That pass used to be refused inside Claude Desktop, where a build that reached it killed the server process partway through with no error at all (#37); the cause was the on-device embedding model asking Electron's allocator for a block it will not serve, so the server now embeds fewer passages per call there and the build runs to completion. It is somewhat slower inside the app than in a terminal and produces exactly the same index, so a user who wants the fastest possible first build can still run one headlessly against the same ZOTEUS_DATA_DIR and let Desktop read the result. A build runs in TWO passes and reports which one it is on as \`phase\`: every item's metadata is indexed first, across the whole library, and only then are attachment bodies crawled (\`fulltextItemsScanned\` of \`fulltextItemsTotal\`). So the library is fully searchable on titles, abstracts, creators and tags long before a full-text crawl that can run for hours finishes — tell the user they can search already rather than asking them to wait for state:"done". Start a job, then POLL \`action: "status"\` every few seconds until \`state\` is "done" (or "error"); calling build or update again while one is running just returns current progress. \`action: "status"\` reports \`state\` (idle|building|done|error), \`operation\` (build|update), \`phase\` (metadata|fulltext), fetch/embed progress, \`itemsRemoved\`, index size, the active embedder, \`libraryVersion\`/\`libraryBackend\` (the version stamp an update diffs from), \`fulltextVersion\` (how far into Zotero's separate full-text sequence the index has read), \`resumedFrom\` (items inherited when a build resumed an interrupted one), \`itemsTotal\`/\`itemsAvailable\` (which differ, with a warning, when the cap stopped the crawl short of the library), \`ownWordsItems\`/\`ownWordsPassages\` (the notes and annotations indexed, with \`ownWordsReason\` if they could not be read), and (when full text was requested) \`fulltextItems\`/\`fulltextPassages\` plus \`fulltextReason\` if it produced nothing. It also reports \`localApiDegradedAt\` when the job saturated Zotero's local API and the whole session fell back to the Zotero Web API: that fallback works, so nothing errors, but the Web API is slower and rate-limited and the rest of the build takes far longer than its start suggested, so tell the user rather than letting them watch an unexplained slowdown (the crawl also backs off to one attachment at a time by itself, to let the app recover). It reports where the index is stored (\`storage\`: sqlite or memory, set by ZOTEUS_INDEX_BACKEND), \`storageNotice\` when opening that store imported or refused an older JSON index, \`persistError\` when the index could not be written to disk at all, and how the last semantic query ranked vectors (\`vectorScan\`: "codes" for the two-stage path, "exact" for a full scan of every vector, with \`vectorScanNotice\` when that needs explaining). When the embedding provider is an API (ZOTEUS_EMBEDDINGS=openai or gemini), status also reports \`embedRate\`: the batch size, the pause between requests, the estimated tokens per request and the tokens per minute the build is actually sustaining, plus \`passagesWithoutVectors\` when the index holds passages nothing has embedded yet. A build whose embedder was rate-limited to a standstill keeps every passage it indexed and stays RESUMABLE: tell the user to run \`action:"build"\` again, which embeds only the passages that have no vector and re-fetches nothing, and NOT \`action:"refresh"\`, which starts the whole crawl over and pays for every vector a second time. A rate-limited request already backs off and retries by itself; if a build reports it is riding the provider's tokens-per-minute limit, the fix is ZOTEUS_EMBED_BATCH_DELAY_MS (with ZOTEUS_EMBED_BATCH_SIZE), not a smaller library. \`action: "stop"\` cancels a running job (partial data is kept and stays searchable; a stopped update leaves the version stamp untouched so the next one repeats the delta, and a stopped build leaves a checkpoint the next \`action:"build"\` resumes from). A partially built index is always usable for keyword search. Local embeddings are CPU-bound (see ZOTEUS_EMBEDDINGS), so large builds take a while: poll status rather than retrying build.`,
   inputSchema: {
-    action: z.enum(['build', 'refresh', 'update', 'status', 'stop']),
+    action: z.enum(['build', 'refresh', 'update', 'status', 'stop', 'pause', 'resume']),
     library_type: z.enum(['user', 'group']).optional(),
     library_id: z.number().int().optional(),
     limit: z
@@ -71,6 +73,40 @@ const indexTool: ToolDefinition = {
         );
       }
       return ok({ ...ctx.search.buildStatus() }, 'No build is currently running.');
+    }
+    if (args.action === 'pause') {
+      // Set the in-memory hold before asking the running loop to stop, then persist it.
+      // This also works while idle, which requestStop() alone deliberately cannot do.
+      const persistence = ctx.search.setPaused(true);
+      const stopped = ctx.search.requestStop();
+      await persistence;
+      return ok(
+        { ...ctx.search.buildStatus() },
+        stopped
+          ? 'Index work is paused. The running job will stop after its current page or batch; the hold survives restarts.'
+          : 'Index work is paused. The hold survives restarts; build, refresh, and update will refuse until resumed.',
+      );
+    }
+    if (args.action === 'resume') {
+      await ctx.search.setPaused(false);
+      return ok(
+        { ...ctx.search.buildStatus() },
+        'Index work is no longer paused. No job was started; call action:"build" or action:"update" explicitly.',
+      );
+    }
+
+    if (ctx.search.isPaused) {
+      const s = ctx.search.buildStatus();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Index work is paused. Call zotero_index action:"resume" before build, refresh, or update.',
+          },
+        ],
+        structuredContent: { ...s },
+        isError: true,
+      };
     }
 
     // build / refresh / update: kick off a background job and return immediately.

--- a/src/tools/semantic-search.ts
+++ b/src/tools/semantic-search.ts
@@ -47,6 +47,21 @@ const semanticSearch: ToolDefinition = {
           isError: true,
         };
       }
+      if (ctx.search.isPaused) {
+        const s = ctx.search.buildStatus();
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                'The semantic-search index is empty and index work is paused. Call zotero_index with ' +
+                'action:"resume", then explicitly start a build; this search will not resume it automatically.',
+            },
+          ],
+          structuredContent: { ...s, autoBuild: false },
+          isError: true,
+        };
+      }
       if (args.auto_build !== false) {
         // First use: populate the index on the fly instead of leaving the user stranded.
         const s = startIndexBuild(ctx);

--- a/tests/features/search-pause.test.ts
+++ b/tests/features/search-pause.test.ts
@@ -5,9 +5,42 @@ import { join } from 'node:path';
 import { MemorySearchIndex } from '../../src/features/search/index-manager.js';
 import { createSearchIndex, nodeSqliteAvailable } from '../../src/features/search/factory.js';
 import { loadIndex } from '../../src/features/search/persistence.js';
+import { saveIndex } from '../../src/features/search/persistence.js';
+import type { IndexSnapshot } from '../../src/features/search/backend.js';
 
 const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
 const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+
+class GatedMemorySearchIndex extends MemorySearchIndex {
+  private writes = 0;
+  private releaseFirst!: () => void;
+  readonly firstWriteStarted = new Promise<void>((resolve) => {
+    this.releaseFirst = resolve;
+  });
+  private unblockFirst!: () => void;
+  private readonly firstWriteGate = new Promise<void>((resolve) => {
+    this.unblockFirst = resolve;
+  });
+
+  constructor(private readonly testPath: string) {
+    super({ embedder: null, logger: silentLogger, path: testPath });
+  }
+
+  release(): void {
+    this.unblockFirst();
+  }
+
+  protected override async writeSnapshot(): Promise<void> {
+    // Capture before waiting: without the production save queue this stale false snapshot
+    // would rename after setPaused(true)'s newer write and erase the durable hold.
+    const snapshot: IndexSnapshot = this.toJSON();
+    if (++this.writes === 1) {
+      this.releaseFirst();
+      await this.firstWriteGate;
+    }
+    await saveIndex({ toJSON: () => snapshot, loadFromJSON() {} }, this.testPath);
+  }
+}
 
 describe('durable index pause', () => {
   it('holds background work without disabling queries', async () => {
@@ -31,11 +64,28 @@ describe('durable index pause', () => {
     const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
     expect(await loadIndex(reopened, path)).toBe(true);
     expect(reopened.isPaused).toBe(true);
-    await expect(reopened.buildIncremental(async () => ({ items: [] }))).rejects.toThrow(/paused.*resume/i);
+    await expect(reopened.buildIncremental(async () => ({ items: [], totalResults: 0 }))).rejects.toThrow(
+      /paused.*resume/i,
+    );
 
     const old = new MemorySearchIndex({ embedder: null, logger: silentLogger });
     old.loadFromJSON({ chunks: [], vectors: [], builtFromVersion: 0 });
     expect(old.isPaused).toBe(false);
+  });
+
+  it('orders an in-flight JSON save before a newer durable pause', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-overlap-'));
+    const path = join(dir, 'search-index.json');
+    const index = new GatedMemorySearchIndex(path);
+    const older = index.save();
+    await index.firstWriteStarted;
+    const pause = index.setPaused(true);
+    index.release();
+    await Promise.all([older, pause]);
+
+    const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    expect(await loadIndex(reopened, path)).toBe(true);
+    expect(reopened.isPaused).toBe(true);
   });
 
   sqliteIt('persists the hold in SQLite while idle and clears it without a schema bump', async () => {

--- a/tests/features/search-pause.test.ts
+++ b/tests/features/search-pause.test.ts
@@ -24,7 +24,7 @@ class GatedMemorySearchIndex extends MemorySearchIndex {
 
   constructor(
     private readonly testPath: string,
-    private readonly failSecond = false,
+    private readonly failWrite = 0,
   ) {
     super({ embedder: null, logger: silentLogger, path: testPath });
   }
@@ -39,7 +39,7 @@ class GatedMemorySearchIndex extends MemorySearchIndex {
       this.releaseFirst();
       await this.firstWriteGate;
     }
-    if (write === 2 && this.failSecond) throw new Error('second write failed');
+    if (write === this.failWrite) throw new Error(`write ${write} failed`);
     await saveIndex({ toJSON: () => snapshot, loadFromJSON() {} }, this.testPath);
   }
 }
@@ -96,19 +96,62 @@ describe('durable index pause', () => {
     const seed = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
     await seed.setPaused(true);
 
-    const index = new GatedMemorySearchIndex(path, true);
+    const index = new GatedMemorySearchIndex(path, 2);
     expect(await loadIndex(index, path)).toBe(true);
     const older = index.save(); // captures paused:true, then waits before publishing it
     await index.firstWriteStarted;
     const failedResume = index.setPaused(false); // captures false, queues second, then fails
     index.release();
     await older;
-    await expect(failedResume).rejects.toThrow(/second write failed/);
+    await expect(failedResume).rejects.toThrow(/write 2 failed/);
     expect(index.isPaused).toBe(true); // setter rolled memory back
 
     const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
     expect(await loadIndex(reopened, path)).toBe(true);
     expect(reopened.isPaused).toBe(true); // disk agrees; the transient false never published
+  });
+
+  it('keeps the live hold while a failing resume is being persisted', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-resume-race-'));
+    const path = join(dir, 'search-index.json');
+    const seed = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    await seed.setPaused(true);
+
+    const index = new GatedMemorySearchIndex(path, 1);
+    expect(await loadIndex(index, path)).toBe(true);
+    const failedResume = index.setPaused(false);
+    await index.firstWriteStarted;
+    expect(index.isPaused).toBe(true);
+    await expect(index.buildIncremental(async () => ({ items: [], totalResults: 0 }))).rejects.toThrow(
+      /paused.*resume/i,
+    );
+    index.release();
+    await expect(failedResume).rejects.toThrow(/write 1 failed/);
+    expect(index.isPaused).toBe(true);
+
+    const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    expect(await loadIndex(reopened, path)).toBe(true);
+    expect(reopened.isPaused).toBe(true);
+  });
+
+  it('makes a concurrent ordinary save observe a completed resume', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-resume-save-'));
+    const path = join(dir, 'search-index.json');
+    const seed = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    await seed.setPaused(true);
+
+    const index = new GatedMemorySearchIndex(path);
+    expect(await loadIndex(index, path)).toBe(true);
+    const resume = index.setPaused(false);
+    await index.firstWriteStarted;
+    const concurrentSave = index.save();
+    index.release();
+    await Promise.all([resume, concurrentSave]);
+    expect(index.isPaused).toBe(false);
+
+    const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    expect(await loadIndex(reopened, path)).toBe(true);
+    expect(reopened.isPaused).toBe(false);
   });
 
   sqliteIt('persists the hold in SQLite while idle and clears it without a schema bump', async () => {

--- a/tests/features/search-pause.test.ts
+++ b/tests/features/search-pause.test.ts
@@ -154,6 +154,30 @@ describe('durable index pause', () => {
     expect(reopened.isPaused).toBe(false);
   });
 
+  it('does not report the JSON backend closed before a pending resume is durable', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-resume-close-'));
+    const path = join(dir, 'search-index.json');
+    const seed = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    await seed.setPaused(true);
+
+    const index = new GatedMemorySearchIndex(path);
+    expect(await loadIndex(index, path)).toBe(true);
+    const resume = index.setPaused(false);
+    await index.firstWriteStarted;
+    let closed = false;
+    const closing = index.close().then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+    expect(closed).toBe(false);
+    index.release();
+    await Promise.all([resume, closing]);
+
+    const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    expect(await loadIndex(reopened, path)).toBe(true);
+    expect(reopened.isPaused).toBe(false);
+  });
+
   sqliteIt('persists the hold in SQLite while idle and clears it without a schema bump', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-sqlite-'));
     const jsonPath = join(dir, 'search-index.json');

--- a/tests/features/search-pause.test.ts
+++ b/tests/features/search-pause.test.ts
@@ -22,7 +22,10 @@ class GatedMemorySearchIndex extends MemorySearchIndex {
     this.unblockFirst = resolve;
   });
 
-  constructor(private readonly testPath: string) {
+  constructor(
+    private readonly testPath: string,
+    private readonly failSecond = false,
+  ) {
     super({ embedder: null, logger: silentLogger, path: testPath });
   }
 
@@ -30,14 +33,13 @@ class GatedMemorySearchIndex extends MemorySearchIndex {
     this.unblockFirst();
   }
 
-  protected override async writeSnapshot(): Promise<void> {
-    // Capture before waiting: without the production save queue this stale false snapshot
-    // would rename after setPaused(true)'s newer write and erase the durable hold.
-    const snapshot: IndexSnapshot = this.toJSON();
-    if (++this.writes === 1) {
+  protected override async writeSnapshot(snapshot: IndexSnapshot): Promise<void> {
+    const write = ++this.writes;
+    if (write === 1) {
       this.releaseFirst();
       await this.firstWriteGate;
     }
+    if (write === 2 && this.failSecond) throw new Error('second write failed');
     await saveIndex({ toJSON: () => snapshot, loadFromJSON() {} }, this.testPath);
   }
 }
@@ -86,6 +88,27 @@ describe('durable index pause', () => {
     const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
     expect(await loadIndex(reopened, path)).toBe(true);
     expect(reopened.isPaused).toBe(true);
+  });
+
+  it('does not publish a transient resume when its queued write fails', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-rollback-'));
+    const path = join(dir, 'search-index.json');
+    const seed = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    await seed.setPaused(true);
+
+    const index = new GatedMemorySearchIndex(path, true);
+    expect(await loadIndex(index, path)).toBe(true);
+    const older = index.save(); // captures paused:true, then waits before publishing it
+    await index.firstWriteStarted;
+    const failedResume = index.setPaused(false); // captures false, queues second, then fails
+    index.release();
+    await older;
+    await expect(failedResume).rejects.toThrow(/second write failed/);
+    expect(index.isPaused).toBe(true); // setter rolled memory back
+
+    const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    expect(await loadIndex(reopened, path)).toBe(true);
+    expect(reopened.isPaused).toBe(true); // disk agrees; the transient false never published
   });
 
   sqliteIt('persists the hold in SQLite while idle and clears it without a schema bump', async () => {

--- a/tests/features/search-pause.test.ts
+++ b/tests/features/search-pause.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MemorySearchIndex } from '../../src/features/search/index-manager.js';
+import { createSearchIndex, nodeSqliteAvailable } from '../../src/features/search/factory.js';
+import { loadIndex } from '../../src/features/search/persistence.js';
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+const sqliteIt = nodeSqliteAvailable() ? it : it.skip;
+
+describe('durable index pause', () => {
+  it('holds background work without disabling queries', async () => {
+    const index = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    await index.build([
+      { key: 'A', data: { itemType: 'journalArticle', title: 'Held index', abstractNote: 'still searchable' } },
+    ]);
+    await index.setPaused(true);
+
+    expect((await index.query('searchable', { limit: 1 }))[0]?.itemKey).toBe('A');
+    await expect(index.build([])).rejects.toThrow(/paused.*resume/i);
+  });
+
+  it('round-trips through the legacy JSON snapshot and defaults old snapshots to running', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-json-'));
+    const path = join(dir, 'search-index.json');
+    const first = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    await first.setPaused(true);
+    expect(JSON.parse(await readFile(path, 'utf8')).paused).toBe(true);
+
+    const reopened = new MemorySearchIndex({ embedder: null, logger: silentLogger, path });
+    expect(await loadIndex(reopened, path)).toBe(true);
+    expect(reopened.isPaused).toBe(true);
+    await expect(reopened.buildIncremental(async () => ({ items: [] }))).rejects.toThrow(/paused.*resume/i);
+
+    const old = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    old.loadFromJSON({ chunks: [], vectors: [], builtFromVersion: 0 });
+    expect(old.isPaused).toBe(false);
+  });
+
+  sqliteIt('persists the hold in SQLite while idle and clears it without a schema bump', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-sqlite-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const first = await createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+    await first.setPaused(true);
+    await first.close();
+
+    const held = await createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+    expect(held.isPaused).toBe(true);
+    expect(held.buildStatus().paused).toBe(true);
+    await held.setPaused(false);
+    await held.close();
+
+    const cleared = await createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+    expect(cleared.isPaused).toBe(false);
+    await cleared.close();
+  });
+});

--- a/tests/features/search-pause.test.ts
+++ b/tests/features/search-pause.test.ts
@@ -171,4 +171,32 @@ describe('durable index pause', () => {
     expect(cleared.isPaused).toBe(false);
     await cleared.close();
   });
+
+  sqliteIt('does not let a concurrent SQLite save restore the hold after resume', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-sqlite-save-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const index = await createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+    await index.setPaused(true);
+    const resume = index.setPaused(false);
+    const concurrentSave = index.save();
+    await Promise.all([resume, concurrentSave]);
+    await index.close();
+
+    const reopened = await createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+    expect(reopened.isPaused).toBe(false);
+    await reopened.close();
+  });
+
+  sqliteIt('does not let a concurrent SQLite close restore the hold after resume', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zoteus-pause-sqlite-close-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const index = await createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+    await index.setPaused(true);
+    const resume = index.setPaused(false);
+    await Promise.all([resume, index.close()]);
+
+    const reopened = await createSearchIndex({ backend: 'sqlite', jsonPath, embedder: null, logger: silentLogger });
+    expect(reopened.isPaused).toBe(false);
+    await reopened.close();
+  });
 });

--- a/tests/tools/index-tool.test.ts
+++ b/tests/tools/index-tool.test.ts
@@ -157,6 +157,42 @@ describe('zotero_index async build', () => {
     expect(res.content[0].text).toMatch(/no build/i);
   });
 
+  it('pauses while idle, refuses every writer, and resumes without starting work', async () => {
+    const search = new MemorySearchIndex({ embedder: null, logger: silentLogger });
+    const ctx = makeCtx(search, makeLibrary(3));
+
+    const paused = await indexTool.handler({ action: 'pause' }, ctx);
+    expect(paused.structuredContent?.paused).toBe(true);
+    expect(search.isBuilding).toBe(false);
+    for (const action of ['build', 'refresh', 'update'] as const) {
+      const refused = await indexTool.handler({ action }, ctx);
+      expect(refused.isError).toBe(true);
+      expect(refused.content[0].text).toMatch(/paused.*resume/i);
+    }
+    expect(ctx.web.listItems).not.toHaveBeenCalled();
+
+    const resumed = await indexTool.handler({ action: 'resume' }, ctx);
+    expect(resumed.structuredContent?.paused).toBe(false);
+    expect(search.isBuilding).toBe(false);
+    expect(resumed.content[0].text).toMatch(/no job was started/i);
+  });
+
+  it('pause also stops a running build and leaves the durable hold set', async () => {
+    const gate = gatedEmbedder();
+    const search = new MemorySearchIndex({ embedder: gate.provider, logger: silentLogger });
+    const ctx = makeCtx(search, makeLibrary(250));
+    await indexTool.handler({ action: 'build' }, ctx);
+    for (let i = 0; i < 200 && gate.pending() === 0; i++) await new Promise((r) => setTimeout(r, 2));
+
+    const paused = await indexTool.handler({ action: 'pause' }, ctx);
+    expect(paused.structuredContent?.paused).toBe(true);
+    gate.open();
+    await pollStatus(ctx);
+    expect(search.isBuilding).toBe(false);
+    expect(search.isPaused).toBe(true);
+    expect(search.buildStatus().items).toBeLessThan(250);
+  });
+
   it('honours the limit input', async () => {
     const library = makeLibrary(50);
     const search = new MemorySearchIndex({ embedder: new FakeEmbeddingProvider(), logger: silentLogger });
@@ -169,6 +205,8 @@ describe('zotero_index async build', () => {
 
   it('exposes the stop action and limit in the schema and mentions polling in the description', () => {
     expect(indexTool.inputSchema.action._def.values).toContain('stop');
+    expect(indexTool.inputSchema.action._def.values).toContain('pause');
+    expect(indexTool.inputSchema.action._def.values).toContain('resume');
     expect(indexTool.inputSchema.limit).toBeDefined();
     expect(indexTool.description).toMatch(/background/i);
     expect(indexTool.description).toMatch(/poll/i);

--- a/tests/tools/search-tools.test.ts
+++ b/tests/tools/search-tools.test.ts
@@ -61,6 +61,18 @@ describe('zotero_index', () => {
 });
 
 describe('zotero_semantic_search', () => {
+  it('does not auto-build an empty index while it is paused', async () => {
+    const search = new MemorySearchIndex({ embedder: null });
+    await search.setPaused(true);
+    const ctx = makeCtx(search);
+    const res = await semanticSearch.handler({ q: 'anything' }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent?.paused).toBe(true);
+    expect(res.structuredContent?.autoBuild).toBe(false);
+    expect(res.content[0].text).toMatch(/paused.*resume/i);
+    expect(ctx.web.listItems).not.toHaveBeenCalled();
+  });
+
   it('auto-builds on first use: empty index starts a background build and says so', async () => {
     const ctx = makeCtx(new MemorySearchIndex({ embedder: null }));
     const res = await semanticSearch.handler({ q: 'anything' }, ctx);


### PR DESCRIPTION
Closes #56.

This implements option 1 as a persisted index flag. `action:"pause"` sets the hold even while idle and cooperatively stops a running job; `action:"resume"` clears it without starting work. The existing `stop` remains a one-shot cancellation.

While held, `build`, `refresh`, `update`, and semantic search's automatic first build refuse before creating background or Zotero API work. Existing indexed content remains queryable. The flag round-trips through both the SQLite meta row and legacy JSON snapshot, with an absent value defaulting to false.

The persistence setter is asynchronous rather than extending synchronous `requestStop()`, so asserting a hold while nothing is running has a write path of its own. Resume is a two-phase transition: the live hold remains set until its clear is durable. JSON saves capture immutable snapshots at invocation, publish in invocation order, and wait for a pause transition before snapshotting; JSON and SQLite close wait for pending transitions, and SQLite save waits before flushing. Thus an older save, a concurrent winding-down build save, close, or a failed opposite setter cannot make disk disagree with the live hold.

Tests cover idle pause, all explicit write actions, running-job cancellation, no automatic build, query availability, both store restarts, old-snapshot compatibility, explicit resume, stale-save ordering, failed-resume rollback/reopen, a concurrent build during failing resume, and save/close concurrent with successful resume on both persistence paths.

Gates on v1.14.0 (`7a5622f`) at head `973adbb`:
- `npm test`: 1,121 passed, 7 skipped
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run lint`
- `npm run build`
- `git diff --check`
