### PR TITLE
fix(search): refuse `mode:"semantic"` when no provider can embed the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`mode:"semantic"` no longer answers "No matches" when there is no embedder to turn the
+  query into a vector (#7).** Semantic ranking needs both ends of the comparison — vectors
+  in the index, and a provider to embed the query — but the refusal only tested the first.
+  An index built with an embedder and reopened with `ZOTEUS_EMBEDDINGS=off` keeps its
+  vectors (they are unusable, not known-wrong), so `hasVectors` stayed true, the refusal did
+  not fire, and the query fell through to a vector ranker with no query vector and a keyword
+  ranker closed by `mode:"semantic"`. The result was a bare `No matches for "…"`,
+  indistinguishable from a library that genuinely holds nothing on the subject;
+  `embedderNotice` is deliberately silent about a provider switched off on purpose, so
+  nothing else explained it either. Semantic mode now refuses whenever no provider is
+  configured at all, names which of the two halves is missing, and — when the vectors carry
+  their provenance — names the provider that built them. `auto` and `keyword` are
+  unaffected. So is a provider that is configured and merely failed: it is still reported
+  through the existing notice, and the next query ranks again as soon as it recovers,
+  without an index rebuild.
+
 ## [1.16.0] - 2026-09-07
 
 ### Fixed

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -107,11 +107,16 @@ summary, because a build whose artifact never reached disk still reports `state:
 - `q` — natural-language query. `mode`: `auto` (hybrid, default), `keyword` (BM25), or `semantic` (vector).
 - Returns ranked items with a snippet and fused score. The index is built automatically on first use (see `auto_build` below), or ahead of time with `zotero_index`.
 - `auto_build` (default `true`) — when the index is empty the tool starts a background build itself and tells you to poll `zotero_index` action:"status" until `done`, then retry, instead of returning a bare error; pass `auto_build: false` to opt out.
-- `mode: "semantic"` ranks by vectors alone, so with **0 vectors** in the index it returns an
-  explicit error naming the cause (missing embedder, or an index built before one was
-  available) rather than an empty hit list, which would be indistinguishable from "your
-  library has nothing on this". `auto` and `keyword` keep working on BM25; `auto` appends a
-  one-line notice when vector ranking is off.
+- `mode: "semantic"` ranks by vectors alone, which needs both ends of the comparison:
+  vectors in the index, and an embedding provider to turn the query into one. With **0
+  vectors**, or with **no provider at all** (`ZOTEUS_EMBEDDINGS=off`, or one that never
+  started), it returns an explicit error naming the cause rather than an empty hit list,
+  which would be indistinguishable from "your library has nothing on this" — an index built
+  with vectors and reopened with embeddings off keeps those vectors, so the 0-vector test
+  alone would let that case through silently. A provider that is configured and merely
+  *failed* is not refused: the one-line notice reports it, and the next query ranks again as
+  soon as it recovers, with no rebuild. `auto` and `keyword` keep working on BM25; `auto`
+  appends a one-line notice when vector ranking is off.
 - Snippets are query-centred and trimmed to word boundaries: the excerpt is positioned around the first query token hit rather than always taken from the document head, so the relevant phrase appears in the snippet even when it occurs deep in the abstract.
 - A hit whose snippet came from a PDF body rather than the item's metadata is marked
   `source: "fulltext"`, so the caller knows the passage is quotable and can fetch it with

--- a/src/tools/semantic-search.ts
+++ b/src/tools/semantic-search.ts
@@ -17,7 +17,7 @@ const semanticSearch: ToolDefinition = {
   name: 'zotero_semantic_search',
   title: 'Semantic / hybrid library search',
   description:
-    'Search the library by meaning, not just keywords. Combines BM25 keyword scoring with vector similarity (when an embedding provider is configured) via reciprocal-rank fusion, and returns the best-matching items with a snippet and score. By default it searches item metadata and abstracts; if the index was built with `fulltext` on (zotero_index fulltext:true, or ZOTEUS_INDEX_FULLTEXT=true) it also searches the body text of attachments, and a hit whose snippet came from a PDF body is marked source:"fulltext". It ALSO searches the words the reader wrote — child notes and PDF annotations (highlight text and comments) — unless that was turned off (ZOTEUS_INDEX_OWN_WORDS=false); a hit from one is marked source:"note" or source:"annotation" and is attributed to the item it hangs off, so an item with forty annotations is one result rather than forty. `mode`: "auto" (hybrid, default), "keyword" (BM25 only), or "semantic" (vector only). "semantic" needs vectors in the index: when the configured embedder is not running (e.g. the on-device model runtime is not installed) it returns an error naming the cause instead of an empty result set, and "auto" keeps working as keyword search while saying so. The index must be built once before first use: when it is empty this tool starts a background build automatically (`auto_build`, on by default) and tells you to poll zotero_index action:"status" and retry — pass `auto_build:false` to opt out. For exact field/tag/itemType filtering use zotero_search_items instead; use this for conceptual/"papers about X" queries. To read the actual passages of a found item (with page locators) use zotero_get_fulltext.',
+    'Search the library by meaning, not just keywords. Combines BM25 keyword scoring with vector similarity (when an embedding provider is configured) via reciprocal-rank fusion, and returns the best-matching items with a snippet and score. By default it searches item metadata and abstracts; if the index was built with `fulltext` on (zotero_index fulltext:true, or ZOTEUS_INDEX_FULLTEXT=true) it also searches the body text of attachments, and a hit whose snippet came from a PDF body is marked source:"fulltext". It ALSO searches the words the reader wrote — child notes and PDF annotations (highlight text and comments) — unless that was turned off (ZOTEUS_INDEX_OWN_WORDS=false); a hit from one is marked source:"note" or source:"annotation" and is attributed to the item it hangs off, so an item with forty annotations is one result rather than forty. `mode`: "auto" (hybrid, default), "keyword" (BM25 only), or "semantic" (vector only). "semantic" needs both vectors in the index and a running embedder to turn the query into one: when either is missing (embeddings switched off, or e.g. the on-device model runtime is not installed) it returns an error naming the cause instead of an empty result set, and "auto" keeps working as keyword search while saying so. The index must be built once before first use: when it is empty this tool starts a background build automatically (`auto_build`, on by default) and tells you to poll zotero_index action:"status" and retry — pass `auto_build:false` to opt out. For exact field/tag/itemType filtering use zotero_search_items instead; use this for conceptual/"papers about X" queries. To read the actual passages of a found item (with page locators) use zotero_get_fulltext.',
   inputSchema: {
     q: z.string().min(1).describe('Natural-language query.'),
     limit: z.number().int().min(1).max(50).optional().describe('Max results (default 10).'),
@@ -93,26 +93,55 @@ const semanticSearch: ToolDefinition = {
       };
     }
     const status = ctx.search.buildStatus();
-    // Semantic mode ranks by vectors alone. With none in the index every query returns an
-    // empty list, which reads exactly like "your library has nothing on this": the failure
-    // mode reported in #7. Refuse instead, and name the cause.
+    // Semantic mode ranks by vectors alone, and that needs both ends of the comparison:
+    // vectors in the index, and an embedder to turn the query into one. Missing either,
+    // every query returns an empty list, which reads exactly like "your library has
+    // nothing on this": the failure mode reported in #7. Refuse instead, and name the
+    // cause. The embedder half is the quieter one, because an index built with vectors
+    // and reopened with ZOTEUS_EMBEDDINGS=off keeps them (they are unusable, not
+    // known-wrong) — so the 0-vector test alone lets it through, and `embedderNotice` is
+    // deliberately silent about a provider switched off on purpose.
     // A store that could not be opened explains itself; this branch would otherwise tell
     // the caller their index holds no vectors and to rebuild it, which is true and beside
     // the point. Falling through lets query() refuse with the file and the command.
-    if (args.mode === 'semantic' && !ctx.search.hasVectors && !ctx.search.storeFault) {
-      const why =
+    //
+    // `embedderId`, not `hasEmbedder`, is the right test for the second half, and the
+    // difference is load-bearing. `embedderId` is undefined exactly when there is no
+    // provider object — which is what query() itself keys on (`this.opts.embedder`), so it
+    // is precisely the case where no query can ever be embedded. `hasEmbedder` is
+    // `embedderActive`, which ALSO goes false on the first query-time failure and stays
+    // false until the next build/update (noteEmbedFailure records the first edge;
+    // embedderError is cleared only by an index job). query() keeps trying the provider
+    // regardless and ranks again the moment it recovers, so refusing on `hasEmbedder`
+    // would turn one rate-limit blip into a mode that stays dead until the user rebuilds
+    // — while `auto` went on embedding the same query successfully. A transient failure is
+    // reported by embedderNotice on the query that hit it, which is the existing contract.
+    const canEmbedQuery = ctx.search.embedderId !== undefined;
+    if (args.mode === 'semantic' && !(ctx.search.hasVectors && canEmbedQuery) && !ctx.search.storeFault) {
+      const noVectors =
         // A model switch is the one cause that names its own remedy, so it wins over the
         // generic "no vectors yet" line.
         status.vectorsStaleReason ??
         (ctx.search.embedderActive
           ? 'The index holds no vectors yet. Rebuild it with zotero_index action:"build" (an index built while the embedder was unavailable stays keyword-only until rebuilt).'
           : `No vectors exist because the embedder is not active: ${ctx.search.embedderReason ?? 'unavailable'}`);
+      // The index knows which provider produced the vectors it is holding, and that
+      // survives the switch-off, so name it rather than making the user go and find out.
+      const builtWith = ctx.search.vectorEmbedderId;
+      const noEmbedder =
+        status.embedderConfigured === 'off'
+          ? 'Embeddings are switched off (ZOTEUS_EMBEDDINGS=off), so the stored vectors have nothing to be ranked ' +
+            `against. Set ZOTEUS_EMBEDDINGS back to ${builtWith ? `the provider that built them (${builtWith})` : 'an embedding provider'} to rank by meaning again.`
+          : `The configured ${status.embedderConfigured} embedder is not active: ${ctx.search.embedderReason ?? 'unavailable'}`;
+      const cause = ctx.search.hasVectors
+        ? `this index holds ${status.vectors} vectors but nothing can embed the query. ${noEmbedder}`
+        : `this index has 0 vectors. ${noVectors}`;
       return {
         content: [
           {
             type: 'text',
             text:
-              `mode:"semantic" cannot run: it ranks by vector similarity only, and this index has 0 vectors. ${why} ` +
+              `mode:"semantic" cannot run: it ranks by vector similarity only, and ${cause} ` +
               'Re-run with mode:"keyword" (or the default "auto") to search this library right now.',
           },
         ],

--- a/tests/features/embedder-degradation.test.ts
+++ b/tests/features/embedder-degradation.test.ts
@@ -194,6 +194,122 @@ describe('zotero_semantic_search with no vectors', () => {
   });
 });
 
+describe('zotero_semantic_search with vectors but nothing to embed the query', () => {
+  /**
+   * The state an index reaches when it was built with an embedder and the server was then
+   * restarted with ZOTEUS_EMBEDDINGS=off: the vectors are still on disk and are kept (they
+   * are not known-wrong, only unusable), so `hasVectors` is true and the 0-vector refusal
+   * does not fire. Semantic mode still cannot rank, because ranking needs the query
+   * embedded too — and `embedderNotice` is deliberately silent about a provider that was
+   * switched off on purpose, so nothing else explains the empty page either.
+   */
+  async function vectorsWithoutEmbedder(configured: string, unavailable?: string): Promise<SearchIndex> {
+    const embedder: EmbeddingProvider = {
+      name: 'openai',
+      model: 'text-embedding-3-small',
+      embed: async (texts) => texts.map(() => [1, 0, 0]),
+    };
+    const built = new MemorySearchIndex({ embedder, configured: 'openai', logger: silentLogger });
+    await built.build(items);
+    // The provenance stamp is kept, not stripped: a server with no embedder of its own has
+    // nothing to compare it against, so reconcileVectorProvenance leaves the rows alone and
+    // vectorEmbedderId still names what produced them — which is what the message quotes.
+    const saved = JSON.parse(JSON.stringify(built.toJSON()));
+
+    const search = new MemorySearchIndex({ embedder: null, configured, unavailable, logger: silentLogger });
+    search.loadFromJSON(saved);
+    return search;
+  }
+
+  it('errors instead of answering "No matches" when embeddings are switched off', async () => {
+    const search = await vectorsWithoutEmbedder('off');
+    expect(search.hasVectors).toBe(true);
+    expect(search.hasEmbedder).toBe(false);
+
+    const res = await semanticSearch.handler({ q: 'deep learning', mode: 'semantic' }, { search } as any);
+
+    // The whole point: an empty hit list here is indistinguishable from a library that
+    // holds nothing on the subject, and no notice covers a deliberate `off`.
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).not.toMatch(/^No matches/);
+    expect(res.content[0].text).toMatch(/ZOTEUS_EMBEDDINGS/);
+    expect(res.content[0].text).toMatch(/mode:"keyword"/);
+    // The index knows what produced the vectors it is still holding; the way back is to
+    // that provider, not to any provider, so the message says which.
+    expect(res.content[0].text).toContain('openai:text-embedding-3-small');
+    expect(res.structuredContent?.hits).toEqual([]);
+    expect(res.structuredContent?.embedderConfigured).toBe('off');
+    expect(res.structuredContent?.embedderActive).toBe(false);
+  });
+
+  it('names the provider and its cause when one was configured but is not running', async () => {
+    const search = await vectorsWithoutEmbedder('local', missingTransformersHint({ dist: 'mcpb' }));
+
+    const res = await semanticSearch.handler({ q: 'deep learning', mode: 'semantic' }, { search } as any);
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/@huggingface\/transformers/);
+    expect(res.structuredContent?.embedderConfigured).toBe('local');
+  });
+
+  it('still answers in auto and keyword mode, which do not need the query embedded', async () => {
+    const search = await vectorsWithoutEmbedder('off');
+
+    for (const args of [{ q: 'deep learning' }, { q: 'deep learning', mode: 'keyword' as const }]) {
+      const res = await semanticSearch.handler(args, { search } as any);
+      expect(res.isError).toBeUndefined();
+      expect((res.structuredContent?.hits as any[]).length).toBeGreaterThan(0);
+    }
+  });
+
+  /**
+   * The refusal must not fire on a provider that is merely *unhealthy*, and the two are
+   * easy to conflate: `embedderActive` goes false on the first query-time failure and stays
+   * false until the next build or update, because `noteEmbedFailure` records only the first
+   * edge and nothing clears it on a later success. `query()` does not consult that flag —
+   * it keys on the provider object — so it re-embeds and ranks again the moment the
+   * provider recovers. A refusal keyed on the flag would convert one rate-limit blip into a
+   * mode that stays dead until the user rebuilds the index, while `auto` went on embedding
+   * the same query successfully.
+   *
+   * This test passes before the change as well as after: it is not the red step, it is the
+   * guard on the one behaviour the fix could plausibly break, and nothing upstream pinned
+   * it.
+   */
+  it('keeps ranking after a transient embedder failure, without an index rebuild', async () => {
+    let failing = false;
+    let embedCalls = 0;
+    const flaky: EmbeddingProvider = {
+      name: 'openai',
+      model: 'text-embedding-3-small',
+      embed: async (texts) => {
+        embedCalls += 1;
+        if (failing) throw new Error('429 rate limited');
+        return texts.map(() => [1, 0, 0]);
+      },
+    };
+    const search = new MemorySearchIndex({ embedder: flaky, configured: 'openai', logger: silentLogger });
+    await search.build(items);
+
+    failing = true;
+    const during = await semanticSearch.handler({ q: 'deep learning', mode: 'semantic' }, { search } as any);
+    // The failing query itself is not refused: the notice is what reports it, as before.
+    expect(during.isError).toBeUndefined();
+    expect(during.content[0].text).toMatch(/Semantic ranking is OFF/);
+    expect(search.embedderActive).toBe(false); // and the flag is now stuck false
+
+    failing = false;
+    const before = embedCalls;
+    const after = await semanticSearch.handler({ q: 'deep learning', mode: 'semantic' }, { search } as any);
+
+    expect(after.isError).toBeUndefined();
+    expect((after.structuredContent?.hits as any[]).length).toBeGreaterThan(0);
+    // Ranked because the query was embedded again, not because a keyword ranker answered:
+    // in mode:"semantic" the keyword side is closed, so a hit here can only be a vector hit.
+    expect(embedCalls).toBe(before + 1);
+  });
+});
+
 describe('local-embedding diagnostics name the path that was searched (#38)', () => {
   /** A directory that resolves nothing: the shape of a mistyped or stale settings value. */
   const emptyRoot = () => mkdtempSync(join(tmpdir(), 'zoteus-wrong-'));


### PR DESCRIPTION
Base: `4467663` (main at v1.16.0 + the readme commit).
Branch: `fix/semantic-refuses-without-embedder` — 2 commits, +181 / −12 over 4 files.

## The symptom

Build the index with an embedder, then restart the server with `ZOTEUS_EMBEDDINGS=off`
and run a semantic search. The tool answers:

```
No matches for "deep learning".
```

That is the whole reply. No `isError`, no notice, no cause. It is byte-identical to what
an honest empty result looks like, so the caller — a model, usually — reads it as "this
library holds nothing on the subject" and moves on. It is the #7 failure mode that the
0-vector refusal was written to prevent, arriving through the one door that refusal does
not cover.

The index in this state is not damaged and is not empty: the same query in `auto` or
`keyword` mode returns hits normally.

## Mechanism

Three things line up, and all three are working as designed on their own.

1. **The vectors survive the switch-off.** `SearchIndexBase.reconcileVectorProvenance`
   (`src/features/search/index-manager.ts:688`) drops stored vectors only when the
   *current* embedder identity disagrees with the stored one. With embeddings off there is
   no current identity, so the guard short-circuits and the rows are kept — correctly,
   since they are unusable, not known-wrong. `tests/features/embedding-config.test.ts:389`
   already pins that ("stays silent with no active embedder, which never queries them
   anyway"). So `hasVectors` is **true**.

2. **The refusal only tests the vectors.** `src/tools/semantic-search.ts:102` reads
   `args.mode === 'semantic' && !ctx.search.hasVectors && !ctx.search.storeFault`. With
   vectors present it does not fire, and the handler falls through to `query()`.

3. **`query()` closes both rankers and returns `[]`.** In `SearchIndexBase.query`
   (`index-manager.ts:2363`): the query is embedded only when
   `mode !== 'keyword' && this.opts.embedder && this.counts().vectors`, and with embeddings
   off `opts.embedder` is undefined, so `qv` stays undefined. Then
   `keywordOpen = mode !== 'semantic'` → `false` and `vectorOpen = qv !== undefined` →
   `false`. The loop runs once over two empty candidate lists and returns `[]`.

The summary is then assembled at `semantic-search.ts:133`. It appends `embedderNotice`,
and `build.ts:70` reads `if (s.embedderActive || s.embedderConfigured === 'off') return ''`
— deliberately silent about a provider switched off on purpose, so a keyword-only index by
choice is not lectured on every call (`embedder-degradation.test.ts:123` pins that).
`staleVectorsNotice` and `unembeddedNotice` are empty here too. What is left is the bare
`No matches`.

Each piece is right; the composition is the defect.

## The fix, and why it is keyed on `embedderId`

```diff
-if (args.mode === 'semantic' && !ctx.search.hasVectors && !ctx.search.storeFault) {
+const canEmbedQuery = ctx.search.embedderId !== undefined;
+if (args.mode === 'semantic' && !(ctx.search.hasVectors && canEmbedQuery) && !ctx.search.storeFault) {
```

The obvious flag to reach for is `hasEmbedder`, and it is the wrong one. This is the part
worth reviewing closely.

`hasEmbedder` is `embedderActive` (`index-manager.ts:608`) =
`Boolean(this.opts.embedder) && !this.embedderError` (`:576–578`). `embedderError` is set
by `noteEmbedFailure` on the **first** query-time embed failure (`:722–726`, first edge
wins) and is cleared only in `build()` (`:904`), `buildIncremental()` (`:1012`) and
`updateIncremental()` (`:1578`) — never on a later success. But `query()` does not consult
it; it keys on the provider object (`:2375`). So after a 429 or an `ECONNRESET`, the next
semantic query re-embeds and ranks normally while the flag stays false until an index job
runs.

Refusing on `hasEmbedder` therefore converts one rate-limit blip into a mode that stays
dead until the user rebuilds — measured below — while `auto` goes on embedding the same
query successfully one line later. The tool's own log line for that state calls it
*falling back to keyword-only*, not bricking the mode.

`embedderId` (`backend.ts:604`, "undefined with no provider") is undefined exactly when
there is no provider object — the same thing `query()` keys on. It is therefore precisely
"no query can ever be embedded here", which is the condition a refusal should test.
Measured: `off` → undefined, configured-but-never-started → undefined, provider present
but flagged by a past failure → **defined**, and that index still returns 2 hits.

A post-query variant (`hits.length === 0 && !after.embedderActive`) was considered and
rejected. It reads the sticky flag too, so it misfires in a state I constructed and
measured: after a transient failure, a query that embeds successfully (1 embed call) and
honestly matches nothing — `VectorStore.search` filters `score > 0`, so zero hits with a
live embedder is reachable — comes back `hits: 0, embedderActive: false`, and that route
would refuse with "the embedder is not active" about a query it had just embedded.
`embedderId` has no such case.

The 0-vector wording is unchanged. The new branch says how many vectors are stranded and
either names the provider that built them — `vectorEmbedderId` survives the switch-off —
or names the configured provider and why it is not active:

> `mode:"semantic"` cannot run: it ranks by vector similarity only, and this index holds 2
> vectors but nothing can embed the query. Embeddings are switched off
> (`ZOTEUS_EMBEDDINGS=off`), so the stored vectors have nothing to be ranked against. Set
> `ZOTEUS_EMBEDDINGS` back to the provider that built them
> (`openai:text-embedding-3-small`) to rank by meaning again. Re-run with `mode:"keyword"`
> (or the default `"auto"`) to search this library right now.

`docs/semantic-search.md` (the "0 vectors" bullet), the tool description and `CHANGELOG.md`
are updated to match. No interface change: `embedderId` and `vectorEmbedderId` are already
on `SearchIndex`.

## State matrix

`mode:"semantic"`, index non-empty, no store fault. Every row driven through the handler on
both trees.

| # | vectors | embedder | before | after |
|---|---|---|---|---|
| 1 | present | working | 2 hits | unchanged |
| 2 | present | `ZOTEUS_EMBEDDINGS=off` | `No matches for "…".` — no error, no cause | **error**, names the stranded vectors, `ZOTEUS_EMBEDDINGS`, and the provider that built them |
| 3a | present | configured, never started | `No matches …` + `Semantic ranking is OFF …` — explained, not an error | **error**, names the provider and its cause |
| 3b | present | configured, throws during *this* query | `No matches …` + `Semantic ranking is OFF …` | unchanged |
| 3c | present | **second** query, provider still down | `No matches …` + same notice | unchanged |
| 3d | present | **provider healthy again** (flag still stuck false) | 2 hits, 1 embed call, notice still appended | **unchanged — 2 hits, 1 embed call** |
| 4 | none | configured but down | error, `… 0 vectors …` | unchanged, byte for byte |
| 4b | none | active | error, `… rebuild it …` | unchanged, byte for byte |
| 5 | none | off | error, `… 0 vectors …` | unchanged, byte for byte |

`auto` and `keyword` are untouched in every row; the gate is still `args.mode === 'semantic'`.

Rows 2 and 3a are the change. Row 3d is the one that constrains the design: an earlier
revision of this patch keyed on `hasEmbedder` and turned 3d into `isError: true` with
**zero** embed calls, permanently, until an index job cleared the flag. That revision
passed all 1253 upstream tests — nothing pinned the self-heal path — which is why the guard
below now exists.

State 3a changes as a consequence of the fix rather than as its target, and I think that is
right: it is the same structural impossibility as row 4, which already errors, differing
only in whether the index happens to hold rows the query cannot reach. It also makes the
tool description true, since it already promised an error there. Say the word if you would
rather 3a stayed a notice — it is one clause.

State 3b keeps its notice deliberately. The failure has not happened yet when the gate
runs, and the provider may well be fine on the next call; the notice is the existing
contract for a degraded provider and this patch does not relitigate it.

## Tests

Four tests in a new describe block in `tests/features/embedder-degradation.test.ts`, on a
helper that reproduces the real state — build with an embedder, serialize, reload into an
index with `embedder: null`. The provenance stamp is deliberately **kept** (not
`delete`d), because that is the shape a real index has and it is what lets the message name
the provider.

- **errors instead of answering "No matches" when embeddings are switched off** — asserts
  `hasVectors === true` and `hasEmbedder === false` first, so the test is pinned to the
  state it claims to cover; then `isError`, that the text does not start with `No matches`,
  that it names `ZOTEUS_EMBEDDINGS`, `mode:"keyword"` and
  `openai:text-embedding-3-small`, and the `structuredContent` fields.
- **names the provider and its cause when one was configured but is not running** — row 3a.
- **still answers in auto and keyword mode** — control; green before and after.
- **keeps ranking after a transient embedder failure, without an index rebuild** — rows
  3b/3d. Drives a flaky provider through fail-then-recover and asserts the recovered query
  is not an error, returns hits, and made exactly one embed call (in `mode:"semantic"` the
  keyword ranker is closed, so a hit can only be a vector hit).

### Red evidence

The first two are the red step, committed on the unfixed tree
(`df42626bb6192dbe51fc1a34bd5a3dc95167c45d`, source untouched from `4467663`):

```
   × … errors instead of answering "No matches" when embeddings are switched off
     → expected undefined to be true
   × … names the provider and its cause when one was configured but is not running
     → expected undefined to be true
      Tests  2 failed | 19 passed (21)
```

`expected undefined to be true` is `res.isError` being absent — the tool answering normally
with an empty page, which is the symptom.

The recovery test is **green on the base tree**, by design: it is not a red step but a
guard on the one behaviour a refusal keyed on embedder *health* would break. Its positive
control is the rejected revision, where it fails:

```
   × … keeps ranking after a transient embedder failure, without an index rebuild
     → expected true to be undefined
```

— `isError: true` where the base tree returns hits.

## Gate

At `9f25f0cf4185596aaaa21f4f6fc3c2d66d1eaabe`, clean tree:

| command | result |
|---|---|
| `npm run typecheck` | pass |
| `npm run typecheck:tests` | pass |
| `npm run lint` | pass |
| `npm run build` | pass |
| `npm test` | **1254 passed, 7 skipped (1261) — 124 files passed, 2 skipped** |

Baseline at `4467663` measured directly: **1250 passed, 7 skipped**. The four added tests
are the whole delta.

`npx prettier --check .` fails on 206 files repo-wide including untouched ones, so it is not
a gate and nothing was reformatted.
