### PR TITLE
fix(test): clean up suite temp directories

### DIFF
--- a/tests/global-setup.test.ts
+++ b/tests/global-setup.test.ts
@@ -1,0 +1,13 @@
+import { tmpdir } from 'node:os';
+import { basename } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('test temporary directory', () => {
+  it('confines worker temporary files to the run directory', () => {
+    const root = tmpdir();
+    expect(basename(root)).toMatch(/^zoteus-test-run-/);
+    expect(process.env.TMPDIR).toBe(root);
+    expect(process.env.TMP).toBe(root);
+    expect(process.env.TEMP).toBe(root);
+  });
+});

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -2,16 +2,20 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+const TEMP_ENV_VARS = ['TMPDIR', 'TMP', 'TEMP'] as const;
+
 export default function setup() {
   const root = mkdtempSync(join(tmpdir(), 'zoteus-test-run-'));
-  const previousTmpdir = process.env.TMPDIR;
-  process.env.TMPDIR = root;
+  const previous = TEMP_ENV_VARS.map((name) => [name, process.env[name]] as const);
+  for (const [name] of previous) process.env[name] = root;
 
   return () => {
-    if (previousTmpdir === undefined) {
-      delete process.env.TMPDIR;
-    } else {
-      process.env.TMPDIR = previousTmpdir;
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
     }
     rmSync(root, { recursive: true, force: true });
   };

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,18 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export default function setup() {
+  const root = mkdtempSync(join(tmpdir(), 'zoteus-test-run-'));
+  const previousTmpdir = process.env.TMPDIR;
+  process.env.TMPDIR = root;
+
+  return () => {
+    if (previousTmpdir === undefined) {
+      delete process.env.TMPDIR;
+    } else {
+      process.env.TMPDIR = previousTmpdir;
+    }
+    rmSync(root, { recursive: true, force: true });
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     environment: 'node',
     globals: false,
     include: ['tests/**/*.test.ts'],
+    globalSetup: ['./tests/global-setup.ts'],
   },
 });


### PR DESCRIPTION
Repeated ordinary test runs leave every directory created through `mkdtempSync(join(tmpdir(), 'zoteus-…'))` behind. On current `main` (`5a81cee`), one `npm test` under an empty private temporary root left 145 `zoteus-*` directories and used 18 MiB in total.

This adds one Vitest `globalSetup` that:

- creates a fresh temporary root for the test process;
- points `TMPDIR`, `TMP`, and `TEMP` at it before test workers start, covering Node's Unix and Windows lookup rules;
- restores all three previous values and removes the complete root in Vitest's returned teardown.

That covers current and future `tmpdir()` callers without changing each test file. In watch mode, cleanup happens when the watch session exits normally, not between reruns; this bounds residue to one session but does not bound growth inside a long-lived session.

Verification on `5a81cee`:

- before: 1,131 passed, 7 skipped; 145 residual `zoteus-*` directories;
- after: the same 1,131 tests pass, plus one worker-confinement regression test; 7 skipped; 0 residual `zoteus-*` directories;
- the new test asserts that a worker resolves `tmpdir()` to the owned run root and receives all three temporary-directory variables;
- `npm run typecheck`, `npm run typecheck:tests`, `npm run lint`, and `npm run build` pass.