### PR TITLE
fix(search): top-level itemType filters (#79) and keyed full-text attachment map (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **The attachment map survives a slow or failing request, and no longer asks Zotero for a
+  deep offset at all (#78).** The map that attaches extracted body text to the item it
+  belongs to used to be built by paging `itemType=attachment` through the whole library, a
+  hundred rows at a time, and a single page that took longer than the per-request budget
+  ended the entire map. On the reporting library (10,733 items, 8,957 attachments with
+  extracted text) that happened reproducibly at the same offsets, at 1,414 and then 1,696 of
+  8,957, so roughly four fifths of the library's body text was never mapped and, before
+  1.18.0, a census-wide full-text cursor was stamped over the gap. Zotero 10.0.2 removed the
+  concurrency latency amplification behind it, and the aborts continued: with nothing else
+  touching the API, one deep page near the tail still occasionally exceeds the budget on its
+  own, which is what a deep offset costs when the app has to walk the library to reach it.
+
+  Two changes, and both were what the reporter asked for. A batch is now retried before it
+  is given up on: three attempts with a short backoff, and if it still does not answer, the
+  map records the keys it could not resolve and **carries on with the next batch** rather
+  than stopping. And the map is now driven by the `/fulltext?since=0` census it already
+  fetches, resolved in `itemKey=` batches of at most 50 (the cap both Zotero APIs enforce),
+  so no request depends on an offset and nothing pages the attachment listing. Those batches
+  keep the `itemType=attachment` filter the annotation lookups learned the hard way: the
+  desktop API answers a keyed lookup with the named items AND every descendant they have, so
+  without it a batch of fifty annotated attachments comes back as thousands of annotation
+  rows and the attachments fall off the end of the page. Rows are also folded in once, which
+  the page crawl could not guarantee: Zotero lists attachments newest-modified first, so an
+  attachment edited mid-crawl could be served on two pages and have its body text
+  concatenated under its item twice.
+
+  The honest trade: on a 9,000-attachment library this is about 180 keyed requests where the
+  crawl was 90 pages, so it is more requests, not fewer. The claim being tested is that a
+  small keyed lookup, answered out of Zotero's own index, survives where a `start=8000` page
+  does not, and that one batch failing now costs one batch instead of the whole map. On the
+  opposite library shape, a few hundred extracted attachments inside a large library, it is
+  a clear win in both directions: eight requests instead of a walk of the entire attachment
+  listing.
+
+  The guarantee from 1.18.0 is unchanged and is what decides `incomplete`: a full-text
+  cursor is never stamped over a map that does not cover the library. The map is incomplete
+  if, and only if, some batch of keys never got an answer at all after its retries, or
+  nothing at all resolved. An answer that simply does not name a key it was given is Zotero
+  saying it does not serve that attachment in this library view (a trashed attachment, on the
+  desktop API), which is exactly what the old crawl concluded when it walked the whole
+  listing and the key never appeared in it; treating that as incomplete would freeze the
+  cursor forever on any library holding one. A map that resolves nothing while Zotero says
+  the library has extracted text is the one answer never taken at face value: it refuses
+  every read, so an update keeps the body passages it already holds. The 500-page ceiling,
+  the deep-offset pagination and the "Zotero stopped serving the listing at N of M" case are
+  all gone with the crawl that produced them.
+
 ## [1.19.0] - 2026-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Zoteus are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`top: true` returned items that have a parent, so "only top-level items" was not true
+  of either API (#79).** Reported against 1.18.0 for `zotero_search_items` with
+  `itemType: "attachment", top: true`: six of the first ten results had a `parentItem`,
+  the same six every time, which left counting standalone attachments impossible without
+  verifying every key one at a time. Measured on 2026-09-12 against a 1302-item library
+  held by both a Zotero 10 desktop and the cloud, and the two APIs turn out to be wrong in
+  two different ways. The desktop local API drops the top-level restriction the moment an
+  `itemType` filter is present: `/items/top?itemType=attachment` answered `Total-Results:
+  363` with every item of the first page carrying a `parentItem`, byte for byte the same
+  answer as `/items?itemType=attachment`. `itemType=annotation` settles what that is,
+  since an annotation is never top-level and `/items/top` reported all 543 of them
+  regardless. The cloud Web API keeps its promise about `parentItem` and breaks the other
+  one: it maps every matching child up to its top-level parent, so the same request came
+  back as 263 preprints, books and conference papers, not one of them an attachment. The
+  true answer for that library is zero standalone attachments, and that is now what both
+  backends give.
+
+  Zoteus no longer asks either API to apply `top` alongside an `itemType` filter, and works
+  it out instead: the keys matching the filter, the library's top-level keys, and the
+  intersection of the two, which is the exact result set in the caller's own `sort` order.
+  `totalResults` is that set's size, not the inflated count the API reports, so the number
+  the tool prints and the pages it hands out come from one and the same list and paging
+  stays coherent (walking a 66-item result two pages at a time returns the same 66 keys in
+  the same order as one call for all of them). Only the page the caller asked for is read
+  as items, by key, which is what keeps this affordable: a whole key set costs a fraction
+  of the same items as JSON, 7 ms against 4.4 s for that library's 363 attachments, because
+  the desktop resolves a storage path per attachment. Both APIs are correct about `top`
+  when no `itemType` is in play, so that path is untouched, and the plain top-level listings
+  the search index and `zotero_tag_audit` page through behave exactly as before. Two
+  numbers that were quietly wrong are now right as a side effect: `itemType: "-attachment"`
+  with `top: true` reported 396 items where the library has 320 top-level items, and
+  `itemType: "annotation"` with `top: true` reported 543 where the answer is none.
+
 ## [1.19.0] - 2026-09-12
 
 ### Added

--- a/src/api/local-client.ts
+++ b/src/api/local-client.ts
@@ -167,6 +167,14 @@ export class LocalApiClient {
    * lookup that failed for it, and a bare status code would throw that away.
    */
   private async getRaw(path: string, query = ''): Promise<string> {
+    return (await this.getRawResponse(path, query)).text;
+  }
+
+  /** As `getRaw`, but keeping the headers: `format=keys` carries its count in them. */
+  private async getRawResponse(
+    path: string,
+    query = '',
+  ): Promise<{ text: string; headers: Headers }> {
     const res = await this.fetcher.fetch(
       `${this.base}${path}${query}`,
       { method: 'GET', headers: this.headers() },
@@ -179,7 +187,7 @@ export class LocalApiClient {
         `Local API ${res.status} for ${path}${body ? `: ${body}` : ''}`,
       );
     }
-    return res.text();
+    return { text: await res.text(), headers: res.headers };
   }
 
   private toListResult<T>(json: T[], headers: Headers): ListResult<T> {
@@ -239,6 +247,40 @@ export class LocalApiClient {
       this.buildQuery(rest as any),
     );
     return this.toListResult(json, headers);
+  }
+
+  /**
+   * The keys of a listing and nothing else (`format=keys`), in the query's own sort order.
+   *
+   * A whole key set costs a fraction of the same set of items: measured against Zotero 10
+   * on a 1302-item library, every attachment key came back in 7 ms where the same 363
+   * attachments as JSON took 4.4 s, because the desktop resolves storage paths per
+   * attachment. That gap is what makes it affordable for `top` to be resolved key-side
+   * (see LibraryRouter.topLevelItemsOfType) instead of by reading every candidate item.
+   *
+   * Neither API caps a `format=keys` response the way it caps a page of items, so a
+   * request with no `limit` answers with the whole set.
+   */
+  async listItemKeys(
+    query: ItemQuery = {},
+    lib?: LibraryRef,
+  ): Promise<{ keys: string[]; totalResults: number; lastModifiedVersion: number }> {
+    const { top: _t, collectionKey, ...rest } = query;
+    const base = collectionKey ? `/collections/${collectionKey}` : '';
+    const segment = query.top ? `${base}/items/top` : `${base}/items`;
+    const { text, headers } = await this.getRawResponse(
+      `${localLibraryPrefix(lib)}${segment}`,
+      this.buildQuery({ ...(rest as any), format: 'keys' }),
+    );
+    const keys = text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    return {
+      keys,
+      totalResults: numOrUndef(headers.get('total-results')) ?? keys.length,
+      lastModifiedVersion: numOrUndef(headers.get('last-modified-version')) ?? 0,
+    };
   }
 
   async getItem(

--- a/src/api/web-client.ts
+++ b/src/api/web-client.ts
@@ -218,6 +218,33 @@ export class WebApiClient {
     return this.toListResult(json, headers);
   }
 
+  /**
+   * The keys of a listing and nothing else (`format=keys`), in the query's own sort order.
+   * The cloud twin of `LocalApiClient.listItemKeys`, and the same bargain: keys only, no
+   * item bodies, and no page cap, so one request settles a whole set.
+   */
+  async listItemKeys(
+    lib: LibraryRef,
+    query: ItemQuery = {},
+  ): Promise<{ keys: string[]; totalResults: number; lastModifiedVersion: number }> {
+    const { top: _top, collectionKey, ...rest } = query;
+    const base = collectionKey ? `/collections/${collectionKey}` : '';
+    const segment = query.top ? `${base}/items/top` : `${base}/items`;
+    const { text, headers } = await this.getRaw(
+      this.prefix(lib) + segment,
+      this.buildQuery({ ...(rest as any), format: 'keys' }),
+    );
+    const keys = text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    return {
+      keys,
+      totalResults: numOrUndef(headers.get('total-results')) ?? keys.length,
+      lastModifiedVersion: numOrUndef(headers.get('last-modified-version')) ?? 0,
+    };
+  }
+
   async getItem(
     lib: LibraryRef,
     key: string,

--- a/src/features/search/fulltext-source.ts
+++ b/src/features/search/fulltext-source.ts
@@ -10,16 +10,41 @@ import type { VersionBackend } from './backend.js';
  */
 export const DEFAULT_FULLTEXT_MAX_CHARS = 40_000;
 
-/** Both Zotero APIs page items 100-at-a-time. */
-const ATTACHMENT_PAGE_SIZE = 100;
+/**
+ * Attachment keys per `?itemKey=` lookup. Both Zotero APIs cap that list at 50
+ * (`web-client.ts:64-69`), so this is the largest batch either of them will answer.
+ *
+ * Cost, stated honestly: on a 9k-attachment library the map now costs about 180 keyed
+ * requests where the old crawl cost 90 deep-offset pages. That is the trade #78 asks for.
+ * A deep page (`start=8000`) makes the desktop app walk the library to reach the offset and
+ * occasionally exceeds the whole per-request budget on its own, while a keyed lookup names
+ * what it wants and is answered out of Zotero's own index; and on the opposite library
+ * shape (a few hundred extracted attachments in a large library) the map is now a handful
+ * of requests rather than a walk of the whole attachment listing.
+ */
+const KEY_BATCH = 50;
+
+/** Attempts per keyed batch: the first, and then two retries. */
+const BATCH_ATTEMPTS = 3;
+
+/** Pause before the second attempt; doubled before the third. */
+const RETRY_BASE_MS = 200;
 
 /**
- * Ceiling on attachment pages walked while mapping attachments to their parent items, so
- * a library with a pathological number of attachments cannot page forever. The walk also
- * stops as soon as every attachment that HAS full text has been located, which is the
- * usual exit.
+ * How many passes are made over keys still unresolved. A healthy lookup names all fifty
+ * keys it was given, so a second pass only happens when an answer came back short or a
+ * batch failed outright, and the loop stops as soon as a pass resolves nothing new.
  */
-const MAX_ATTACHMENT_PAGES = 500;
+const MAX_SWEEPS = 3;
+
+/**
+ * Consecutive batches that may fail every attempt before the map stops asking. A desktop
+ * app that has quit partway through makes every batch fail, and paying three attempts and
+ * two backoffs for each of 180 batches would spend minutes learning what three batches in
+ * a row already said. The keys never asked about count as unanswered, exactly like the
+ * ones that were.
+ */
+const MAX_CONSECUTIVE_BATCH_FAILURES = 3;
 
 export interface FulltextSource {
   /**
@@ -60,10 +85,9 @@ export interface FulltextSource {
   unavailable?: string;
   /**
    * Set when this source holds only part of the library's body text, or none of it because
-   * it never opened: the attachment crawl did not reach the end of the library (a failed
-   * request, its page ceiling, or a listing that stopped serving pages short of its own
-   * total), or the census behind it failed. The cause alone, short enough to sit inside a
-   * sentence the caller composes.
+   * it never opened: a batch of attachment keys Zotero never answered even after its
+   * retries, a map that resolved nothing at all, or a census that failed. The cause alone,
+   * short enough to sit inside a sentence the caller composes.
    *
    * What it does NOT mean is a library with nothing extracted in it, which is a complete
    * answer. An incomplete source cannot tell "this item has no text" from "this item is on
@@ -113,12 +137,20 @@ function emptySource(unavailable?: string, incomplete?: string): FulltextSource 
  * Build the attachment -> parent-item map the index build needs to attach PDF body text to
  * the item it belongs to.
  *
- * Two cheap library-wide reads instead of per-item probing: `/fulltext?since=0` names every
- * attachment that HAS extracted text (one request), and paging `itemType=attachment` gives
- * each one its `parentItem`. Only the intersection is ever fetched, so the number of
- * full-text GETs equals the number of attachments that actually have text, the minimum
- * possible. Resolving it per item instead would cost an extra children request for every
- * item in the build, most of them for nothing.
+ * One cheap library-wide read and then keyed lookups, instead of per-item probing:
+ * `/fulltext?since=0` names every attachment that HAS extracted text (one request), and the
+ * census it answers with is resolved to parent items 50 keys at a time. Only the
+ * intersection is ever fetched, so the number of full-text GETs equals the number of
+ * attachments that actually have text, the minimum possible. Resolving it per item instead
+ * would cost an extra children request for every item in the build, most of them for
+ * nothing.
+ *
+ * The map used to page `itemType=attachment` through the whole library instead, and one
+ * deep page near the tail taking longer than the per-request budget ended the entire map,
+ * reproducibly at the same offsets on a 9k-attachment library (#78). Keyed lookups name
+ * what they want, so no request depends on an offset; a batch that fails is retried and
+ * then skipped rather than aborting the map; and the page ceiling and the deep-offset
+ * pagination are both gone.
  *
  * Never throws: a library whose full-text endpoints are unreachable (a cloud key without
  * file access, an offline desktop app) degrades to a metadata-only build with a reason
@@ -163,97 +195,120 @@ export async function createFulltextSource(
   const byItem = new Map<string, string[]>();
   /** The reverse of `byItem`: what `/fulltext?since=` answers in, mapped to what we index. */
   const parentOf = new Map<string, string>();
-  let mapped = 0;
   /** What this map is missing, if anything; becomes `incomplete` on the source. */
   let incomplete: string | undefined;
+  /** The first reason a keyed lookup failed, which is the one worth quoting. */
+  let why = '';
+
+  /** Fold one lookup's rows into the map. */
+  const absorb = (rows: any[]): void => {
+    for (const it of rows) {
+      const d = it.data ?? it;
+      const key = it.key ?? d.key;
+      // Census keys only, and each of them once. A keyed lookup can name a row this map
+      // never asked about, and a later sweep re-asks keys an earlier answer may already
+      // have named; counting one attachment twice would inflate the map AND concatenate
+      // that attachment's body text twice under its item.
+      if (!key || !(key in withText) || parentOf.has(key)) continue;
+      // A top-level attachment (no parent) is itself the indexed item.
+      const parent = d.parentItem ?? key;
+      const list = byItem.get(parent);
+      if (list) list.push(key);
+      else byItem.set(parent, [key]);
+      parentOf.set(key, parent);
+    }
+  };
+
   /**
-   * Whether the crawl below got to the end of what it was walking, which is the only thing
-   * that makes "this item is not in the map" mean "this item has no extracted text".
-   *
-   * It is tracked rather than inferred because the loop has four exits and only one of them
-   * throws. Two of them are ends: every attachment that HAS text has been located (the
-   * usual one, and it does not need the rest of the library), or the listing has been
-   * walked to its own stated total. The other two are truncations that raise no error at
-   * all: the page ceiling, and a page that comes back empty while the listing's own total
-   * says there is more to come. Deriving the flag from the `catch` alone left
-   * both of those stamping a census-wide cursor over a map that covered a fraction of the
-   * library (#78).
+   * One keyed lookup, retried a bounded number of times. `false` means Zotero never
+   * answered it at all, and that is the only thing that makes the map incomplete: an answer
+   * that simply does not name a key it was given is Zotero saying it does not serve that
+   * attachment in this library view, which is exactly what the old crawl concluded when it
+   * walked the whole listing and the key never appeared in it.
    */
-  let reachedEnd = false;
-  /** Why the crawl stopped short, when it did so without a request failing. */
-  let stoppedShort: string | undefined;
-  try {
-    let start = 0;
-    for (let page = 0; ; page++) {
-      // Every attachment with text is located. The rest of the library holds none, so
-      // there is nothing further this map could learn: a complete answer, not a truncation.
-      if (mapped >= total) {
-        reachedEnd = true;
-        break;
-      }
-      if (page >= MAX_ATTACHMENT_PAGES) {
-        stoppedShort =
-          `the crawl hit its ceiling of ${MAX_ATTACHMENT_PAGES} pages of ` +
-          `${ATTACHMENT_PAGE_SIZE} attachments without reaching the end of the library`;
-        break;
-      }
-      const res = await ctx.router.searchItems({
-        library,
-        backend,
-        itemType: 'attachment',
-        limit: ATTACHMENT_PAGE_SIZE,
-        start,
-      });
-      const items = res.data ?? [];
-      if (items.length === 0) {
-        // Nothing left to read. Against the listing's own total that is either the end of
-        // it, or Zotero stopping short of what it said it had; with no total to check it
-        // against, an empty page is the only end there is.
-        if (res.totalResults && start < res.totalResults) {
-          stoppedShort = `Zotero stopped serving the attachment listing at ${start} of ${res.totalResults}`;
-        } else {
-          reachedEnd = true;
+  const resolveBatch = async (batch: string[]): Promise<boolean> => {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        const res = await ctx.router.searchItems({
+          library,
+          backend,
+          itemKey: batch.join(','),
+          // Not decoration: the desktop API answers an `itemKey` lookup with the named
+          // items AND every descendant they have, so a batch of fifty annotated
+          // attachments comes back as thousands of annotation rows and the attachments
+          // this is looking for fall off the end of the page. Naming the type asks for
+          // exactly the fifty rows wanted, on both APIs. The same rule, learned the same
+          // way, governs the keyed lookups in `own-words-source.ts`.
+          itemType: 'attachment',
+          limit: KEY_BATCH,
+        });
+        absorb(res.data ?? []);
+        return true;
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        if (!why) why = reason;
+        if (attempt >= BATCH_ATTEMPTS) {
+          ctx.logger.warn(
+            `Could not resolve ${batch.length} attachment(s) to their items after ` +
+              `${BATCH_ATTEMPTS} attempts: ${reason}. The map carries on without them.`,
+          );
+          return false;
         }
-        break;
-      }
-      for (const it of items) {
-        const d = it.data ?? it;
-        const key = it.key ?? d.key;
-        if (!key || !(key in withText)) continue;
-        // A top-level attachment (no parent) is itself the indexed item.
-        const parent = d.parentItem ?? key;
-        const list = byItem.get(parent);
-        if (list) list.push(key);
-        else byItem.set(parent, [key]);
-        parentOf.set(key, parent);
-        mapped++;
-      }
-      start += items.length;
-      if (res.totalResults && start >= res.totalResults) {
-        reachedEnd = true;
-        break;
+        await new Promise((r) => setTimeout(r, RETRY_BASE_MS * 2 ** (attempt - 1)));
       }
     }
-  } catch (e) {
-    const why = e instanceof Error ? e.message : String(e);
-    // Whatever was mapped before the failure is still usable; only say so when nothing was.
-    if (mapped === 0) {
-      return emptySource(
-        `Attachments could not be listed (${why}). The index was built from metadata only.`,
-        `attachments could not be listed: ${why}`,
-      );
+  };
+
+  // Sorted so the batches are deterministic, which is what makes a failure reproducible and
+  // lets a report name the batch that failed.
+  let pending = Object.keys(withText).sort();
+  /** Keys whose lookup never answered, on the last pass. Non-empty => incomplete. */
+  let unanswered: string[] = [];
+  for (let sweep = 0; sweep < MAX_SWEEPS && pending.length; sweep++) {
+    const before = parentOf.size;
+    const failed: string[] = [];
+    let consecutive = 0;
+    for (let i = 0; i < pending.length; i += KEY_BATCH) {
+      if (consecutive >= MAX_CONSECUTIVE_BATCH_FAILURES) {
+        // Zotero has stopped answering this map altogether. Everything left counts as
+        // unanswered, and asking is no longer worth the requests.
+        failed.push(...pending.slice(i));
+        break;
+      }
+      const batch = pending.slice(i, i + KEY_BATCH);
+      // One batch failing does not end the map: the batches after it are still asked, which
+      // is the whole point (#78).
+      if (await resolveBatch(batch)) consecutive = 0;
+      else {
+        consecutive++;
+        failed.push(...batch);
+      }
     }
-    stoppedShort = why;
+    unanswered = failed;
+    pending = pending.filter((k) => !parentOf.has(k));
+    // Nothing new came back: another identical pass would cost requests and learn nothing.
+    if (parentOf.size === before) break;
   }
-  if (!reachedEnd) {
-    // Usable, but no longer able to say that an item it does not hold has no text: the item
-    // may simply sit on the pages this crawl never reached (#67). Same sentence whichever
-    // door the crawl left by, and the same one it has always had when a request threw,
-    // because that text is what a report of this quotes.
-    incomplete = `the attachment map stopped early after ${mapped}/${total} attachment(s): ${stoppedShort}`;
-    ctx.logger.warn(
-      `Full-text mapping stopped early after ${mapped}/${total} attachments: ${stoppedShort}`,
+
+  const mapped = parentOf.size;
+  if (mapped === 0) {
+    // Zotero says this library holds attachments with extracted text, and named none of
+    // them when asked for them by key. That is a broken map rather than a library view
+    // without them, and it must refuse every read rather than report an empty answer an
+    // update would index over the body text it already holds (#67).
+    const reason = why || 'Zotero named none of them when asked for them by key';
+    return emptySource(
+      `The attachment map stopped early after 0/${total} attachment(s): ${reason}. ` +
+        'The index was built from metadata only.',
+      `the attachment map stopped early after 0/${total} attachment(s): ${reason}`,
     );
+  }
+  if (unanswered.length) {
+    // Usable, but no longer able to say that an item it does not hold has no text: the item
+    // may belong to one of the batches Zotero never answered (#67). The same sentence the
+    // crawl used when a page failed, because that text is what a report of this quotes.
+    incomplete = `the attachment map stopped early after ${mapped}/${total} attachment(s): ${why}`;
+    ctx.logger.warn(`Full-text mapping stopped early after ${mapped}/${total} attachments: ${why}`);
   }
 
   let failures = 0;

--- a/src/router/library-router.ts
+++ b/src/router/library-router.ts
@@ -13,6 +13,15 @@ import type { LocalApiClient, SyncObjectType } from '../api/local-client.js';
 import type { VersionBackend } from '../features/search/backend.js';
 import { PendingCloudWrites, type PendingWrite } from './pending-writes.js';
 
+/**
+ * Keys per `?itemKey=` request. Both APIs cap that list at 50, so a full page of 100
+ * results is two requests rather than one refusal.
+ */
+const ITEM_KEY_BATCH = 50;
+
+/** The page size a caller that named no `limit` gets, matching zotero_search_items. */
+const DEFAULT_PAGE = 25;
+
 export interface LibraryRouterOptions {
   config: ZoteusConfig;
   capabilities: Capabilities;
@@ -220,8 +229,88 @@ export class LibraryRouter {
   async searchItems(query: ItemQuery & ReadOpts = {}): Promise<ListResult> {
     const { library, backend, ...q } = query;
     const lib = library ?? this.defaultLibrary();
+    // `top` combined with an `itemType` filter is the one shape neither API answers the
+    // way the tool promises, so Zoteus works it out itself (#79).
+    if (q.top && q.itemType) return this.topLevelItemsOfType(lib, backend, q);
     if (await this.route(lib, backend)) return this.local!.listItems(q, lib);
     return this.web.listItems(lib, q);
+  }
+
+  /**
+   * `top: true` together with an `itemType` filter, resolved by Zoteus rather than by the
+   * API, because neither API answers that combination the way `top` is documented
+   * ("Only top-level items"). Measured on 2026-09-12 against a 1302-item library held by
+   * both a Zotero 10 desktop and the cloud, asking for `itemType=attachment, top=true`:
+   *
+   *   - the desktop local API DROPS the top-level restriction as soon as an `itemType`
+   *     filter is present. `/items/top?itemType=attachment` answered Total-Results 363
+   *     with all ten items of the first page carrying a `parentItem`, byte for byte the
+   *     same answer as `/items?itemType=attachment`. `itemType=annotation` settles it:
+   *     an annotation is never top-level, yet `/items/top` reported all 543 of them.
+   *     This is what #79 reported.
+   *   - the cloud Web API keeps its promise about `parentItem` but breaks the other one:
+   *     it maps each matching child UP to its top-level parent, so the same request came
+   *     back as 263 preprints, books and conference papers, not one of them an
+   *     attachment. No `parentItem` anywhere, and no item of the requested type either.
+   *
+   * The true answer for that library is zero standalone attachments, which is what this
+   * method returns on both backends.
+   *
+   * Both APIs are correct about `top` with no `itemType` in play (`/items/top` alone gave
+   * 320 of 1302, none with a `parentItem`; `/items/top?itemKey=<child>` answers with
+   * nothing), so the restriction is only ever taken away from them for this one shape,
+   * and the ordinary `top` listing that the search index and zotero_tag_audit page
+   * through is left exactly as it was.
+   *
+   * `totalResults` is EXACT, not an estimate and not the API's inflated count: the whole
+   * key set is intersected before anything is sliced, so the number the tool reports and
+   * the pages it hands out come from one and the same list. That is affordable only
+   * because keys are cheap (see `listItemKeys`); reading every candidate item instead
+   * would have cost seconds per search on attachments alone.
+   */
+  private async topLevelItemsOfType(
+    lib: LibraryRef,
+    backend: VersionBackend | undefined,
+    q: ItemQuery,
+  ): Promise<ListResult> {
+    const useLocal = await this.route(lib, backend);
+    const keysOf = (query: ItemQuery) =>
+      useLocal ? this.local!.listItemKeys(query, lib) : this.web.listItemKeys(lib, query);
+    const itemsOf = (query: ItemQuery) =>
+      useLocal ? this.local!.listItems(query, lib) : this.web.listItems(lib, query);
+
+    const { top: _top, limit, start, ...filters } = q;
+    // The second read is deliberately filter-free apart from `includeTrashed`: it is the
+    // library's top-level key set, the fact the APIs get right, and the filters are
+    // already accounted for by the first read. Giving it the `itemType` back would walk
+    // straight into the bug this method exists to route around.
+    const [matching, topLevel] = await Promise.all([
+      keysOf({ ...filters, top: false }),
+      keysOf({ top: true, includeTrashed: filters.includeTrashed }),
+    ]);
+    const isTopLevel = new Set(topLevel.keys);
+    const hits = matching.keys.filter((key) => isTopLevel.has(key));
+
+    const from = start ?? 0;
+    const wanted = hits.slice(from, from + (limit ?? DEFAULT_PAGE));
+    const fetched = new Map<string, any>();
+    for (let i = 0; i < wanted.length; i += ITEM_KEY_BATCH) {
+      const batch = wanted.slice(i, i + ITEM_KEY_BATCH);
+      // `top: true` matters on the desktop, whose `?itemKey=` on plain /items answers with
+      // the named items AND every descendant they have (77 items for three keys, measured);
+      // on /items/top it is exactly the keys asked for. Every key here is top-level by
+      // construction, so nothing the caller should see is filtered out by asking that way.
+      const page = await itemsOf({ itemKey: batch.join(','), top: true, limit: batch.length });
+      for (const item of page.data) if (item?.key) fetched.set(item.key, item);
+    }
+
+    return {
+      // Back in the order the keys came in, which is the caller's `sort`: neither API
+      // promises to honour the order of an `itemKey` list.
+      data: wanted.map((key) => fetched.get(key)).filter(Boolean),
+      totalResults: hits.length,
+      lastModifiedVersion: matching.lastModifiedVersion,
+    };
   }
 
   async getItem(

--- a/tests/api/local-client.test.ts
+++ b/tests/api/local-client.test.ts
@@ -592,4 +592,40 @@ describe('LocalApiClient tag and sync-delta reads', () => {
       status: 500,
     });
   });
+
+  // #79: `top` on an itemType-filtered search is resolved from key sets rather than by
+  // trusting `/items/top`, so the keys read is the request that has to be exactly right.
+  describe('listItemKeys', () => {
+    it('reads /items with format=keys and splits the plain-text body', async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        expect(url).toContain('/users/0/items?');
+        expect(url).not.toContain('/items/top');
+        expect(url).toContain('format=keys');
+        expect(url).toContain('itemType=attachment');
+        return new Response('AAAAAAAA\nBBBBBBBB\nCCCCCCCC', {
+          status: 200,
+          headers: { 'Total-Results': '3', 'Last-Modified-Version': '681' },
+        });
+      });
+      const res = await makeLocal(fetchImpl).listItemKeys({ itemType: 'attachment' });
+      expect(res.keys).toEqual(['AAAAAAAA', 'BBBBBBBB', 'CCCCCCCC']);
+      expect(res.totalResults).toBe(3);
+      expect(res.lastModifiedVersion).toBe(681);
+    });
+
+    it('reads /items/top for the top-level key set', async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        expect(url).toContain('/users/0/items/top?');
+        expect(url).toContain('format=keys');
+        return new Response('AAAAAAAA\n', { status: 200, headers: { 'Total-Results': '1' } });
+      });
+      const res = await makeLocal(fetchImpl).listItemKeys({ top: true });
+      expect(res.keys).toEqual(['AAAAAAAA']);
+    });
+
+    it('reads an empty key set as no keys rather than one blank one', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200, headers: { 'Total-Results': '0' } }));
+      expect((await makeLocal(fetchImpl).listItemKeys({ itemType: 'book' })).keys).toEqual([]);
+    });
+  });
 });

--- a/tests/api/web-client.test.ts
+++ b/tests/api/web-client.test.ts
@@ -99,4 +99,37 @@ describe('WebApiClient', () => {
     const schema = await makeClient(fetchImpl).getSchema();
     expect(schema.version).toBe(39);
   });
+
+  // #79, the cloud half: same key sets, same guarantee.
+  describe('listItemKeys', () => {
+    it('reads /items with format=keys and splits the plain-text body', async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        expect(url).toContain('/users/19552201/items?');
+        expect(url).not.toContain('/items/top');
+        expect(url).toContain('format=keys');
+        expect(url).toContain('itemType=attachment');
+        return new Response('AAAAAAAA\nBBBBBBBB', {
+          status: 200,
+          headers: { 'Total-Results': '2', 'Last-Modified-Version': '3476' },
+        });
+      });
+      const res = await makeClient(fetchImpl).listItemKeys(
+        { type: 'user', id: 19552201 },
+        { itemType: 'attachment' },
+      );
+      expect(res.keys).toEqual(['AAAAAAAA', 'BBBBBBBB']);
+      expect(res.totalResults).toBe(2);
+      expect(res.lastModifiedVersion).toBe(3476);
+    });
+
+    it('reads /items/top for the top-level key set', async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        expect(url).toContain('/users/19552201/items/top?');
+        expect(url).toContain('format=keys');
+        return new Response('AAAAAAAA', { status: 200, headers: { 'Total-Results': '1' } });
+      });
+      const res = await makeClient(fetchImpl).listItemKeys({ type: 'user', id: 19552201 }, { top: true });
+      expect(res.keys).toEqual(['AAAAAAAA']);
+    });
+  });
 });

