### PR TITLE
fix(router): keep pending callbacks scoped to their write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- An older read's desktop catch-up check no longer clears the pending marker for a newer
+  cloud write in the same library. Baseline probes also belong to the exact write that
+  started them, so two writes to the same key cannot inherit one another's baseline.
+
 ## [1.18.0] - 2026-09-10
 
 ### Fixed

--- a/src/router/library-router.ts
+++ b/src/router/library-router.ts
@@ -151,13 +151,14 @@ export class LibraryRouter {
     const key = keys[keys.length - 1];
     if (!key) return;
     const slot = this.librarySlot(lib);
-    this.pending.note(slot, { type, key, removed, before: undefined });
+    const write: PendingWrite = { type, key, removed, before: undefined };
+    this.pending.note(slot, write);
     // A delete is watched for the object disappearing, so it needs no baseline; and a
     // library the desktop does not serve has nothing to compare against.
     if (removed || !this.local || !this.useLocal(lib)) return;
     void this.local
       .objectVersion(type, key, lib)
-      .then((before) => this.pending.setBaseline(slot, key, before))
+      .then((before) => this.pending.setBaseline(slot, write, before))
       .catch(() => {
         // Without a baseline the write clears as soon as the desktop has the key at all.
         // That is exact for a create and weak for an update, which is the right way round:
@@ -179,8 +180,9 @@ export class LibraryRouter {
     const write = this.pending.get(slot);
     if (!write) return true;
     if (!(await this.desktopHasCaughtUp(library, write))) return false;
-    this.pending.clear(slot);
-    return true;
+    // A newer write may have arrived while the desktop check was in flight. Its state
+    // belongs to that write, not this read; keep this read on the cloud in that case too.
+    return this.pending.clear(slot, write);
   }
 
   /**

--- a/src/router/pending-writes.ts
+++ b/src/router/pending-writes.ts
@@ -46,16 +46,19 @@ export class PendingCloudWrites {
   }
 
   /**
-   * Fill in the baseline for a write that is still the pending one. Scoped to the key
-   * because the baseline is measured after the entry is recorded: a second write landing in
-   * between replaces the entry, and the first write's baseline must not be pasted onto it.
+   * Fill in the baseline only for the exact write that started the probe. The same key can
+   * be written twice while a probe is in flight; matching the key would let the older
+   * probe initialize the newer write with a version that predates it.
    */
-  setBaseline(slot: string, key: string, before: number | null): void {
+  setBaseline(slot: string, write: PendingWrite, before: number | null): void {
     const current = this.bySlot.get(slot);
-    if (current?.key === key && current.before === undefined) current.before = before;
+    if (current === write && current.before === undefined) current.before = before;
   }
 
-  clear(slot: string): void {
+  /** Retire only the write that a completed catch-up check actually witnessed. */
+  clear(slot: string, write: PendingWrite): boolean {
+    if (this.bySlot.get(slot) !== write) return false;
     this.bySlot.delete(slot);
+    return true;
   }
 }

--- a/tests/router/pending-write-generation.test.ts
+++ b/tests/router/pending-write-generation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LibraryRouter } from '../../src/router/library-router.js';
+import { loadConfig } from '../../src/config.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+function makeRouter() {
+  const local = {
+    objectVersion: vi.fn(async (_type: string, _key: string): Promise<number | null> => null),
+    listItems: vi.fn(async () => ({ data: [{ key: 'LOCAL' }] })),
+  };
+  const web = { listItems: vi.fn(async () => ({ data: [{ key: 'CLOUD' }] })) };
+  const router = new LibraryRouter({
+    config: loadConfig({ ZOTEUS_LOCAL: 'on' } as any),
+    capabilities: { cloud: { userID: 1 }, localApi: true, localGroupIds: [2] } as any,
+    local: local as any,
+    web: web as any,
+  });
+  return { router, local };
+}
+
+describe('pending writes across overlapping reads and writes', () => {
+  it.each(['user', 'group'] as const)('does not clear a newer %s write when an older read finishes', async (type) => {
+    const library = { type, id: type === 'user' ? 1 : 2 };
+    const { router, local } = makeRouter();
+    const check = deferred<number | null>();
+    local.objectVersion.mockResolvedValueOnce(null).mockImplementationOnce(() => check.promise);
+    router.noteCloudWrite(library, 'items', ['FIRST']);
+    await settle();
+    const olderRead = router.searchItems({ library });
+
+    router.noteCloudWrite(library, 'items', ['SECOND']);
+    await settle();
+    check.resolve(7);
+    expect((await olderRead).data[0].key).toBe('CLOUD');
+    // SECOND is still absent. The stale check must not remove its marker.
+    expect((await router.searchItems({ library })).data[0].key).toBe('CLOUD');
+    local.objectVersion.mockResolvedValue(8);
+    expect((await router.searchItems({ library })).data[0].key).toBe('LOCAL');
+  });
+
+  it('does not let an older baseline initialize a newer write to the same key', async () => {
+    const library = { type: 'user' as const, id: 1 };
+    const { router, local } = makeRouter();
+    const first = deferred<number | null>();
+    const second = deferred<number | null>();
+    local.objectVersion.mockImplementationOnce(() => first.promise).mockImplementationOnce(() => second.promise);
+    router.noteCloudWrite(library, 'items', ['SAME']);
+    router.noteCloudWrite(library, 'items', ['SAME']);
+    first.resolve(4);
+    await settle();
+    second.resolve(5);
+    await settle();
+
+    // Version 5 predates the second write; only its own baseline is meaningful.
+    local.objectVersion.mockResolvedValue(5);
+    expect((await router.searchItems()).data[0].key).toBe('CLOUD');
+    local.objectVersion.mockResolvedValue(6);
+    expect((await router.searchItems()).data[0].key).toBe('LOCAL');
+  });
+});


### PR DESCRIPTION
A read that finishes checking an older cloud write can clear the pending marker for a newer write in the same library. Later verification reads then use the desktop before the newer write has synced, recreating the missing-item/duplicate-write loop.

This PR scopes asynchronous callbacks to the exact PendingWrite object:

- A completed catch-up check retires only the write it checked. If another write replaced it, this read stays on the cloud.
- A delayed baseline probe initializes only its own write. Matching the key was insufficient when the same item was written twice before either probe finished.

Three deterministic regression cases fail on upstream `87122d4` and pass here: overlapping writes in personal and group libraries, and out-of-order baseline probes for repeated writes to one key. Each includes recovery to local reads once the current witness catches up.

Validation on Node 24.19.0:

- `npm run typecheck`, `npm run typecheck:tests`, `npm run lint`: pass.
- `npm test`: **1,623 passed, 8 skipped**.
- Combined with #81: all **61 router tests pass** and the build passes.

Review checked the same-key case, library isolation, pinned crawls, normal local recovery, and composition with the companion fix. The races were exercised through the real router with mocked endpoints and controlled promise ordering; no live Zotero timing claim is made. This does not change the existing single-witness synchronization heuristic.

Based directly on current upstream main. #81 concerns an unresolved baseline being mistaken for a synchronized update; neither source change depends on the other. If both land, retain both Unreleased changelog bullets (that is the only conflict in the tested combination).