### PR TITLE
fix(router): keep unknown write baselines on the cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Reads after a cloud update stay on the cloud while the desktop baseline probe is still
+  pending or has failed. An existing desktop item no longer counts as a synced update
+  merely because its key is present. If the baseline fails, the conservative override
+  lasts until a later write replaces the witness or the process ends.
+
 ## [1.18.0] - 2026-09-10
 
 ### Fixed

--- a/src/router/library-router.ts
+++ b/src/router/library-router.ts
@@ -159,9 +159,9 @@ export class LibraryRouter {
       .objectVersion(type, key, lib)
       .then((before) => this.pending.setBaseline(slot, key, before))
       .catch(() => {
-        // Without a baseline the write clears as soon as the desktop has the key at all.
-        // That is exact for a create and weak for an update, which is the right way round:
-        // it is the create whose absence sends an agent round the loop again.
+        // Keep the cloud override when no baseline could be established. Presence alone
+        // cannot distinguish a synced write from an existing item with stale fields.
+        // A later write may replace this witness; otherwise it lasts for this process.
       });
   }
 
@@ -191,6 +191,11 @@ export class LibraryRouter {
    */
   private async desktopHasCaughtUp(library: LibraryRef, write: PendingWrite): Promise<boolean> {
     if (!this.local) return false;
+    // The baseline request starts asynchronously after the write. Until it resolves,
+    // undefined is unknown, not "the item was absent". An existing item may still hold
+    // the old fields even when a second probe can already answer. Deletions need no
+    // baseline because absence itself witnesses them.
+    if (!write.removed && write.before === undefined) return false;
     let now: number | null;
     try {
       now = await this.local.objectVersion(write.type, write.key, library);
@@ -201,10 +206,10 @@ export class LibraryRouter {
     }
     if (write.removed) return now === null;
     if (now === null) return false;
-    // No baseline, or none to have: presence is the whole signal for a created object.
-    if (write.before === undefined || write.before === null) return true;
+    // A measured absence, unlike an unknown baseline, makes presence meaningful.
+    if (write.before === null) return true;
     // It already had the object, so only its own version moving proves the write landed.
-    return now > write.before;
+    return write.before !== undefined && now > write.before;
   }
 
   /** Item keys and versions (`?format=versions`), routed like every other read. */

--- a/src/router/pending-writes.ts
+++ b/src/router/pending-writes.ts
@@ -14,8 +14,10 @@ export interface PendingWrite {
   /** The write REMOVED the object, so catching up means the desktop no longer has it. */
   removed: boolean;
   /**
-   * The desktop's own version for that object immediately BEFORE the write: a number when
-   * it already had it, null when it did not, undefined when it could not be asked.
+   * The desktop's own version sampled by the baseline probe when the cloud write is
+   * reported: a number when it already had it, null when it did not, undefined while the
+   * probe is pending or if it failed. An unknown baseline must not release the cloud
+   * override merely because an object with that key exists.
    *
    * This is what separates "the desktop has an object with that key" from "the desktop has
    * THIS write". A create needs only the first (the key was absent and now is not), but an

--- a/tests/router/pending-write-baseline.test.ts
+++ b/tests/router/pending-write-baseline.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LibraryRouter } from '../../src/router/library-router.js';
+import { loadConfig } from '../../src/config.js';
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+function makeRouter() {
+  const local = {
+    objectVersion: vi.fn(async (): Promise<number | null> => 5),
+    listItems: vi.fn(async () => ({ data: [{ key: 'LOCAL' }] })),
+  };
+  const router = new LibraryRouter({
+    config: loadConfig({ ZOTEUS_LOCAL: 'on' } as any),
+    capabilities: { cloud: { userID: 1 }, localApi: true, localGroupIds: [2] } as any,
+    local: local as any,
+    web: { listItems: async () => ({ data: [{ key: 'CLOUD' }] }) } as any,
+  });
+  return { router, local };
+}
+
+describe('reads before a cloud write baseline is known', () => {
+  it.each(['user', 'group'] as const)('does not mistake a preexisting %s item for a synced update', async (type) => {
+    const library = { type, id: type === 'user' ? 1 : 2 };
+    const { router, local } = makeRouter();
+    let release!: (value: number | null) => void;
+    local.objectVersion.mockImplementationOnce(() => new Promise((r) => { release = r; }));
+    router.noteCloudWrite(library, 'items', ['EXISTING']);
+
+    // The read can finish while the baseline query is still in flight. Presence alone
+    // says nothing about whether the existing item's updated fields have reached Zotero.
+    expect((await router.searchItems({ library })).data[0].key).toBe('CLOUD');
+    release(5);
+    await settle();
+    expect((await router.searchItems({ library })).data[0].key).toBe('CLOUD');
+    local.objectVersion.mockResolvedValue(6);
+    expect((await router.searchItems({ library })).data[0].key).toBe('LOCAL');
+  });
+
+  it('does not treat a failed baseline as evidence that an existing item is current', async () => {
+    const { router, local } = makeRouter();
+    local.objectVersion.mockRejectedValueOnce(new Error('transient baseline failure'));
+    router.noteCloudWrite({ type: 'user', id: 1 }, 'items', ['EXISTING']);
+    await settle();
+    // Later probes could succeed but have no baseline to compare against.
+    expect((await router.searchItems()).data[0].key).toBe('CLOUD');
+  });
+
+  it('still releases a create after a known-absent baseline becomes present', async () => {
+    const { router, local } = makeRouter();
+    local.objectVersion.mockResolvedValueOnce(null);
+    router.noteCloudWrite({ type: 'user', id: 1 }, 'items', ['NEW']);
+    await settle();
+    expect((await router.searchItems()).data[0].key).toBe('LOCAL');
+  });
+
+  it('still releases a deletion without requiring a baseline', async () => {
+    const { router, local } = makeRouter();
+    local.objectVersion.mockResolvedValue(null);
+    router.noteCloudWrite({ type: 'user', id: 1 }, 'items', ['GONE'], true);
+    expect((await router.searchItems()).data[0].key).toBe('LOCAL');
+  });
+});


### PR DESCRIPTION
An existing desktop item can be mistaken for a synchronized cloud update while the router's baseline probe is still pending. `before: undefined` currently allows presence alone to clear the cloud override, even though the desktop may still hold the old fields.

This PR keeps unpinned reads on the cloud until a non-deletion write has a known baseline. A measured absence (`null`) still permits returning to local once the item appears, and deletions still use absence directly.

Three regression cases fail on upstream `87122d4` and pass here: an existing-item update with a delayed baseline in personal and group libraries, and a failed baseline followed by a responsive desktop. Two controls stay green before and after: a known-absent create and a deletion.

**Trade-off:** if the baseline probe fails, this PR keeps the library on the cloud until a later write replaces the witness or the process ends. It does not infer synchronization from an unrelated version or an arbitrary timeout. This is deliberately conservative and documented in the changelog. The probe is sampled after the cloud write is reported; this patch does not solve every limitation of that existing synchronization heuristic.

Validation on Node 24.19.0:

- `npm run typecheck`, `npm run typecheck:tests`, `npm run lint`: pass.
- `npm test`: **1,625 passed, 8 skipped**.
- Combined with #80: all **61 router tests pass** and the build passes.

Review checked delayed and failed probes, normal version advancement, known-absent creates, deletions, pinned crawls, and composition with #80. Tests use the real router with mocked endpoints and controlled promise ordering, not live-library smoke tests.

Based directly on upstream main `87122d4`; this does not depend on #80. Their source changes combine automatically. If both land, retain both Unreleased changelog bullets (the only conflict in the tested combination).