--- a/tests/features/search-fulltext-cursor.test.ts
+++ b/tests/features/search-fulltext-cursor.test.ts
@@ -65,10 +65,13 @@ class FakeZotero {
         const start = q.start ?? 0;
         const limit = q.limit ?? PAGE_SIZE;
         if (q.itemType === 'attachment') {
-          const page = atts().slice(start, start + limit);
+          // The map asks for attachments by key, 50 at a time, so this answers by key.
+          const want = q.itemKey ? new Set(String(q.itemKey).split(',')) : undefined;
+          const all = want ? atts().filter((a) => want.has(a.key)) : atts();
+          const page = all.slice(start, start + limit);
           return {
             data: page.map((a) => ({ key: a.key, data: { key: a.key, itemType: 'attachment', parentItem: a.parent } })),
-            totalResults: atts().length,
+            totalResults: all.length,
             lastModifiedVersion: this.itemVersion,
           };
         }
@@ -465,19 +468,16 @@ describe.each(backends)('a build whose attachment map stopped early (%s backend)
   });
 
   /**
-   * The two doors out of the page loop that are not the `catch`. Neither throws, so
-   * neither used to mark the map incomplete, and the census-wide cursor was stamped over a
-   * map that had covered a fraction of the library: the same silent gap, reached without
-   * a failed request. The predicate has to mean what it says: the map did not reach the
-   * end of the library.
+   * The map resolving NOTHING is the one answer that is never taken at face value. Zotero
+   * has just said this library holds attachments with extracted text; a keyed lookup that
+   * names none of them is a broken map, not a library view without them, and stamping a
+   * census-wide cursor over it is the silent gap #78 is about, reached without any request
+   * failing at all.
    */
