### PR TITLE
fix(search): take an item's binary codes with the passages a catch-up clears (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **The first `action:"update"` after a build no longer costs every later semantic query the
+  two-stage vector path (#30).** An update runs two catch-up passes that replace one item's
+  passages wholesale — the full-text pass that picks up newly extracted attachment text
+  (#26), and the own-words pass that re-reads an edited note or annotation (#33). Both
+  removed those passages and their vectors and left the binary codes taken from them behind,
+  where a whole-item delete had always taken them with it. One code per replaced passage
+  then described a row the index no longer held; the coverage check that reads the codes
+  counts one per stored vector, found more codes than vectors, and sent every semantic query
+  back to the exact scan the codes exist to avoid — the 42x this path was landed for — until
+  someone noticed and ran a full `action:"build"`. Nothing said so beyond the scan notice on
+  `zotero_index action:"status"`. Both clears now drop the codes of the passages they remove,
+  scoped by source so the item's other passages keep theirs.
+
 ## [1.16.0] - 2026-09-07
 
 ### Fixed

--- a/src/features/search/sqlite-index.ts
+++ b/src/features/search/sqlite-index.ts
@@ -321,6 +321,8 @@ interface Statements {
   // The two-stage vector path (#30). Everything below reads or maintains `vector_codes`.
   insertCode: StatementSync;
   deleteItemCodes: StatementSync;
+  deleteFulltextCodes: StatementSync;
+  deleteOwnWordsCodes: StatementSync;
   deletePassageCode: StatementSync;
   anyCode: StatementSync;
   allCodes: StatementSync;
@@ -1039,6 +1041,16 @@ export class SqliteSearchIndex extends SearchIndexBase {
       // insert once it is the largest one free. So a code MUST leave with the passage it
       // was taken from: left behind, it would eventually describe a different passage.
       deleteItemCodes: db.prepare('DELETE FROM vector_codes WHERE pid IN (SELECT pid FROM passages WHERE item_key = ?)'),
+      // Scoped by source, and deliberately not the statement above: the two partial clears
+      // leave the item's other passages in place, so a delete over the whole item would
+      // strip the codes off rows nothing touched and send every later query back to the
+      // exact scan for the coverage gap it opened.
+      deleteFulltextCodes: db.prepare(
+        "DELETE FROM vector_codes WHERE pid IN (SELECT pid FROM passages WHERE item_key = ? AND source = 'fulltext')",
+      ),
+      deleteOwnWordsCodes: db.prepare(
+        "DELETE FROM vector_codes WHERE pid IN (SELECT pid FROM passages WHERE item_key = ? AND source IN ('note', 'annotation'))",
+      ),
       deletePassageCode: db.prepare('DELETE FROM vector_codes WHERE pid = (SELECT pid FROM passages WHERE id = ?)'),
       anyCode: db.prepare('SELECT 1 AS present FROM vector_codes LIMIT 1'),
       allCodes: db.prepare('SELECT pid, code FROM vector_codes ORDER BY pid'),
@@ -1359,6 +1371,10 @@ export class SqliteSearchIndex extends SearchIndexBase {
    */
   protected clearFulltext(itemKey: string): void {
     this.begin();
+    // Before the passages go, exactly as in deleteItem: the codes are keyed by their
+    // rowids, and after the delete there is nothing left to name them by.
+    if (this.hasCodes) this.stmts.deleteFulltextCodes.run(itemKey);
+    this.invalidateCodes();
     const rows = this.stmts.itemFulltext.all(itemKey) as Array<{ pid: number; text: string; has_vector: number }>;
     for (const row of rows) {
       this.stmts.deleteFts.run(row.pid, normalizeForSearch(row.text));
@@ -1377,6 +1393,8 @@ export class SqliteSearchIndex extends SearchIndexBase {
   /** The own-words twin of `clearFulltext`, down to the external-content delete protocol. */
   protected clearOwnWords(itemKey: string): void {
     this.begin();
+    if (this.hasCodes) this.stmts.deleteOwnWordsCodes.run(itemKey);
+    this.invalidateCodes();
     const rows = this.stmts.itemOwnWords.all(itemKey) as Array<{ pid: number; text: string; has_vector: number }>;
     for (const row of rows) {
       this.stmts.deleteFts.run(row.pid, normalizeForSearch(row.text));

--- a/tests/features/search-two-stage.test.ts
+++ b/tests/features/search-two-stage.test.ts
@@ -4,7 +4,7 @@ import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { createSearchIndex, nodeSqliteAvailable, sqliteIndexPath } from '../../src/features/search/factory.js';
-import type { SearchIndex } from '../../src/features/search/backend.js';
+import type { OwnWordsAccess, OwnWordsEntry, SearchIndex } from '../../src/features/search/backend.js';
 import type { EmbeddingProvider } from '../../src/features/search/embeddings.js';
 
 /**
@@ -42,6 +42,25 @@ class DenseEmbedder implements EmbeddingProvider {
   constructor(private readonly dim = DIM) {}
   async embed(texts: string[]): Promise<number[][]> {
     return texts.map((t) => vectorFor(t, this.dim));
+  }
+}
+
+/**
+ * The same embedder, with one hook: a callback runs inside the next `embed` call and then
+ * disarms itself. That is the only place a test can stand in the middle of a catch-up — the
+ * pass clears an item's passages, inserts their replacements, and awaits the embedder before
+ * any of them has a vector, which is exactly the window a live query arrives in.
+ */
+class ProbingEmbedder extends DenseEmbedder {
+  private probe: (() => void) | undefined;
+  probeOnce(fn: () => void): void {
+    this.probe = fn;
+  }
+  override async embed(texts: string[]): Promise<number[][]> {
+    const probe = this.probe;
+    this.probe = undefined;
+    probe?.();
+    return super.embed(texts);
   }
 }
 
@@ -89,6 +108,55 @@ async function corpus(opts: CorpusOptions = {}): Promise<{ index: SearchIndex; j
   return { index, jsonPath };
 }
 
+/** The body text a full-text pass serves for one item, and the text it replaces it with. */
+const bodyOf = (key: string) => `the body of ${key}, on widgets and the gears they drive`;
+const revisedBodyOf = (key: string) => `the revised body of ${key}, on sprockets and escapements`;
+
+/**
+ * A corpus whose items carry body text, built through the incremental path so the index
+ * stores a full-text cursor. Both are what an `action:"update"` catch-up needs: without a
+ * cursor the pass is narrowed to items holding no body passages at all, which is the one
+ * shape where the clear it runs has nothing to remove.
+ */
+async function bodyCorpus(
+  count: number,
+  embedder: EmbeddingProvider = new DenseEmbedder(),
+): Promise<{ index: SearchIndex; jsonPath: string; keys: string[] }> {
+  const dir = mkdtempSync(join(tmpdir(), 'zoteus-ann-body-'));
+  const jsonPath = join(dir, 'search-index.json');
+  const all = items(count);
+  const keys = all.map((i) => i.key as string);
+  const index = await createSearchIndex({
+    backend: 'sqlite',
+    jsonPath,
+    embedder,
+    logger: silentLogger,
+  });
+  await index.buildIncremental(
+    async (start: number) =>
+      start === 0 ? { items: all, totalResults: count, lastModifiedVersion: 7 } : { items: [], totalResults: count },
+    {
+      fulltextFor: async (key: string) => bodyOf(key),
+      fulltextKeys: async () => new Set(keys),
+      // A stored cursor, so a later update asks the full-text sequence what has been
+      // extracted since it rather than treating the whole library as a coverage gap.
+      fulltextVersion: () => 100,
+    },
+  );
+  await index.save();
+  return { index, jsonPath, keys };
+}
+
+/** One item's notes and annotations, as the update's census serves them. */
+function ownWordsAccess(noteVersion: number, text: string, itemKey: string): OwnWordsAccess {
+  return {
+    childVersions: async () => new Map([[`${itemKey}N`, noteVersion]]),
+    itemsFor: async () => new Set([itemKey]),
+    textsFor: async (key: string) =>
+      key === itemKey ? [{ key: `${itemKey}N`, kind: 'note', text }] : ([] as OwnWordsEntry[]),
+  };
+}
+
 /** The protected ranker, as the fusion calls it: ids and scores, best first. */
 function rank(index: SearchIndex, query: number[], topK: number): Array<{ id: string; score: number }> {
   return (index as unknown as { vectorSearch(q: number[], k: number): Array<{ id: string; score: number }> }).vectorSearch(
@@ -104,6 +172,22 @@ function codeRows(dbPath: string): { codes: number; vectors: number; dim: string
   const dim = (db.prepare("SELECT value FROM meta WHERE key = 'codeDim'").get() as { value?: string } | undefined)?.value;
   db.close();
   return { codes, vectors, dim };
+}
+
+/**
+ * Codes naming a passage the index no longer holds. Nothing can fill them in, and SQLite
+ * hands their rowids to the next inserts, so this count is the invariant the two
+ * catch-up passes below are asserted against.
+ */
+function orphanCodes(dbPath: string): number {
+  const db = new DatabaseSync(dbPath);
+  const n = (
+    db
+      .prepare('SELECT count(*) AS n FROM vector_codes c LEFT JOIN passages p ON p.pid = c.pid WHERE p.pid IS NULL')
+      .get() as { n: number }
+  ).n;
+  db.close();
+  return n;
 }
 
 /** Strip an index back to what a build before this feature wrote: no codes, no mean. */
@@ -313,6 +397,135 @@ describe('the codes stay level with the vectors', () => {
       const afterDelete = codeRows(dbPath);
       expect(afterDelete.vectors).toBe(600);
       expect(afterDelete.codes).toBe(600);
+    } finally {
+      await index.close();
+    }
+  });
+
+  sqliteIt('takes the codes with the body passages a full-text catch-up replaces', async () => {
+    const { index, jsonPath, keys } = await bodyCorpus(600);
+    const dbPath = sqliteIndexPath(jsonPath);
+    try {
+      expect(codeRows(dbPath).codes).toBe(1200);
+      // Opening a PDF makes Zotero extract its text and touches no item version, so this
+      // is the pass that reaches that item: its body passages are replaced wholesale
+      // (their ids are reused by the new text) while its metadata passages stay put.
+      await index.updateIncremental({
+        backend: 'local',
+        fetchChanged: async () => ({ items: [], totalResults: 0, lastModifiedVersion: 8 }),
+        liveKeys: async () => new Set(keys),
+        fulltextFor: async (key: string) => revisedBodyOf(key),
+        fulltextKeys: async () => new Set(keys),
+        fulltextCatchUp: async () => ({ itemKeys: new Set(['K0001']), version: 101 }),
+      });
+      await index.save();
+
+      const rows = codeRows(dbPath);
+      expect(rows.codes).toBe(rows.vectors);
+      expect(orphanCodes(dbPath)).toBe(0);
+      // And the point of keeping them level: the next semantic query is still served by
+      // the codes, instead of falling back to the exact scan this path exists to avoid.
+      const hits = rank(index, vectorFor('a query after the catch-up'), 10);
+      expect(hits).toHaveLength(10);
+      expect(index.buildStatus().vectorScan).toBe('codes');
+      expect(index.buildStatus().vectorScanNotice).toBeUndefined();
+    } finally {
+      await index.close();
+    }
+  });
+
+  sqliteIt('takes the codes with the own words an update rewrites', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zoteus-ann-notes-'));
+    const jsonPath = join(dir, 'search-index.json');
+    const all = items(600);
+    const keys = all.map((i) => i.key as string);
+    const index = await createSearchIndex({
+      backend: 'sqlite',
+      jsonPath,
+      embedder: new DenseEmbedder(),
+      logger: silentLogger,
+    });
+    const dbPath = sqliteIndexPath(jsonPath);
+    try {
+      await index.buildIncremental(
+        async (start: number) =>
+          start === 0 ? { items: all, totalResults: 600, lastModifiedVersion: 7 } : { items: [], totalResults: 600 },
+        { ownWords: ownWordsAccess(5, 'a note on widgets and the gears they drive', 'K0001') },
+      );
+      await index.save();
+      expect(codeRows(dbPath).codes).toBe(601);
+
+      // The own-words twin of the pass above: a note edited after the build appears in no
+      // item delta, so this is the only thing that re-reads it, and it too replaces the
+      // item's passages wholesale. That this case is red at all depends on the note NOT
+      // holding the largest rowid, which is true because indexItem interleaves an item's
+      // own words with its metadata during the build. Were own words ever moved to a pass
+      // of their own after the items, the replacement would reuse the note's rowid and
+      // putVector would clear the inherited code, leaving this green over a store that
+      // still leaks.
+      await index.updateIncremental({
+        backend: 'local',
+        fetchChanged: async () => ({ items: [], totalResults: 0, lastModifiedVersion: 8 }),
+        liveKeys: async () => new Set(keys),
+        ownWords: ownWordsAccess(9, 'the same note, rewritten around sprockets', 'K0001'),
+      });
+      await index.save();
+
+      const rows = codeRows(dbPath);
+      expect(rows.codes).toBe(rows.vectors);
+      expect(orphanCodes(dbPath)).toBe(0);
+      const hits = rank(index, vectorFor('a query after the note was rewritten'), 10);
+      expect(hits).toHaveLength(10);
+      expect(index.buildStatus().vectorScan).toBe('codes');
+      expect(index.buildStatus().vectorScanNotice).toBeUndefined();
+    } finally {
+      await index.close();
+    }
+  });
+
+  sqliteIt('forgets the resident codes a catch-up clears, so a query racing it cannot read a cleared row', async () => {
+    // A semantic query is not refused while an update runs: zotero_semantic_search only
+    // declines on an empty index, so on a populated one the two overlap by design. The
+    // resident codes name rowids, the catch-up frees the largest of them, and SQLite hands
+    // that rowid straight back to the passage the same pass inserts — which has no vector
+    // yet, because it is the batch this await is embedding. A cache that outlives the clear
+    // therefore offers the rescore a candidate whose vector is NULL, and the rescore selects
+    // by rowid with no `vector IS NOT NULL` filter to catch it.
+    const embedder = new ProbingEmbedder();
+    const { index, jsonPath, keys } = await bodyCorpus(600, embedder);
+    try {
+      // Warm the codes, so the query below has a resident cache to be served from.
+      rank(index, vectorFor('warm the cache'), 10);
+      expect(index.buildStatus().vectorScan).toBe('codes');
+
+      let raced: { error?: unknown; scan?: string; notice?: string; hits?: number } = {};
+      embedder.probeOnce(() => {
+        try {
+          const hits = rank(index, vectorFor(bodyOf('K0599')), 10);
+          const status = index.buildStatus();
+          raced = { scan: status.vectorScan, notice: status.vectorScanNotice, hits: hits.length };
+        } catch (e) {
+          raced = { error: e };
+        }
+      });
+      await index.updateIncremental({
+        backend: 'local',
+        fetchChanged: async () => ({ items: [], totalResults: 0, lastModifiedVersion: 8 }),
+        liveKeys: async () => new Set(keys),
+        fulltextFor: async (key: string) => revisedBodyOf(key),
+        fulltextKeys: async () => new Set(keys),
+        // The LAST item indexed, whose body passage holds the largest rowid.
+        fulltextCatchUp: async () => ({ itemKeys: new Set(['K0599']), version: 101 }),
+      });
+      await index.save();
+
+      expect(raced.error).toBeUndefined();
+      // The clear dropped the cache, so the query found none and declined rather than
+      // building one over rows the running update is still writing.
+      expect(raced.scan).toBe('exact');
+      expect(raced.notice).toContain('update is running');
+      expect(raced.hits).toBe(10);
+      expect(codeRows(sqliteIndexPath(jsonPath)).codes).toBe(1200);
     } finally {
       await index.close();
     }


### PR DESCRIPTION
Based on `4467663` (main at v1.16.0 + the README commit).

## What breaks

`SqliteSearchIndex` has three ways to remove passages, and only one of them
maintains the `vector_codes` cache the two-stage vector path (#30) reads.

`deleteItem` drops the item's codes before its passages go
(`src/features/search/sqlite-index.ts:1316-1317`), because codes are keyed by
rowid and after the delete there is nothing left to name them by — the comment
on `deleteItemCodes` (`:1041`) states the invariant.

Its two partial siblings do neither:

- `clearFulltext(itemKey)` at `:1360` removes the item's `source = 'fulltext'`
  passages, decrementing `c.vectors` for each one that carries a vector, and
  removes no codes.
- `clearOwnWords(itemKey)` at `:1378` does the same for
  `source IN ('note', 'annotation')`.

Those two are exactly the catch-up passes an `action:"update"` runs:
`index-manager.ts:1922` calls `clearFulltext` from the full-text catch-up (#26 —
opening a PDF makes Zotero extract its text and touches no item version), and
`index-manager.ts:2089` calls `clearOwnWords` from the own-words catch-up (#33 —
writing a note versions the child, never the parent). Both replace the item's
passages wholesale.

## The failures a user sees

**Every semantic query goes back to the exact scan, permanently.**

After the first incremental catch-up over an index that holds codes,
`vector_codes` carries one row per replaced passage whose passage is gone.
`refreshCodes` (`:1772`) only writes codes for vectors that carry none
(`uncodedPids`), so nothing later removes them: the surplus is permanent.
`loadCodes` (`:1821`) counts one code per stored vector, finds more codes than
vectors, and returns

> There are more binary codes than the 1200 stored vectors they must describe.

`codesFor` then declines, and every semantic query falls back to the exact float
scan the codes exist to avoid — the 42x this path was landed for — for the life
of the index, until someone runs a full `action:"build"`. The only trace is the
`vectorScanNotice` on `zotero_index action:"status"`; a user who does not read it
sees a semantic search that was fast after the build and slow ever after.

**And a query that arrives during the catch-up throws.**

`zotero_semantic_search` (`src/tools/semantic-search.ts:32-34`) declines during a
running job only when the index is empty, so on a populated index queries and an
update overlap by design. The catch-up clears the item's passages, inserts their
replacements with no vector yet, and awaits the embedder. A resident `codeCache`
that outlived the clear still names the freed rowid; SQLite has just handed that
rowid back to one of the new rows; and `rescoreStatement` (`:1656`) selects
candidates by rowid — `SELECT id, vector FROM passages WHERE pid IN (…)`, with no
`vector IS NOT NULL` filter — so `toFloats` (`:2205`) dereferences null:

```
TypeError: Cannot read properties of null (reading 'byteOffset')
```

Both are reproduced end to end through the public API by the tests below.
Neither produces *wrong* results: every score still comes from a real float32
vector, so a query that returns at all returns the correct ranking.

## The fix, and why that shape

Two source-scoped statements, mirroring the existing `deleteFulltext` /
`deleteOwnWords` pair one for one, plus `invalidateCodes()`, at the top of each
clear:

```sql
DELETE FROM vector_codes WHERE pid IN
  (SELECT pid FROM passages WHERE item_key = ? AND source = 'fulltext')
DELETE FROM vector_codes WHERE pid IN
  (SELECT pid FROM passages WHERE item_key = ? AND source IN ('note', 'annotation'))
```

**Why not reuse `deleteItemCodes`.** It takes every code of the item, and
`clearFulltext` deliberately leaves the item's metadata passages (and the item
row) exactly where they are. Stripping their codes would exchange a surplus for
a shortfall — `loadCodes` would report "the binary codes cover N of the M stored
vectors" and decline the coded path just the same, for rows nothing touched.
Scoping the delete by `source` is what keeps the two halves of the item
independent.

**Why before the delete, not after.** The subquery names the doomed rows through
`passages`; run after `deleteFulltext`, it selects nothing and the statement is a
no-op. This is the ordering `deleteItem` already uses, for the same reason.

**Why `invalidateCodes()` as well.** It is not housekeeping and it is not a table
wipe (that is `dropCodes()`, `:1889`): it drops the *resident* `codeCache`, and
it is what turns the `TypeError` above into the ordinary refusal — with no cache,
`codesFor` sees a job running and declines to build one over rows the update is
still writing, so the query scans exactly and says so. Every other path that
removes or replaces a vector already calls it — `putVector` (`:1416`),
`adoptVector` (`:898`), `deleteItem` (`:1317`), `dropCodes` (`:1895`); the two
clears were the only ones that did not.

Both halves are independently necessary, and that is measured rather than
asserted: with the two scoped deletes in place and only the two
`this.invalidateCodes();` lines removed, the third test below fails with the same
`TypeError` while the other two pass.

## What the tests assert, and that they were seen red

Three cases in `tests/features/search-two-stage.test.ts`, under the existing
`the codes stay level with the vectors` block:

1. **`takes the codes with the body passages a full-text catch-up replaces`** —
   a 600-item index built through `buildIncremental` with body text and a stored
   full-text cursor (1200 vectors, above the default 500-candidate floor, so
   `finalizeVectors` really writes codes), then one `updateIncremental` whose
   `fulltextCatchUp` names one item. Asserts codes == vectors, zero codes naming
   an absent passage, and that the next semantic query is still served by the
   codes (`vectorScan === 'codes'`, no notice).
2. **`takes the codes with the own words an update rewrites`** — the same over
   the own-words pass: 600 metadata passages plus one note (601 vectors), then an
   update whose `ownWords` census reports a newer note version. Same three
   assertions. Its comment records the one thing its redness depends on: the note
   must not hold the largest rowid, which holds because `indexItem`
   (`index-manager.ts:2216`) interleaves own words per item during the build.
3. **`forgets the resident codes a catch-up clears, so a query racing it cannot
   read a cleared row`** — the crash. Warm the cache with one query, then run a
   catch-up on the **last** item indexed with a semantic query fired from inside
   the embedder, i.e. during the await between the clear and the first
   `putVector`. Asserts the query does not throw, that it scanned exactly with
   the build-running notice, and that it still returned its ten hits.

The fixtures are built through the public build/update API with the documented
options; nothing reaches into internals beyond the existing `rank()` cast the
file already uses, and each index is over the code-building floor honestly rather
than by lowering it.

**Red step, on the committed unfixed tree** (tests committed alone, source
untouched, working tree clean):

```
 × ... takes the codes with the body passages a full-text catch-up replaces
   → expected 1201 to be 1200 // Object.is equality
 × ... takes the codes with the own words an update rewrites
   → expected 602 to be 601 // Object.is equality
 × ... forgets the resident codes a catch-up clears, so a query racing it cannot read a cleared row
   → expected TypeError: Cannot read properties of null… to be undefined
     Received: [TypeError: Cannot read properties of null (reading 'byteOffset')]

 Test Files  1 failed (1)
      Tests  3 failed | 14 passed (17)
```

Full suite on that tree: **1250 passed, 3 failed (these three), 7 skipped, 1260
total**. After the fix: **1253 passed, 7 skipped, 1260 total, 0 failed**.
`npm run typecheck`, `npm run typecheck:tests`, `npm run lint` and `npm run
build` are all clean. (Prettier reports all three touched files as unformatted,
but it reports each of them unformatted on `4467663` too, so it is not a gate
here and I left formatting alone.)

## A fourth case written and dropped, and why

I also wrote a case for the hazard the `deleteItemCodes` comment warns about:
after a catch-up on the last item indexed, assert the replacement does not keep
its predecessor's code at the reused rowid.

**That case passes without this change**, so I removed it rather than ship a test
that proves nothing. `putVector` (`:1407-1416`) resolves a passage id to its
rowid and deletes whatever code sits there before storing the new vector, and
`refreshCodes` then writes a fresh one — so a re-embedded replacement never keeps
a stale code. The reuse hazard is real only for a passage that is cleared and
never re-embedded, and that case shows up as an ordinary orphan, caught by the
count check like any other. What the reuse *does* cause is the crash in case 3,
where the inherited rowid is read before the vector is written.

## What I could not verify

- **No measurement on a real library.** The 42x figure is the maintainer's own,
  from the 1.9.0 CHANGELOG entry for #30; I did not re-measure it. The tests
  assert the coded path is *taken*, not how fast it is.
- The fix touches the SQLite backend only. The JSON backend
  (`index-manager.ts:2614/2630`) and the corrupt-store stub
  (`corruption.ts:133/139`) hold no codes and need nothing.