-  it('marks the map incomplete when the crawl runs out of pages', async () => {
-    // 503 attachments Zotero has never opened, and behind them the two it has. The crawl
-    // spends its whole page ceiling on the unextracted ones and never reaches the text.
+  it('withholds the cursor when the keyed lookups resolve no attachment at all', async () => {
     const zotero = new FakeZotero();
     zotero.putItem('K1', 'Deep learning', 'convolutional networks classify images');
     zotero.putItem('K2', 'Photovoltaic perovskites', 'tandem cell stability');
-    for (let i = 0; i < 503; i++) zotero.attach(`PAD${i}`, 'K1');
     zotero.attach('ATT1', 'K1');
     zotero.attach('ATT2', 'K2');
     zotero.extract('ATT1', BODY_ONE);
@@ -486,9 +486,11 @@ describe.each(backends)('a build whose attachment map stopped early (%s backend)
     const search = await openIndex(backend);
     const router = zotero.router();
     const listing = router.searchItems;
-    // One attachment per page, so the 500-page ceiling is what ends this crawl.
+    // Zotero answers the keyed lookup, and names nothing.
     router.searchItems = vi.fn(async (q: any) =>
-      q.itemType === 'attachment' ? listing({ ...q, limit: 1 }) : listing(q),
+      q.itemType === 'attachment'
+        ? { data: [], totalResults: 0, lastModifiedVersion: zotero.itemVersion }
+        : listing(q),
     );
     startIndexBuild(makeCtx(search, router), undefined, undefined, { fulltext: true });
     await settle(search);
@@ -501,44 +503,42 @@ describe.each(backends)('a build whose attachment map stopped early (%s backend)
     await search.close();
   });
 
-  it('marks the map incomplete when a page comes back empty with the listing unfinished', async () => {
+  /**
+   * The other side of that rule, and it has to hold or the cursor freezes forever: an
+   * attachment Zotero ANSWERS about without naming is one it does not serve in this
+   * library view (a trashed attachment, on the desktop API), which is exactly what the old
+   * crawl concluded when it walked the whole listing and never saw the key. The rest of
+   * the map is whole, so the cursor is stamped.
+   */
+  it('stamps the cursor when a lookup answers without naming one of its keys', async () => {
     const zotero = threeExtracted();
     const search = await openIndex(backend);
     const router = zotero.router();
     const listing = router.searchItems;
-    let attachmentPages = 0;
     router.searchItems = vi.fn(async (q: any) => {
       if (q.itemType !== 'attachment') return listing(q);
-      // One attachment, then nothing at all, although the listing's own total says two
-      // thirds of the library's attachments are still to come.
-      if (attachmentPages++ > 0) return { data: [], totalResults: 3, lastModifiedVersion: zotero.itemVersion };
-      return listing({ ...q, limit: 1 });
+      const res = await listing(q);
+      return { ...res, data: res.data.filter((row: any) => row.key !== 'ATT3') };
     });
     startIndexBuild(makeCtx(search, router), undefined, undefined, { fulltext: true });
     await settle(search);
 
     const s = search.buildStatus();
     expect(s.state).toBe('done');
-    expect(s.fulltextItems).toBe(1);
-    expect(s.fulltextVersion).toBe(0);
-    expect(s.fulltextReason).toMatch(/attachment map stopped early after 1\/3/);
+    expect(s.fulltextItems).toBe(2);
+    expect(s.fulltextVersion).toBe(zotero.fulltextVersion);
+    expect(s.fulltextReason).toBeUndefined();
     await search.close();
   });
 
-  /** The usual exit is not a truncation: every attachment with text was located. */
-  it('stamps the cursor when the map located every attachment that has text', async () => {
+  /** The usual exit: every attachment with text was resolved, by key, in one batch. */
+  it('stamps the cursor over a keyed map, and never pages the attachment listing', async () => {
     const zotero = threeExtracted();
-    // Three more attachments Zotero has never opened, sitting after the extracted ones, so
-    // the crawl stops on `mapped === total` with pages of the library still unread.
+    // Three more attachments Zotero has never opened. The map is driven by the full-text
+    // census, so they cost no request at all: nothing walks the attachment listing.
     for (let i = 0; i < 3; i++) zotero.attach(`PAD${i}`, 'K1');
     const search = await openIndex(backend);
     const router = zotero.router();
-    const listing = router.searchItems;
-    // One at a time, so the crawl exits on "every attachment with text is located" with
-    // half the listing still unwalked, which is the exit it takes on a real library.
-    router.searchItems = vi.fn(async (q: any) =>
-      q.itemType === 'attachment' ? listing({ ...q, limit: 1 }) : listing(q),
-    );
     startIndexBuild(makeCtx(search, router), undefined, undefined, { fulltext: true });
     await settle(search);
 
@@ -546,6 +546,15 @@ describe.each(backends)('a build whose attachment map stopped early (%s backend)
     expect(s.fulltextItems).toBe(3);
     expect(s.fulltextVersion).toBe(zotero.fulltextVersion);
     expect(s.fulltextReason).toBeUndefined();
+
+    // Three extracted attachments is one batch of keys, and no offset is ever requested:
+    // the deep pages that timed out on a 9k-attachment library are gone (#78).
+    const lookups = router.searchItems.mock.calls
+      .map((c: any[]) => c[0])
+      .filter((q: any) => q.itemType === 'attachment');
+    expect(lookups).toHaveLength(1);
+    expect(lookups[0].itemKey.split(',').sort()).toEqual(['ATT1', 'ATT2', 'ATT3']);
+    expect(lookups.every((q: any) => q.start === undefined)).toBe(true);
     await search.close();
   });
 });

--- a/tests/features/search-fulltext-throttle.test.ts
+++ b/tests/features/search-fulltext-throttle.test.ts
@@ -58,7 +58,12 @@ function makeCtx(opts: {
 
   const searchItems = vi.fn(async (q: any) => {
     const start = q.start ?? 0;
-    const source = q.itemType === 'attachment' ? attachments : items;
+    let source: any[] = q.itemType === 'attachment' ? attachments : items;
+    // The attachment map asks by key, 50 at a time, so the double has to answer by key.
+    if (q.itemKey) {
+      const want = new Set(String(q.itemKey).split(','));
+      source = source.filter((row) => want.has(row.key));
+    }
     return {
       data: source.slice(start, start + (q.limit ?? PAGE_SIZE)),
       totalResults: source.length,

--- a/tests/features/search-fulltext.test.ts
+++ b/tests/features/search-fulltext.test.ts
@@ -108,8 +108,10 @@ function makeCtx(opts: {
   withText?: Record<string, number>;
   fulltext?: Record<string, any>;
   sinceThrows?: boolean;
-  /** Page the attachment crawl one at a time and fail its second page, mid-map. */
-  pageTwoThrows?: boolean;
+  /** Fail the first N keyed attachment lookups, whichever keys they name. */
+  failFirstLookups?: number;
+  /** Fail every keyed lookup naming one of these attachment keys, forever. */
+  failKeys?: string[];
   config?: Record<string, string>;
 } = {}) {
   const attachments = opts.attachments ?? [];
@@ -119,12 +121,23 @@ function makeCtx(opts: {
     return withText;
   });
   const getFullText = vi.fn(async (key: string) => opts.fulltext?.[key] ?? null);
+  const BUDGET = 'Zotero took longer than the 25s budget to answer a single request';
+  let lookups = 0;
   const searchItems = vi.fn(async (q: any) => {
     const start = q.start ?? 0;
     const source = q.itemType === 'attachment' ? attachments : [];
-    if (opts.pageTwoThrows && q.itemType === 'attachment' && start > 0) throw new Error('page two gone');
-    const size = opts.pageTwoThrows ? 1 : (q.limit ?? PAGE_SIZE);
-    return { data: source.slice(start, start + size), totalResults: source.length, lastModifiedVersion: 1 };
+    // The attachment map asks by key, so the double answers by key, as both APIs do.
+    const want = q.itemKey ? new Set(String(q.itemKey).split(',')) : undefined;
+    if (q.itemType === 'attachment') {
+      if (++lookups <= (opts.failFirstLookups ?? 0)) throw new Error(BUDGET);
+      if (want && opts.failKeys?.some((k) => want.has(k))) throw new Error(BUDGET);
+    }
+    const rows = want ? source.filter((row: any) => want.has(row.key)) : source;
+    return {
+      data: rows.slice(start, start + (q.limit ?? PAGE_SIZE)),
+      totalResults: rows.length,
+      lastModifiedVersion: 1,
+    };
   });
   const ctx: any = {
     config: loadConfig((opts.config ?? {}) as any),
@@ -239,19 +252,95 @@ describe('createFulltextSource', () => {
     expect(src.readFailures()).toBe(1);
   });
 
-  it('refuses to answer for an item its attachment map never reached', async () => {
-    // The map stopped early, so an item it does not hold may simply be on the pages this
-    // crawl never read. Saying "no text" there is a guess an update would index (#67).
+  it('refuses to answer for an item whose batch of keys Zotero never answered', async () => {
+    // A batch that never answered leaves its items unknown, so an item the map does not
+    // hold may simply belong to it. Saying "no text" there is a guess an update would
+    // index over the body passages the item already has (#67).
     const { ctx } = makeCtx({
       attachments: [attachment('ATT1', 'ITEM1'), attachment('ATT2', 'ITEM2')],
       withText: { ATT1: 1, ATT2: 2 },
       fulltext: { ATT1: { content: 'first body' } },
-      pageTwoThrows: true,
+      // ATT1 and ATT2 are one batch, so break it after a first pass has mapped ATT1: the
+      // sweep over what is left is what fails for good.
+      failKeys: ['ATT2'],
     });
+    // Resolve ATT1 out of band, the way a first pass does, then let the sweep fail.
+    ctx.router.searchItems.mockImplementationOnce(async () => ({
+      data: [attachment('ATT1', 'ITEM1')],
+      totalResults: 1,
+      lastModifiedVersion: 1,
+    }));
     const src = await createFulltextSource(ctx, undefined);
-    expect(src.incomplete).toMatch(/attachment map stopped early after 1\/2 attachment\(s\): page two gone/);
+    expect(src.incomplete).toMatch(/attachment map stopped early after 1\/2 attachment\(s\): .*25s budget/);
     expect(await src.textFor('ITEM1')).toBe('first body');
     await expect(src.textFor('ITEM2')).rejects.toThrow(/stopped early/);
+  });
+
+  /** #78: the map is driven by the full-text census, in keyed batches, never by offsets. */
+  describe('keyed batching (#78)', () => {
+    /** `n` attachments, each under its own item, all of them extracted. */
+    function manyAttachments(n: number) {
+      const attachments = Array.from({ length: n }, (_, i) => attachment(key(i), `ITEM${i}`));
+      const withText = Object.fromEntries(attachments.map((a, i) => [a.key, i + 1]));
+      const fulltext = Object.fromEntries(attachments.map((a) => [a.key, { content: `body of ${a.key}` }]));
+      return { attachments, withText, fulltext };
+    }
+    /** Zero-padded, so the map's sorted batches are the obvious ones. */
+    const key = (i: number) => `A${String(i).padStart(3, '0')}`;
+
+    /** Every attachment lookup the map issued. */
+    const lookups = (searchItems: any) =>
+      searchItems.mock.calls.map((c: any[]) => c[0]).filter((q: any) => q.itemType === 'attachment');
+
+    it('asks by key, at most 50 at a time, and never asks for an offset', async () => {
+      const { ctx, searchItems } = makeCtx(manyAttachments(120));
+      const src = await createFulltextSource(ctx, undefined);
+
+      expect(src.incomplete).toBeUndefined();
+      expect(src.attachments).toBe(120);
+      const asked = lookups(searchItems);
+      expect(asked).toHaveLength(3); // 50 + 50 + 20
+      for (const q of asked) {
+        expect(q.itemKey.split(',').length).toBeLessThanOrEqual(50);
+        expect(q.limit).toBe(50);
+        // The load-bearing filter: an `itemKey` lookup on the desktop API answers with the
+        // named items AND all their descendants unless the type is named.
+        expect(q.itemType).toBe('attachment');
+        expect(q.start).toBeUndefined();
+      }
+      // Sorted keys, so batch one is exactly the first fifty.
+      expect(asked[0].itemKey.split(',')).toEqual(Array.from({ length: 50 }, (_, i) => key(i)));
+    });
+
+    it('retries a batch that fails twice and then succeeds, and stays complete', async () => {
+      const { ctx, searchItems } = makeCtx({ ...manyAttachments(20), failFirstLookups: 2 });
+      const src = await createFulltextSource(ctx, undefined);
+
+      // Two failures, then the answer: the map is whole, so the cursor may be stamped.
+      expect(lookups(searchItems)).toHaveLength(3);
+      expect(src.incomplete).toBeUndefined();
+      expect(src.attachments).toBe(20);
+      expect(src.maxVersion).toBe(20);
+      expect(await src.textFor('ITEM7')).toBe(`body of ${key(7)}`);
+    });
+
+    it('carries on past a batch that never answers, and ends incomplete', async () => {
+      // The middle batch is broken for good; the third must still be asked for. Before
+      // this, one failed request ended the whole map (#78).
+      const { ctx, searchItems } = makeCtx({ ...manyAttachments(120), failKeys: [key(60)] });
+      const src = await createFulltextSource(ctx, undefined);
+
+      expect(src.attachments).toBe(70); // batches one and three
+      expect(src.items).toBe(70);
+      expect(src.incomplete).toMatch(/attachment map stopped early after 70\/120 attachment\(s\)/);
+      // The batch after the broken one was asked for, and its text is served.
+      expect(await src.textFor('ITEM110')).toBe(`body of ${key(110)}`);
+      // Three attempts on the failing batch in the first pass, three more in the sweep.
+      const failed = lookups(searchItems).filter((q: any) => q.itemKey.includes(key(60)));
+      expect(failed).toHaveLength(6);
+      // An item on the batch that never answered is unknown, not textless (#67).
+      await expect(src.textFor('ITEM60')).rejects.toThrow(/stopped early/);
+    });
   });
 });
 
@@ -301,6 +390,31 @@ describe('startIndexBuild with full text', () => {
     const hits = await ctx.search.query('eleven percent throughput', { limit: 1 });
     expect(hits[0]!.itemKey).toBe('K1');
     expect(hits[0]!.source).toBe('fulltext');
+  });
+
+  it('stamps the full-text cursor over a map whose retries made it whole (#78)', async () => {
+    const { ctx } = makeCtx({
+      attachments: [attachment('ATT1', 'K1')],
+      withText: { ATT1: 9 },
+      fulltext: { ATT1: { content: BODY } },
+      failFirstLookups: 2,
+    });
+    const items = makeLibrary(3);
+    const listAttachments = ctx.router.searchItems;
+    ctx.router.searchItems = vi.fn(async (q: any) =>
+      q.top ? { data: items.slice(q.start ?? 0), totalResults: items.length, lastModifiedVersion: 1 } : listAttachments(q),
+    );
+
+    startIndexBuild(ctx, undefined, undefined, { fulltext: true });
+    await finished(ctx.search);
+
+    const s = ctx.search.buildStatus();
+    expect(s.state).toBe('done');
+    expect(s.fulltextItems).toBe(1);
+    // Two failed attempts cost the map nothing: it is whole, so the cursor is stamped and
+    // the next update asks Zotero's full-text sequence from there rather than from 0.
+    expect(s.fulltextReason).toBeUndefined();
+    expect(s.fulltextVersion).toBe(9);
   });
 
   it('says why a requested full-text build produced nothing', async () => {

--- a/tests/features/search-fulltext.test.ts
+++ b/tests/features/search-fulltext.test.ts
@@ -146,6 +146,26 @@ function attachment(key: string, parent?: string) {
   return { key, data: { key, itemType: 'attachment', contentType: 'application/pdf', parentItem: parent } };
 }
 
+/**
+ * A saved web page, which is what Zotero stores for a `webpage` item: `imported_url` rather
+ * than `imported_file`, and `text/html` rather than a PDF. Zotero extracts its text into the
+ * same full-text index a PDF's goes into and serves it from the same `/fulltext` endpoint, so
+ * nothing downstream of the census may treat it differently (#78).
+ */
+function htmlSnapshot(key: string, parent?: string) {
+  return {
+    key,
+    data: {
+      key,
+      itemType: 'attachment',
+      contentType: 'text/html',
+      linkMode: 'imported_url',
+      filename: 'index.html',
+      parentItem: parent,
+    },
+  };
+}
+
 describe('createFulltextSource', () => {
   it('maps attachments to their parent and fetches only those that have text', async () => {
     const { ctx, getFullText } = makeCtx({
@@ -164,6 +184,26 @@ describe('createFulltextSource', () => {
     // Never fetched: the un-extracted attachment costs no request at all.
     expect(getFullText).toHaveBeenCalledTimes(1);
     expect(getFullText).not.toHaveBeenCalledWith('ATT3', expect.anything());
+  });
+
+  it('serves an HTML snapshot exactly as it serves a PDF', async () => {
+    // Nothing between Zotero's census and the indexed passage may narrow by content type,
+    // link mode or file extension: an `imported_url` `text/html` snapshot is text Zotero
+    // extracted, and the map, the read and the cap treat it as such (#78).
+    const { ctx, getFullText } = makeCtx({
+      attachments: [htmlSnapshot('SNAP1', 'PAGE1'), attachment('ATT1', 'ITEM1')],
+      withText: { SNAP1: 12, ATT1: 13 },
+      fulltext: { SNAP1: { content: 'the snapshot body' }, ATT1: { content: 'the pdf body' } },
+    });
+    const src = await createFulltextSource(ctx, undefined);
+
+    expect(src.attachments).toBe(2);
+    expect([...src.itemKeys].sort()).toEqual(['ITEM1', 'PAGE1']);
+    expect(await src.textFor('PAGE1')).toBe('the snapshot body');
+    expect(getFullText).toHaveBeenCalledWith('SNAP1', expect.anything());
+    // And the reverse direction, which is what an update resolves its delta through: the
+    // snapshot's key comes back as the page it hangs off, not dropped as an unknown item.
+    expect([...src.itemsFor(['SNAP1'])]).toEqual(['PAGE1']);
   });
 
   it('treats a top-level attachment as its own item', async () => {
@@ -300,6 +340,43 @@ describe('startIndexBuild with full text', () => {
 
     const hits = await ctx.search.query('eleven percent throughput', { limit: 1 });
     expect(hits[0]!.itemKey).toBe('K1');
+    expect(hits[0]!.source).toBe('fulltext');
+  });
+
+  it('indexes a saved web page\'s body onto the webpage item that owns it', async () => {
+    // The shape reported against #78: a `webpage` item whose ONLY child is an `imported_url`
+    // `text/html` snapshot, so nothing but the snapshot can put body text on it. Zotero has
+    // the text, and the build has to carry it all the way to a passage attributed to the
+    // parent, or the page is findable by its title alone.
+    const SNAPSHOT_BODY =
+      'The scheduler picks the best moment for a card to come up for review again. '.repeat(12);
+    const { ctx } = makeCtx({
+      attachments: [htmlSnapshot('SNAP1', 'PAGE1')],
+      withText: { SNAP1: 7 },
+      fulltext: { SNAP1: { content: SNAPSHOT_BODY } },
+      config: { ZOTEUS_INDEX_FULLTEXT: 'true' },
+    });
+    const items = [
+      { key: 'PAGE1', data: { itemType: 'webpage', title: 'The Mnemosyne Project', abstractNote: '' } },
+      { key: 'K9', data: { itemType: 'journalArticle', title: 'Unrelated paper' } },
+    ];
+    const listAttachments = ctx.router.searchItems;
+    ctx.router.searchItems = vi.fn(async (q: any) =>
+      q.top ? { data: items.slice(q.start ?? 0), totalResults: items.length, lastModifiedVersion: 1 } : listAttachments(q),
+    );
+
+    startIndexBuild(ctx);
+    await finished(ctx.search);
+
+    const s = ctx.search.buildStatus();
+    expect(s.state).toBe('done');
+    expect(s.fulltextItems).toBe(1);
+    expect(s.fulltextPassages).toBeGreaterThan(0);
+
+    // A phrase that exists only inside the snapshot finds the page, as body text and not as
+    // a title match: `source` is what separates the two.
+    const hits = await ctx.search.query('best moment card come up review', { limit: 1 });
+    expect(hits[0]!.itemKey).toBe('PAGE1');
     expect(hits[0]!.source).toBe('fulltext');
   });
 

--- a/tests/router/top-level-search.test.ts
+++ b/tests/router/top-level-search.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LibraryRouter } from '../../src/router/library-router.js';
+import { LocalApiClient } from '../../src/api/local-client.js';
+import { RateLimitedFetcher } from '../../src/api/http.js';
+import { loadConfig } from '../../src/config.js';
+
+const cloudInfo = { userID: 19552201, username: 'oscardvs', access: {} };
+
+/**
+ * A library shaped like the one #79 was reported against, plus the one thing that library
+ * happened not to contain: a standalone attachment. Three top-level items, two attachments
+ * that hang off two of them, and one attachment that hangs off nothing.
+ */
+const ITEMS: Record<string, any> = {
+  BOOK1AAA: { key: 'BOOK1AAA', data: { key: 'BOOK1AAA', itemType: 'book' } },
+  ART1AAAA: { key: 'ART1AAAA', data: { key: 'ART1AAAA', itemType: 'journalArticle' } },
+  STANDALO: { key: 'STANDALO', data: { key: 'STANDALO', itemType: 'attachment' } },
+  CHILD1AA: {
+    key: 'CHILD1AA',
+    data: { key: 'CHILD1AA', itemType: 'attachment', parentItem: 'BOOK1AAA' },
+  },
+  CHILD2AA: {
+    key: 'CHILD2AA',
+    data: { key: 'CHILD2AA', itemType: 'attachment', parentItem: 'ART1AAAA' },
+  },
+};
+
+const TOP_KEYS = ['BOOK1AAA', 'ART1AAAA', 'STANDALO'];
+/**
+ * What BOTH APIs hand back for `itemType=attachment`, whether or not `/top` was asked for:
+ * the desktop ignores the top-level restriction once an itemType filter is present, so the
+ * two child attachments are in there. Measured against Zotero 10 on 2026-09-12.
+ */
+const ATTACHMENT_KEYS = ['CHILD1AA', 'CHILD2AA', 'STANDALO'];
+
+const KEY_SETS: Record<string, string[]> = {
+  attachment: ATTACHMENT_KEYS,
+  book: ['BOOK1AAA'],
+};
+
+/** Any filter the table does not name matches everything, child items included. */
+const EVERYTHING = 'attachment || book || journalArticle';
+
+/**
+ * The two clients take their arguments the other way round (the cloud is addressed
+ * `(lib, query)`, the desktop `(query, lib?)`), so the fakes have to as well: getting that
+ * backwards is exactly the kind of mistake these tests are here to catch.
+ */
+type Style = 'web' | 'local';
+const queryOf = (style: Style, args: any[]) => (style === 'web' ? args[1] : args[0]) ?? {};
+
+function keyReader(style: Style) {
+  return vi.fn(async (...args: any[]) => {
+    const query = queryOf(style, args);
+    const keys = query.top ? TOP_KEYS : (KEY_SETS[query.itemType] ?? Object.keys(ITEMS));
+    return { keys, totalResults: keys.length, lastModifiedVersion: 4242 };
+  });
+}
+
+function itemReader(style: Style) {
+  return vi.fn(async (...args: any[]) => {
+    const asked = String(queryOf(style, args).itemKey ?? '')
+      .split(',')
+      .filter(Boolean);
+    // Deliberately answered in an order of its own: neither API promises to respect the
+    // order of an `itemKey` list, so the router must put the page back in sort order.
+    const data = asked
+      .slice()
+      .reverse()
+      .map((k) => ITEMS[k])
+      .filter(Boolean);
+    return { data, totalResults: data.length, lastModifiedVersion: 4242 };
+  });
+}
+
+function makeRouter(opts: { localApi: boolean }) {
+  const web = {
+    listItems: itemReader('web'),
+    // The cloud's own spelling of the bug: `/items/top?itemType=attachment` answers with
+    // the PARENTS of matching attachments, so a caller asking for attachments is handed
+    // books and journal articles instead. Never reached once the router resolves `top`.
+    listItemKeys: keyReader('web'),
+  };
+  const local = {
+    listItems: itemReader('local'),
+    listItemKeys: keyReader('local'),
+  };
+  const router = new LibraryRouter({
+    config: loadConfig({ ZOTEUS_LOCAL: opts.localApi ? 'on' : 'off' } as any),
+    capabilities: { cloud: cloudInfo, localApi: opts.localApi, localGroupIds: [] } as any,
+    web: web as any,
+    local: local as any,
+  });
+  return { router, web, local };
+}
+
+describe('searchItems with top and an itemType filter (#79)', () => {
+  it('returns no item carrying a parentItem, on the desktop local API', async () => {
+    const { router } = makeRouter({ localApi: true });
+    const res = await router.searchItems({ itemType: 'attachment', top: true, limit: 10 });
+    expect(res.data.map((i: any) => i.key)).toEqual(['STANDALO']);
+    expect(res.data.filter((i: any) => i.data.parentItem)).toEqual([]);
+  });
+
+  it('returns no item carrying a parentItem, on the cloud Web API', async () => {
+    const { router } = makeRouter({ localApi: false });
+    const res = await router.searchItems({ itemType: 'attachment', top: true, limit: 10 });
+    expect(res.data.map((i: any) => i.key)).toEqual(['STANDALO']);
+    expect(res.data.filter((i: any) => i.data.parentItem)).toEqual([]);
+  });
+
+  it('counts only the top-level matches in totalResults', async () => {
+    const { router } = makeRouter({ localApi: true });
+    const res = await router.searchItems({ itemType: 'attachment', top: true, limit: 10 });
+    // Not the 3 the API reports for that filter: one of them is top-level.
+    expect(res.totalResults).toBe(1);
+    expect(res.lastModifiedVersion).toBe(4242);
+  });
+
+  it('asks for the top-level key set without carrying the itemType filter into it', async () => {
+    const { router, local } = makeRouter({ localApi: true });
+    await router.searchItems({ itemType: 'attachment', top: true, includeTrashed: true });
+    const topRead = local.listItemKeys.mock.calls.find((c: any[]) => c[0].top);
+    expect(topRead?.[0].itemType).toBeUndefined();
+    // includeTrashed still has to reach it, or trashed top-level items drop out of the set.
+    expect(topRead?.[0].includeTrashed).toBe(true);
+  });
+
+  it('pages coherently: every page disjoint, together the whole filtered set', async () => {
+    const { router } = makeRouter({ localApi: true });
+    const seen: string[] = [];
+    let total = 0;
+    for (let start = 0; ; start += 2) {
+      const page = await router.searchItems({ itemType: EVERYTHING, top: true, limit: 2, start });
+      total = page.totalResults;
+      seen.push(...page.data.map((i: any) => i.key));
+      if (start + 2 >= page.totalResults) break;
+    }
+    expect(total).toBe(3);
+    expect(seen).toEqual(TOP_KEYS);
+    expect(new Set(seen).size).toBe(3);
+  });
+
+  it('restores the key order the filter returned, not the order the API answered in', async () => {
+    const { router } = makeRouter({ localApi: true });
+    const res = await router.searchItems({ itemType: EVERYTHING, top: true, limit: 10 });
+    expect(res.data.map((i: any) => i.key)).toEqual(TOP_KEYS);
+  });
+
+  it('splits the page into itemKey batches of 50, which is the cap both APIs impose', async () => {
+    const many = Array.from({ length: 60 }, (_, i) => `KEY${String(i).padStart(5, '0')}`);
+    const { router, local } = makeRouter({ localApi: true });
+    local.listItemKeys.mockImplementation(async () => ({
+      keys: many,
+      totalResults: many.length,
+      lastModifiedVersion: 7,
+    }));
+    await router.searchItems({ itemType: 'attachment', top: true, limit: 60 });
+    expect(local.listItems).toHaveBeenCalledTimes(2);
+    expect(local.listItems.mock.calls[0][0].itemKey.split(',')).toHaveLength(50);
+    expect(local.listItems.mock.calls[1][0].itemKey.split(',')).toHaveLength(10);
+  });
+
+  it('reads the page from /items/top, which is the only keyed read the desktop answers exactly', async () => {
+    const { router, local } = makeRouter({ localApi: true });
+    await router.searchItems({ itemType: 'attachment', top: true, limit: 10 });
+    // Plain /items?itemKey= on the desktop answers with the named items AND every
+    // descendant they have, which would put child attachments straight back in.
+    expect(local.listItems.mock.calls[0][0].top).toBe(true);
+  });
+
+  it('leaves a top search with no itemType filter on the ordinary listing path', async () => {
+    const { router, local } = makeRouter({ localApi: true });
+    await router.searchItems({ top: true, limit: 10 });
+    expect(local.listItemKeys).not.toHaveBeenCalled();
+    expect(local.listItems).toHaveBeenCalledTimes(1);
+    expect(local.listItems.mock.calls[0][0].top).toBe(true);
+  });
+
+  it('leaves an itemType search with no top filter on the ordinary listing path', async () => {
+    const { router, local } = makeRouter({ localApi: true });
+    await router.searchItems({ itemType: 'attachment', limit: 10 });
+    expect(local.listItemKeys).not.toHaveBeenCalled();
+    expect(local.listItems).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The whole stack against a stand-in for the desktop that answers the way Zotero 10 really
+ * does: `/items/top` keeps the top-level restriction until an `itemType` filter turns up,
+ * and then quietly drops it. Nothing here is mocked above the HTTP call, so the URLs the
+ * real LocalApiClient builds are part of what is being asserted.
+ */
+describe('searchItems against a desktop that ignores /items/top when filtering by type', () => {
+  function fakeDesktop() {
+    return vi.fn(async (rawUrl: string) => {
+      const url = new URL(rawUrl);
+      const isTop = url.pathname.endsWith('/items/top');
+      const itemType = url.searchParams.get('itemType');
+      const itemKey = url.searchParams.get('itemKey');
+      const keysOnly = url.searchParams.get('format') === 'keys';
+
+      let keys: string[];
+      if (itemKey) {
+        keys = itemKey.split(',');
+        // The desktop applies the top-level restriction to a keyed read correctly.
+        if (isTop) keys = keys.filter((k) => TOP_KEYS.includes(k));
+      } else if (itemType === 'attachment') {
+        // The bug: `top` buys the caller nothing once itemType is in the query.
+        keys = ATTACHMENT_KEYS;
+      } else {
+        keys = isTop ? TOP_KEYS : Object.keys(ITEMS);
+      }
+
+      const headers = { 'Total-Results': String(keys.length), 'Last-Modified-Version': '681' };
+      if (keysOnly) return new Response(keys.join('\n'), { status: 200, headers });
+      return new Response(JSON.stringify(keys.map((k) => ITEMS[k])), { status: 200, headers });
+    });
+  }
+
+  function wired() {
+    const fetchImpl = fakeDesktop();
+    const local = new LocalApiClient({
+      fetcher: new RateLimitedFetcher({ fetchImpl, maxConcurrency: 4 }),
+    });
+    const router = new LibraryRouter({
+      config: loadConfig({ ZOTEUS_LOCAL: 'on' } as any),
+      capabilities: { cloud: cloudInfo, localApi: true, localGroupIds: [] } as any,
+      web: {} as any,
+      local,
+    });
+    return { router, fetchImpl };
+  }
+
+  it('would have returned child attachments before the fix, and returns none now', async () => {
+    const { router, fetchImpl } = wired();
+
+    // What the desktop itself still says, and what #79 saw: three attachments, two of them
+    // children, from the endpoint documented as top-level only.
+    const raw = await new LocalApiClient({
+      fetcher: new RateLimitedFetcher({ fetchImpl, maxConcurrency: 4 }),
+    }).listItems({ itemType: 'attachment', top: true });
+    expect(raw.data.filter((i: any) => i.data.parentItem)).toHaveLength(2);
+
+    const res = await router.searchItems({ itemType: 'attachment', top: true, limit: 10 });
+    expect(res.data.map((i: any) => i.key)).toEqual(['STANDALO']);
+    expect(res.totalResults).toBe(1);
+  });
+
+  it('reports zero, not the count the filter itself gives, when nothing matching is top-level', async () => {
+    const { router } = wired();
+    const res = await router.searchItems({ itemType: 'attachment', top: true, limit: 10 });
+    // Take the standalone attachment away and the honest answer is none at all.
+    delete (ITEMS as any).STANDALO;
+    const empty = await router.searchItems({ itemType: 'attachment', top: true, limit: 10 });
+    ITEMS.STANDALO = { key: 'STANDALO', data: { key: 'STANDALO', itemType: 'attachment' } };
+    expect(res.totalResults).toBe(1);
+    expect(empty.data).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #79 and closes #78.

- #79: `top: true` combined with an `itemType` filter is now resolved from key sets instead of trusting either API, which both answer it wrongly (the desktop drops the top-level restriction, the cloud maps children up to their parents). Exact `totalResults`, coherent paging, regression tests on both backends.
- #78: the full-text attachment map is driven by the `/fulltext?since=` census in `itemKey` batches of 50 with per-batch retry, and continues past a batch that never answers; anything unresolved still marks the map incomplete so the 1.18.0 cursor guarantee holds. Plus regression tests pinning HTML-snapshot indexing, which turned out not to be a gap.

Gates on the merged tree: typecheck, typecheck:tests, lint green; 1712 tests passed, 8 skipped.